### PR TITLE
Add Minio Client (MC) and AdminIO to the DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@ ARG GO_VERSION="1.15"
 
 FROM hashicorp/terraform:0.14.0 as terraform
 FROM minio/minio:RELEASE.2020-11-25T22-36-25Z as minio
+FROM minio/mc:RELEASE.2020-11-25T23-04-07Z-amd64 as mc
+FROM rzrbld/adminio-api:release-1.6 as adminio-api
+FROM rzrbld/adminio-ui:release-1.7 as adminio-ui
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${GO_VERSION}
 
 # Copy and install Terraform binary
@@ -15,6 +18,24 @@ ENV MINIO_VOLUMES=/tmp/minio
 
 # Copy and install MinIO binary
 COPY --from=minio /usr/bin/minio /usr/local/bin/
+
+# Copy and install MinIO Client (MC) binary
+COPY --from=mc /usr/bin/mc /usr/local/bin/
+
+# Define environment variables for AdminIO
+ENV MINIO_HOST_PORT=localhost:9000
+ENV MINIO_ACCESS=${MINIO_ACCESS_KEY}
+ENV MINIO_SECRET=${MINIO_SECRET_KEY}
+
+# Copy and install AdminIO binary
+COPY --from=adminio-api /usr/bin/adminio /usr/local/bin/
+
+# Define environment variables for AdminIO-UI
+ENV ADMINIO_UI_PORT=1234
+ENV ADMINIO_UI_PATH=/usr/local/share/adminio-ui
+
+# Copy and install pre-built AdminIO-UI
+COPY --from=adminio-ui /usr/share/nginx/html ${ADMINIO_UI_PATH}
 
 # Install Node.js
 ARG INSTALL_NODE="true"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,12 @@
         "golang.Go",
         "hashicorp.terraform"
 	],
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"postStartCommand": "make install_linux & minio server ${MINIO_VOLUMES} & adminio & npx angular-http-server -p ${ADMINIO_UI_PORT} --path ${ADMINIO_UI_PATH} &",
+	"forwardPorts": [
+		9000,
+		8080,
+		1234
+	]
 }
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,10 @@
 tasks:
   - command: minio server ${MINIO_VOLUMES}
     name: MinIO Server
+  - command: adminio
+    name: AdminIO Server
+  - command: npx angular-http-server -p ${ADMINIO_UI_PORT} --path ${ADMINIO_UI_PATH}
+    name: AdminIO-UI Server
   - init: make install_linux
 image:
   file: .devcontainer/Dockerfile
-vscode:
-  extensions:
-    - hashicorp.terraform@2.3.0:KgEabs4baG2MuLl5VL6Iyg==


### PR DESCRIPTION
So now we can use `mc` binary and also access AdminIO-UI that is auto-started on port `1234` (This port can be changed on Dockerfile `ENV ADMINIO_UI_PORT`).

References:
Minio Client (MC): https://github.com/minio/mc
AdminIO: https://github.com/rzrbld/adminio-ui
