### PR TITLE
Configure the Minio Provider by environment variables

### DIFF
--- a/minio/provider.go
+++ b/minio/provider.go
@@ -13,6 +13,9 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Minio Host and Port",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"MINIO_ENDPOINT",
+				}, nil),
 			},
 			"minio_region": {
 				Type:        schema.TypeString,
@@ -24,11 +27,17 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Minio Access Key",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"MINIO_ACCESS_KEY",
+				}, nil),
 			},
 			"minio_secret_key": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Minio Secret Key",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"MINIO_SECRET_KEY",
+				}, nil),
 			},
 			"minio_api_version": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Hi,

For some ci/cd tools integration it will be a nice feature to configure the ```minio_server```,```minio_access_key``` and ```minio_secret_key``` by environment variables.

