### PR TITLE
validate markdown action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs CI
+on:
+  push:
+    branches:
+      - master
+      - feature/**
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+jobs:
+  mdvalidate:
+    name: Validate Markdown Files
+    runs-on: ubuntu-latest
+    env:
+      GOARCH: amd64
+      GOOS: linux
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+            fetch-depth: 1
+      
+      - name: Markdown Link Validation
+        uses: nolte/github-action/markdown/validate@v0.1.0
+        with:
+          args: "--frail" # task fails if warnings exists.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Usage](#usage)
 - [Roadmap](#roadmap)
 - [License](#license)
-- [Acknowledgement](#acknowledgement)
+- [Acknowledgement](#acknowledgements)
 
 ## About this project
 
@@ -60,7 +60,7 @@ Valid provider filenames are `terraform-provider-NAME_X.X.X` or `terraform-provi
 
 ## Examples
 
-Use [examples/main.tf](./examples/main.tf) to create some test config, such as:
+Use [examples/main.tf](./examples/user/main.tf) to create some test config, such as:
 
 ```go
 provider "minio" {

--- a/docs/github/CODE_OF_CONDUCT.md
+++ b/docs/github/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@
 - Treat everyone with respect and kindness.
 - Be thoughtful in how you communicate.
 - Don’t be destructive or inflammatory.
-- If you encounter an issue, please mail [amanda@amandasouza.app](amanda@amandasouza.app).
+- If you encounter an issue, please mail [amanda@amandasouza.app](mailto:amanda@amandasouza.app).
 
 ## Our Pledge
 
@@ -46,7 +46,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [amanda@amandasouza.app](amanda@amandasouza.app). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [amanda@amandasouza.app](mailto:amanda@amandasouza.app). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
Hi,

At the moment the Markdowns contains two broken Links, like ```Use examples/main.tf to create some test config, such as:```

This additional Github Workflow validate the existing Markdown Files with [remarkjs/remark-validate-links](https://github.com/remarkjs/remark-validate-links#cli), [/nolte/github-action/markdown/validate](https://github.com/nolte/github-action/tree/master/markdown/validate).

Example Output: [nolte/terraform-provider-minio/runs](https://github.com/aminueza/terraform-provider-minio/runs/421710546)
