### PR TITLE
Update Go Version references from "1.15" to "1.16" as the newer version is required to build for darwin_arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Made with <span style="color: #e25555;">&#9829;</span> using [Go](https://golang
 ## Supported Versions
 
 - Terraform v0.14
-- Go v1.15
+- Go v1.16
 
 It doesn't mean that this provider won't run on previous versions of Terraform or Go, though.
 It just means that we can't guarantee backward compatibility.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aminueza/terraform-provider-minio
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.42.35


### PR DESCRIPTION
# Update Go Version references from "1.15" to "1.16"

This PR implements the following changes:
* Update Go Version references because the newer version is required to build for "darwin_arm64". Also because in all other files we're already using Go v1.16.