### PR TITLE
Allow Renovate Bot to auto-merge patches (or lower-level) dependencies updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
# Allow Renovate Bot to auto-merge patches (or lower-level) dependencies updates

This PR implements the following changes:

* Sets 'packageRules' and 'dependencyDashboard' settings for Renovate Bot. As we're running tests automatically on each Pull Request, it's fine to auto-merge dependencies patches when all the tests are passing.

## Reference

- https://docs.renovatebot.com/configuration-options/#automerge