### PR TITLE
Add possibility to specify IAM User secretes

### DIFF
--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -39,6 +39,7 @@ func IAMUserConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMUserConf
 	return &S3MinioIAMUserConfig{
 		MinioAdmin:        m.S3Admin,
 		MinioIAMName:      d.Get("name").(string),
+		MinioSecret:       d.Get("secret").(string),
 		MinioDisableUser:  d.Get("disable_user").(bool),
 		MinioUpdateKey:    d.Get("update_secret").(bool),
 		MinioForceDestroy: d.Get("force_destroy").(bool),

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -40,6 +40,7 @@ type S3MinioBucket struct {
 type S3MinioIAMUserConfig struct {
 	MinioAdmin        *madmin.AdminClient
 	MinioIAMName      string
+	MinioSecret       string
 	MinioDisableUser  bool
 	MinioForceDestroy bool
 	MinioUpdateKey    bool


### PR DESCRIPTION
This enables documenting legacy users without having to rotate passwords.

Techniques like eYAML / git-crypt / KMS / sops / .. can still provide the layer of  secrecy needed by the project.
