### PR TITLE
Support being a nested provider

### DIFF
--- a/minio/provider.go
+++ b/minio/provider.go
@@ -10,7 +10,7 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"minio_server": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Minio Host and Port",
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"MINIO_ENDPOINT",
@@ -24,7 +24,7 @@ func Provider() *schema.Provider {
 			},
 			"minio_access_key": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Minio Access Key",
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"MINIO_ACCESS_KEY",
@@ -32,7 +32,7 @@ func Provider() *schema.Provider {
 			},
 			"minio_secret_key": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Minio Secret Key",
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"MINIO_SECRET_KEY",


### PR DESCRIPTION
Because minio requires that minio_server, minio_access_key, and minio_secret_key are set you can't validate a module without setting them.

```
terraform_validate ./modules/blah 
	
Error: Missing required argument

The argument "minio_access_key" is required, but was not set.


Error: Missing required argument

The argument "minio_secret_key" is required, but was not set.


Error: Missing required argument

The argument "minio_server" is required, but was not set.	
```

But if you set them in the module you can't use for_each in calls to that module.

```
Module "blah" cannot be used with for_each because it contains a nested
provider configuration for "minio", at
modules/blah/providers.tf:14,10-17.

This module can be made compatible with for_each by changing it to receive all
of its provider configurations from the calling module, by using the
"providers" argument in the calling module block.
```


This PR simply changes the variables to be optional.

If you genuinely do not provide minio_server you just get the following error;
```
Error: Endpoint:  does not follow ip address or domain name standards.
```
