### PR TITLE
Add `arn` attribute to the `minio_s3_bucket` resource

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -41,6 +41,7 @@ output "minio_url" {
 
 ### Read-Only
 
+- **arn** (String)
 - **bucket_domain_name** (String)
 
 

--- a/examples/bucket/bucket.tf
+++ b/examples/bucket/bucket.tf
@@ -26,9 +26,9 @@ resource "minio_s3_bucket_policy" "policy" {
   "Statement": [
     {
       "Effect": "Allow",
-	    "Principal": {"AWS": ["*"]},
-      "Resource": ["arn:aws:s3:::${minio_s3_bucket.state_terraform_s3.bucket}"],
-	    "Action": ["s3:ListBucket"]
+      "Principal": {"AWS": ["*"]},
+      "Resource": ["${minio_s3_bucket.state_terraform_s3.arn}"],
+      "Action": ["s3:ListBucket"]
     }
   ]
 }

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -60,6 +60,10 @@ func resourceMinioBucket() *schema.Resource {
 				Default:  "private",
 				ForceNew: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"bucket_domain_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,6 +151,7 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 
 	bucketURL := bucketConfig.MinioClient.EndpointURL()
 
+	_ = d.Set("arn", bucketArn(d.Id()))
 	_ = d.Set("bucket_domain_name", bucketDomainName(d.Id(), bucketURL))
 
 	return nil
@@ -287,6 +292,10 @@ func exportPolicyString(policyStruct BucketPolicy, bucketName string) string {
 		return NewResourceError("unable to parse bucket policy", bucketName, err)[0].Summary
 	}
 	return string(policyJSON)
+}
+
+func bucketArn(bucket string) string {
+	return fmt.Sprintf("%s%s", awsResourcePrefix, bucket)
 }
 
 func bucketDomainName(bucket string, bucketConfig *url.URL) string {

--- a/minio/resource_minio_s3_bucket_policy_test.go
+++ b/minio/resource_minio_s3_bucket_policy_test.go
@@ -19,11 +19,11 @@ func TestAccS3BucketPolicy_basic(t *testing.T) {
   "Statement": [
     {
       "Effect": "Allow",
-	  "Principal": {"AWS": ["*"]},
+      "Principal": {"AWS": ["*"]},
       "Resource": [
-		"arn:aws:s3:::%[1]s"
+        "arn:aws:s3:::%[1]s"
       ],
-	  "Action": ["s3:ListBucket"]
+      "Action": ["s3:ListBucket"]
     }
   ]
 }`, name)
@@ -63,7 +63,7 @@ func TestAccS3BucketPolicy_policyUpdate(t *testing.T) {
       "Resource": [
         "arn:aws:s3:::%[1]s"
       ],
-	  "Action": ["s3:ListBucket"]
+      "Action": ["s3:ListBucket"]
     }
   ]
 }`, name)
@@ -79,7 +79,7 @@ func TestAccS3BucketPolicy_policyUpdate(t *testing.T) {
       "Resource": [
         "arn:aws:s3:::%[1]s"
       ],
-	  "Action": ["s3:ListBucketVersions"]
+      "Action": ["s3:ListBucketVersions"]
     }
   ]
 }`, name)
@@ -122,12 +122,12 @@ func TestAccS3BucketPolicy_order(t *testing.T) {
   "Statement": [
     {
       "Effect": "Allow",
-	  "Principal": {"AWS": ["*"]},
+      "Principal": {"AWS": ["*"]},
       "Resource": [
-		"arn:aws:s3:::%[1]s",
-		"arn:aws:s3:::%[1]s/*"
+        "arn:aws:s3:::%[1]s",
+	"arn:aws:s3:::%[1]s/*"
       ],
-	  "Action": ["s3:ListBucket", "s3:ListBucketVersions"]
+      "Action": ["s3:ListBucket", "s3:ListBucketVersions"]
     }
   ]
 }`, name)
@@ -161,11 +161,11 @@ resource "minio_s3_bucket_policy" "bucket" {
   "Statement": [
     {
       "Effect": "Allow",
-	  "Principal": {"AWS": ["*"]},
+      "Principal": {"AWS": ["*"]},
       "Resource": [
-		"arn:aws:s3:::${minio_s3_bucket.bucket.bucket}"
+        "${minio_s3_bucket.bucket.arn}"
       ],
-	  "Action": ["s3:ListBucket"]
+      "Action": ["s3:ListBucket"]
     }
   ]
 }
@@ -191,9 +191,9 @@ resource "minio_s3_bucket_policy" "bucket" {
         "AWS": ["*"]
       },
       "Resource": [
-        "arn:aws:s3:::${minio_s3_bucket.bucket.bucket}"
+        "${minio_s3_bucket.bucket.arn}"
       ],
-	  "Action": ["s3:ListBucketVersions"]
+      "Action": ["s3:ListBucketVersions"]
     }
   ]
 }
@@ -219,10 +219,10 @@ resource "minio_s3_bucket_policy" "bucket" {
         "AWS": ["*"]
       },
       "Resource": [
-		"arn:aws:s3:::${minio_s3_bucket.bucket.bucket}/*",
-        "arn:aws:s3:::${minio_s3_bucket.bucket.bucket}"
+        "${minio_s3_bucket.bucket.arn}/*",
+        "${minio_s3_bucket.bucket.arn}"
       ],
-	  "Action": ["s3:ListBucketVersions", "s3:ListBucket"]
+      "Action": ["s3:ListBucketVersions", "s3:ListBucket"]
     }
   ]
 }

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -31,6 +31,8 @@ func TestAccMinioS3Bucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "bucket", testAccBucketName(rInt)),
 					resource.TestCheckResourceAttr(
+						resourceName, "arn", testAccBucketArn(rInt)),
+					resource.TestCheckResourceAttr(
 						resourceName, "bucket_domain_name", testAccBucketDomainName(rInt)),
 					resource.TestCheckResourceAttr(
 						resourceName, "acl", testAccBucketACL(acl)),
@@ -361,6 +363,10 @@ func testAccCheckMinioS3BucketACLInState(n string, acl string) resource.TestChec
 
 func testAccBucketName(randInt string) string {
 	return randInt
+}
+
+func testAccBucketArn(randInt string) string {
+	return fmt.Sprintf("arn:aws:s3:::%s", randInt)
 }
 
 func testAccBucketDomainName(randInt string) string {


### PR DESCRIPTION
Form and expose the `arn` attribute for the bucket resource.

This makes it easier to create IAM policies.