### PR TITLE
Add ability to set bucket quota on bucket resource

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -37,6 +37,7 @@ output "minio_url" {
 - **bucket_prefix** (String)
 - **force_destroy** (Boolean)
 - **id** (String) The ID of this resource.
+- **quota** (Number) The limit of the amount of data in the bucket (bytes).
 
 ### Read-Only
 

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -145,14 +145,6 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 		_ = d.Set("bucket", d.Id())
 	}
 
-	if _, ok := d.GetOk("quota"); !ok {
-		bucketQuota, err := bucketConfig.MinioAdmin.GetBucketQuota(ctx, bucketConfig.MinioBucket)
-		if err != nil {
-			return diag.Errorf("unable to get quota")
-		}
-		_ = d.Set("quota", bucketQuota.Quota)
-	}
-
 	bucketURL := bucketConfig.MinioClient.EndpointURL()
 
 	_ = d.Set("bucket_domain_name", bucketDomainName(d.Id(), bucketURL))

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -95,7 +95,7 @@ func minioCreateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 	if e, err := bucketConfig.MinioClient.BucketExists(ctx, bucket); err != nil {
 		return NewResourceError("unable to check bucket", bucket, err)
 	} else if e {
-		return NewResourceError("ucket already exists!", bucket, err)
+		return NewResourceError("bucket already exists!", bucket, err)
 	}
 
 	err := bucketConfig.MinioClient.MakeBucket(ctx, bucket, minio.MakeBucketOptions{
@@ -231,7 +231,7 @@ func minioSetBucketACL(ctx context.Context, bucketConfig *S3MinioBucket) diag.Di
 	policyString, policyExists := defaultPolicies[bucketConfig.MinioACL]
 
 	if !policyExists {
-		return NewResourceError("nsupported ACL", bucketConfig.MinioACL, errors.New("(valid acl: private, public-write, public-read, public-read-write, public)"))
+		return NewResourceError("unsupported ACL", bucketConfig.MinioACL, errors.New("(valid acl: private, public-write, public-read, public-read-write, public)"))
 	}
 
 	if policyString != "" {


### PR DESCRIPTION
# Add ability to set bucket quota on bucket resource

This PR implements the following changes:

1. Fixes typos
2. Allows setting `quota` (data limit) on bucket resource
3. Generates bucket resource docs

## Reference
 - Resolves: #257
 - See also: pulumi/pulumi-minio#37

## (Optional) People
@BuJo agreed to review

## Closing issues
- Closes:  #257