### PR TITLE
Add 'init' instructions to make use of Gitpod Prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,13 +7,16 @@ tasks:
       docker-compose -f ${DOCKER_COMPOSE_GITPOD_PATH} up
   - env:
       TERRAFORM_VERSION: 0.14.0
-    command: >
+    init: >
       export TERRAFORM_DOWNLOAD_FILE_NAME=terraform_${TERRAFORM_VERSION}_linux_amd64.zip &&
       wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_DOWNLOAD_FILE_NAME} &&
       unzip ${TERRAFORM_DOWNLOAD_FILE_NAME} &&
       rm ${TERRAFORM_DOWNLOAD_FILE_NAME} &&
-      sudo mv terraform /usr/local/bin/terraform &&
-      sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin &&
+      sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b .
+    command: |
+      sudo mv terraform /usr/local/bin/terraform
+      sudo mv task /usr/local/bin/task
+      go get -v -t -d ./...
       task install
 
 ports:
@@ -26,3 +29,8 @@ ports:
   - port: 8000
     name: AdminIO-UI Server
     onOpen: open-preview
+
+vscode:
+  extensions:
+    - golang.go
+    - hashicorp.terraform

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@
 version: '3'
 
 vars:
-  PLUGIN_VERSION: 1.2.0
+  PLUGIN_VERSION: 1.3.0
   OUTPUT_FILENAME: terraform-provider-minio
 
 tasks:


### PR DESCRIPTION
# Add 'init' instructions to make use of Gitpod Prebuilds

This PR includes the following changes:

* Speeds up the startup of Gitpod by making use of [Prebuilds](https://www.gitpod.io/docs/prebuilds/), and add two IDE extensions to work with the Go and Terraform files out of the box.
* Updates the plugin version on `Taskfile.yml`. This version number is used only in local builds during development. The builds generated by GoReleaser use a version obtained from the latest git tag instead.