### PR TITLE
Bucket import acl

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,7 @@ tasks:
     desc: Build the plugin into current folder.
     cmds:
       - echo "Building {{.OUTPUT_FILENAME}}"
-      - go build -o "{{.OUTPUT_FILENAME}}"
+      - go build -gcflags "all=-N -l" -o "{{.OUTPUT_FILENAME}}"
       - echo "Done!"
     silent: true
 

--- a/minio/import_minio_s3_buckets.go
+++ b/minio/import_minio_s3_buckets.go
@@ -2,9 +2,11 @@ package minio
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/minio-go/v7/pkg/policy"
 )
 
 func resourceMinioS3BucketImportState(
@@ -12,22 +14,24 @@ func resourceMinioS3BucketImportState(
 	d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
 
-	results := make([]*schema.ResourceData, 1)
-	results[0] = d
-
 	conn := meta.(*S3MinioClient).S3Client
 	pol, err := conn.GetBucketPolicy(ctx, d.Id())
 	if err != nil {
 		return nil, fmt.Errorf("Error importing Minio S3 bucket policy: %s", err)
 	}
+	if pol == "" {
+		return []*schema.ResourceData{d}, nil
+	}
 
-	policy := resourceMinioBucket()
-	pData := policy.Data(nil)
-	pData.SetId(d.Id())
-	pData.SetType("minio_s3_bucket_policy")
-	_ = pData.Set("bucket", d.Id())
-	_ = pData.Set("acl", pol)
-	results = append(results, pData)
+	var bucketPolicy BucketPolicy
+	err = json.Unmarshal([]byte(pol), &bucketPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("Error importing Minio S3 bucket policy: %s", err)
+	}
 
-	return results, nil
+	policyName := policy.GetPolicy(bucketPolicy.Statements, d.Id(), "")
+
+	_ = d.Set("acl", policyName)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"github.com/minio/madmin-go"
 	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/policy"
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
@@ -98,16 +99,6 @@ type S3MinioIAMGroupPolicyConfig struct {
 	MinioIAMGroup      string
 }
 
-//Stmt defines policy statement
-type Stmt struct {
-	Sid        string
-	Actions    set.StringSet `json:"Action"`
-	Conditions ConditionMap  `json:"Condition,omitempty"`
-	Effect     string        `json:",omitempty"`
-	Principal  string        `json:"Principal,omitempty"`
-	Resources  set.StringSet `json:"Resource"`
-}
-
 //Princ defines policy princ
 type Princ struct {
 	AWS           set.StringSet `json:"AWS,omitempty"`
@@ -116,9 +107,9 @@ type Princ struct {
 
 //BucketPolicy defines bucket policy
 type BucketPolicy struct {
-	Version    string `json:",omitempty"`
-	ID         string `json:",omitempty"`
-	Statements []Stmt `json:"Statement"`
+	Version    string             `json:",omitempty"`
+	ID         string             `json:",omitempty"`
+	Statements []policy.Statement `json:"Statement"`
 }
 
 //IAMPolicyDoc returns IAM policy

--- a/minio/public_policy.go
+++ b/minio/public_policy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
-//PublicPolicy returns readonly policy
+// PublicPolicy returns policy where everyone can fully list/modify objects
 func PublicPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",

--- a/minio/public_policy.go
+++ b/minio/public_policy.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"fmt"
+	"github.com/minio/minio-go/v7/pkg/policy"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -10,11 +11,11 @@ import (
 func PublicPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",
-		Statements: []Stmt{
+		Statements: []policy.Statement{
 			{
 				Sid:       "AllowAllS3Actions",
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Actions:   allBucketActions,
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s", awsResourcePrefix, bucket.MinioBucket), fmt.Sprintf("%s%s/*", awsResourcePrefix, bucket.MinioBucket)}...),
 			},

--- a/minio/public_policy_test.go
+++ b/minio/public_policy_test.go
@@ -15,12 +15,11 @@ func TestPublicPolicy(t *testing.T) {
 
 	stringPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowAllS3Actions","Action":["s3:AbortMultipartUpload","s3:CreateBucket","s3:DeleteBucket","s3:DeleteBucketPolicy","s3:DeleteObject","s3:GetBucketLocation","s3:GetBucketNotification","s3:GetBucketPolicy","s3:GetObject","s3:HeadBucket","s3:ListAllMyBuckets","s3:ListBucket","s3:ListBucketMultipartUploads","s3:ListMultipartUploadParts","s3:ListenBucketNotification","s3:PutBucketNotification","s3:PutBucketPolicy","s3:PutObject"],"Effect":"Allow","Principal":"*","Resource":["arn:aws:s3:::test","arn:aws:s3:::test/*"]}]}`
 
-	policy, err := json.Marshal(PublicPolicy(minio))
-
-	if err != nil {
+	var expected BucketPolicy
+	if err := json.Unmarshal([]byte(stringPolicy), &expected); err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, string(policy), string(stringPolicy))
-
+	policy := PublicPolicy(minio)
+	assert.DeepEqual(t, expected, policy)
 }

--- a/minio/public_read_policy.go
+++ b/minio/public_read_policy.go
@@ -7,23 +7,16 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
-// ReadOnlyPolicy returns policy where objects can be listed and read
-func ReadOnlyPolicy(bucket *S3MinioBucket) BucketPolicy {
+// PublicReadPolicy returns policy where everyone can read objects
+func PublicReadPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",
 		Statements: []policy.Statement{
 			{
-				Sid:       "ListAllBucket",
-				Actions:   readOnlyAllBucketsActions,
+				Sid:       "AllowAllS3Actions",
 				Effect:    "Allow",
 				Principal: policy.User{AWS: set.CreateStringSet("*")},
-				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s*", awsResourcePrefix)}...),
-			},
-			{
-				Sid:       "AllObjectActionsMyBuckets",
 				Actions:   readListMyObjectActions,
-				Effect:    "Allow",
-				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s", awsResourcePrefix, bucket.MinioBucket), fmt.Sprintf("%s%s/*", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 		},

--- a/minio/readonly_policy.go
+++ b/minio/readonly_policy.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"fmt"
+	"github.com/minio/minio-go/v7/pkg/policy"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -10,19 +11,19 @@ import (
 func ReadOnlyPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",
-		Statements: []Stmt{
+		Statements: []policy.Statement{
 			{
 				Sid:       "ListAllBucket",
 				Actions:   readOnlyAllBucketsActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s*", awsResourcePrefix)}...),
 			},
 			{
 				Sid:       "AllObjectActionsMyBuckets",
 				Actions:   readListMyObjectActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s", awsResourcePrefix, bucket.MinioBucket), fmt.Sprintf("%s%s/*", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 		},

--- a/minio/readonly_policy_test.go
+++ b/minio/readonly_policy_test.go
@@ -15,12 +15,12 @@ func TestReadPolicy(t *testing.T) {
 
 	stringPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"ListAllBucket","Action":["s3:ListAllMyBuckets","s3:ListBucket"],"Effect":"Allow","Principal":"*","Resource":["arn:aws:s3:::*"]},{"Sid":"AllObjectActionsMyBuckets","Action":["s3:GetObject","s3:ListBucket"],"Effect":"Allow","Principal":"*","Resource":["arn:aws:s3:::test","arn:aws:s3:::test/*"]}]}`
 
-	policy, err := json.Marshal(ReadOnlyPolicy(minio))
-
-	if err != nil {
+	var expected BucketPolicy
+	if err := json.Unmarshal([]byte(stringPolicy), &expected); err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, string(policy), string(stringPolicy))
+	policy := ReadOnlyPolicy(minio)
+	assert.DeepEqual(t, expected, policy)
 
 }

--- a/minio/readwrite_policy.go
+++ b/minio/readwrite_policy.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"fmt"
+	"github.com/minio/minio-go/v7/pkg/policy"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -10,19 +11,19 @@ import (
 func ReadWritePolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",
-		Statements: []Stmt{
+		Statements: []policy.Statement{
 			{
 				Sid:       "ListObjectsInBucket",
 				Actions:   readOnlyBucketActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 			{
 				Sid:       "UploadObjectActions",
 				Actions:   uploadObjectActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s/*", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 		},

--- a/minio/readwrite_policy.go
+++ b/minio/readwrite_policy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
-//ReadWritePolicy returns readonly policy
+// ReadWritePolicy returns a policy where objects can be uploaded and read
 func ReadWritePolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",

--- a/minio/readwrite_policy_test.go
+++ b/minio/readwrite_policy_test.go
@@ -15,12 +15,12 @@ func TestReadWritePolicy(t *testing.T) {
 
 	stringPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"ListObjectsInBucket","Action":["s3:ListBucket"],"Effect":"Allow","Principal":"*","Resource":["arn:aws:s3:::test"]},{"Sid":"UploadObjectActions","Action":["s3:PutObject"],"Effect":"Allow","Principal":"*","Resource":["arn:aws:s3:::test/*"]}]}`
 
-	policy, err := json.Marshal(ReadWritePolicy(minio))
-
-	if err != nil {
+	var expected BucketPolicy
+	if err := json.Unmarshal([]byte(stringPolicy), &expected); err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, string(policy), string(stringPolicy))
+	policy := ReadWritePolicy(minio)
+	assert.DeepEqual(t, expected, policy)
 
 }

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -25,7 +25,7 @@ func resourceMinioBucket() *schema.Resource {
 		UpdateContext: minioUpdateBucket,
 		DeleteContext: minioDeleteBucket,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceMinioS3BucketImportState,
 		},
 
 		SchemaVersion: 0,

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -117,7 +117,7 @@ func TestAccMinioS3Bucket_generatedName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl", "bucket_prefix"},
+					"force_destroy", "bucket_prefix"},
 			},
 		},
 	})
@@ -144,18 +144,24 @@ func TestAccMinioS3Bucket_UpdateAcl(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
+				ImportStateId:     ri,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
+					"force_destroy"},
 			},
 			{
-				Config: postConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMinioS3BucketExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "acl", "private"),
-				),
+				ResourceName: resourceName,
+				Config:       postConfig,
+				Check:        testAccCheckMinioS3BucketACLInState(resourceName, "private"),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     ri,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 		},
 	})
@@ -298,6 +304,29 @@ func testAccCheckMinioS3DestroyBucket(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("Error destroying Bucket (%s) in testAccCheckMinioS3DestroyBucket: %s", rs.Primary.ID, err)
 		}
+		return nil
+	}
+}
+
+func testAccCheckMinioS3BucketACLInState(n string, acl string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		attr, ok := rs.Primary.Attributes["acl"]
+		if !ok {
+			return fmt.Errorf("Attribute acl not found")
+		}
+		if attr != acl {
+			return fmt.Errorf("Attribute acl %s, wanted: %s", attr, acl)
+		}
+
 		return nil
 	}
 }

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -39,7 +39,7 @@ func TestAccMinioS3Bucket_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
+					"force_destroy"},
 			},
 		},
 	})
@@ -65,7 +65,7 @@ func TestAccMinioS3Bucket_Bucket_EmptyString(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
+					"force_destroy"},
 			},
 		},
 	})
@@ -92,7 +92,7 @@ func TestAccMinioS3Bucket_namePrefix(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl", "bucket_prefix"},
+					"force_destroy", "bucket_prefix"},
 			},
 		},
 	})

--- a/minio/writeonly_policy.go
+++ b/minio/writeonly_policy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
-//WriteOnlyPolicy returns writeonly policy
+// WriteOnlyPolicy returns policy where objects can be listed and written
 func WriteOnlyPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",

--- a/minio/writeonly_policy.go
+++ b/minio/writeonly_policy.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"fmt"
+	"github.com/minio/minio-go/v7/pkg/policy"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -10,19 +11,19 @@ import (
 func WriteOnlyPolicy(bucket *S3MinioBucket) BucketPolicy {
 	return BucketPolicy{
 		Version: "2012-10-17",
-		Statements: []Stmt{
+		Statements: []policy.Statement{
 			{
 				Sid:       "ListBucketAction",
 				Actions:   readOnlyBucketActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 			{
 				Sid:       "AllObjectActionsMyBuckets",
 				Actions:   writeOnlyObjectActions,
 				Effect:    "Allow",
-				Principal: "*",
+				Principal: policy.User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet([]string{fmt.Sprintf("%s%s/*", awsResourcePrefix, bucket.MinioBucket)}...),
 			},
 		},


### PR DESCRIPTION
Add bucket import handling to not force bucket recreation due to changes in the `acl` field.

* Fixes #89
* Fixes #65

The way `mc` (or ration `minio`) detects the `acl` name is... horrible?  But I think this way could work.  I'm not sure about using the `minio` internals inside `payload.go` is wanted..  It's already used for `StringSet`, so I *think* it should be ok?

The tests are good, but I haven't run it for real yet.