### PR TITLE
Support importing iam users, fixes #90

### DIFF
--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -135,12 +135,16 @@ func minioReadUser(d *schema.ResourceData, meta interface{}) error {
 
 	iamUserConfig := IAMUserConfig(d, meta)
 
-	output, err := iamUserConfig.MinioAdmin.GetUserInfo(context.Background(), iamUserConfig.MinioIAMName)
+	output, err := iamUserConfig.MinioAdmin.GetUserInfo(context.Background(), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error reading IAM User %s: %s", d.Id(), err)
 	}
 
 	log.Printf("[WARN] (%v)", output)
+
+	if _, ok := d.GetOk("name"); !ok {
+		_ = d.Set("name", d.Id())
+	}
 
 	if err := d.Set("status", string(output.Status)); err != nil {
 		return err


### PR DESCRIPTION
I'm not sure if this is correct, I based this on the bucket import code and it seems to be working, at least when using the basic example in #90.

https://github.com/aminueza/terraform-provider-minio/blob/b8557a4c2b19039dc8575713dcba166ba6f74632/minio/resource_minio_s3_bucket.go#L121-L144

`iamUserConfig.MinioIAMName` is not populated at that time if the resource is not present in the tfstate.
This currently only reads the account status from minio, I'm not sure if it's possible to get more information populated here.
As far as I can tell the secret is not available from the API.

`mc admin user info minio foo --json`
```json
{
 "status": "success",
 "accessKey": "foo",
 "userStatus": "enabled"
}
```

`terraform import minio_iam_user.foo foo`
```
minio_iam_user.foo: Importing from ID "foo"...
minio_iam_user.foo: Import prepared!
  Prepared minio_iam_user for import
minio_iam_user.foo: Refreshing state... [id=foo]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```
`terraform plan`
```
minio_iam_user.foo: Refreshing state... [id=foo]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```