### PR TITLE
Add minio_insecure to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ provider minio {
   minio_region      = "..."
   minio_api_version = "..."
   minio_ssl         = "..."
+  minio_insecure    = "..."
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,3 +84,6 @@ The following arguments are supported in the `provider` block:
 
 - `minio_ssl` - (Optional) Minio SSL enabled (default: `false`). It can also be sourced from the
   `MINIO_ENABLE_HTTPS` environment variable
+
+- `minio_insecure` - (Optional) Disable SSL certificate verification (default: `false`).
+  It can also be sourced from the `MINIO_INSECURE` environment variable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,10 +50,10 @@ provider "minio" {
 
 You can provide your configuration via the environment variables representing your minio credentials:
 
-```
-$ export MINIO_ENDPOINT="http://myendpoint"
-$ export MINIO_ACCESS_KEY="244tefewg"
-$ export MINIO_SECRET_KEY="xgwgwqqwv"
+```bash
+export MINIO_ENDPOINT="http://myendpoint"
+export MINIO_ACCESS_KEY="244tefewg"
+export MINIO_SECRET_KEY="xgwgwqqwv"
 ```
 
 When using this method, you may omit the
@@ -69,18 +69,18 @@ resource "minio_s3_bucket" "state_terraform_s3" {
 
 The following arguments are supported in the `provider` block:
 
-* `minio_server` - (Required) Minio Host and Port. It must be provided, but
+- `minio_server` - (Required) Minio Host and Port. It must be provided, but
   it can also be sourced from the `MINIO_ENDPOINT` environment variable
 
-* `minio_access_key` - (Required) Minio Access Key. It must be provided, but
+- `minio_access_key` - (Required) Minio Access Key. It must be provided, but
   it can also be sourced from the `MINIO_ACCESS_KEY` environment variable
 
-* `minio_secret_key` - (Required) Minio Secret Key. It must be provided, but
+- `minio_secret_key` - (Required) Minio Secret Key. It must be provided, but
   it can also be sourced from the `MINIO_SECRET_KEY` environment variable
 
-* `minio_region` - (Optional) Minio Region (`default: us-east-1`).
+- `minio_region` - (Optional) Minio Region (`default: us-east-1`).
 
-* `minio_api_version` - (Optional) Minio API Version (type: string, options: `v2` or `v4`, default: `v4`).
+- `minio_api_version` - (Optional) Minio API Version (type: string, options: `v2` or `v4`, default: `v4`).
 
-* `minio_ssl` - (Optional) Minio SSL enabled (default: `false`). It can also be sourced from the
+- `minio_ssl` - (Optional) Minio SSL enabled (default: `false`). It can also be sourced from the
   `MINIO_ENABLE_HTTPS` environment variable

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -56,8 +56,9 @@ func Provider() *schema.Provider {
 				}, nil),
 			},
 			"minio_insecure": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disable SSL certificate verification (default: false)",
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"MINIO_INSECURE",
 				}, nil),


### PR DESCRIPTION
# Add `minio_insecure` to docs

This PR implements the following changes:

- Adds `minio_insecure` documentation.
- Reformat index.md following markdownlint rules.

## Reference

Follow-up on #157, just adds documentation of `minio_insecure`. I noticed other issues regarding the CACERT variables so I left those out to avoid adding confusion until that's fixed.
