### PR TITLE
Fix GitHub Action "Checkup"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,8 +42,8 @@ jobs:
         run: go get -v -t -d ./...
       - name: Build the docker-compose stack
         run: docker-compose -f test-compose.yml up -d
-      - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+      - name: Install Task
+        uses: arduino/setup-task@v1
         with:
           version: '3.x'
       - name: Run test task

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,6 +40,10 @@ jobs:
         id: go
       - name: Build the docker-compose stack
         run: docker-compose -f test-compose.yml up -d
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.0
+          terraform_wrapper: false
       - name: Install Task
         uses: arduino/setup-task@v1
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ secrets.GO_VERSION }}
+          go-version: 1.16.x
         id: go
       - name: Build the docker-compose stack
         run: docker-compose -f test-compose.yml up -d

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,14 +38,14 @@ jobs:
         with:
           go-version: ${{ secrets.GO_VERSION }}
         id: go
-      - name: Get dependencies
-        run: go get -v -t -d ./...
       - name: Build the docker-compose stack
         run: docker-compose -f test-compose.yml up -d
       - name: Install Task
         uses: arduino/setup-task@v1
         with:
           version: '3.x'
+      - name: Run install task
+        run: task install
       - name: Run test task
         run: task test
       - name: Remove containers

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       sed -i 's/apiBaseUrl = "http:\/\/localhost:8080"/apiBaseUrl = `https:\/\/8080${location.hostname.substr(4)}`/' ${ADMINIO_UI_PATH}/env.js &&
       npx --yes angular-http-server -p ${ADMINIO_UI_PORT} --path ${ADMINIO_UI_PATH}
     name: AdminIO-UI Server
-  - init: |
+  - command: |
       cd $(mktemp -d) &&
       go mod init task &&
       go get github.com/go-task/task/v3/cmd/task &&


### PR DESCRIPTION
# Fix GitHub Action "Checkup"

This PR implements the following changes:
* Install a specific version of Go and Terraform, which we know that are working.
* Update GitHub action to install Task, as the previous was deprecated. This fixes this warning:  
    ![image](https://user-images.githubusercontent.com/418083/149841067-884ec388-77d6-4dc0-96d0-4e83fd3a0b38.png)
