### PR TITLE
Update `minio_s3_object` resource example

### DIFF
--- a/docs/resources/s3_object.md
+++ b/docs/resources/s3_object.md
@@ -23,6 +23,7 @@ resource "minio_s3_object" "txt_file" {
   bucket_name = minio_s3_bucket.state_terraform_s3.bucket
   object_name = "text.txt"
   content = "Lorem ipsum dolor sit amet."
+  content_type = "text/plain"
 }
 
 output "minio_id" {

--- a/examples/resources/minio_s3_object/main.tf
+++ b/examples/resources/minio_s3_object/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    minio = {
+      source = "aminueza/minio"
+      version = ">= 1.0.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "minio" {
+  minio_server = var.minio_server
+  minio_region = var.minio_region
+  minio_access_key = var.minio_access_key
+  minio_secret_key = var.minio_secret_key
+}
+

--- a/examples/resources/minio_s3_object/resource.tf
+++ b/examples/resources/minio_s3_object/resource.tf
@@ -8,8 +8,9 @@ resource "minio_s3_object" "txt_file" {
   bucket_name = minio_s3_bucket.state_terraform_s3.bucket
   object_name = "text.txt"
   content = "Lorem ipsum dolor sit amet."
+  content_type = "text/plain"
 }
 
 output "minio_id" {
-  value = "${minio_s3_object.txt_file.id}"
+  value = minio_s3_object.txt_file.id
 }

--- a/examples/resources/minio_s3_object/variables.tf
+++ b/examples/resources/minio_s3_object/variables.tf
@@ -1,0 +1,19 @@
+variable "minio_region" {
+  description = "Default MINIO region"
+  default     = "us-east-1"
+}
+
+variable "minio_server" {
+  description = "Default MINIO host and port"
+  default = "localhost:9000"
+}
+
+variable "minio_access_key" {
+  description = "MINIO user"
+  default = "minio"
+}
+
+variable "minio_secret_key" {
+  description = "MINIO secret user"
+  default = "minio123"
+}


### PR DESCRIPTION
This is a follow-up for PR #236, which added support for setting the `content_type` for `minio_s3_object`.