### PR TITLE
renovate, update aws-sdk less often

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["aws-sdk"],
+      "schedule": ["after 9pm on friday"]
     }
   ],
   "dependencyDashboard": false


### PR DESCRIPTION
* To reduce the update load, let's update the aws sdk less often.
* Idea from https://docs.renovatebot.com/configuration-options/#packagerules
