### PR TITLE
Update Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,6 +28,9 @@ ports:
   - port: 9000
     name: MinIO Server
     onOpen: ignore
+  - port: 9001
+    name: MinIO Server Console
+    onOpen: ignore
   - port: 8080
     name: AdminIO Server
     onOpen: ignore


### PR DESCRIPTION
# Update Gitpod configuration

This PR implements the following changes:

- Ignore port 9001 used by MinIO Server Console, when opening the project on Gitpod, as this port is not meant to be opened in a browser.