### PR TITLE
Avoid mentioning specific architectures of prebuilds on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It just means that we can't guarantee backward compatibility.
 
 ## Building and Installing
 
-Prebuilt versions of this provider are available for MacOS and Linux on the [releases page](https://github.com/aminueza/terraform-provider-minio/releases/latest).
+Prebuilt versions of this provider are available on the [releases page](https://github.com/aminueza/terraform-provider-minio/releases/latest).
 
 But if you need to build it yourself, just download this repository, [install](https://taskfile.dev/#/installation) [Task](https://taskfile.dev/):
 


### PR DESCRIPTION
# Avoid mentioning specific architectures of prebuilds on Readme
Because we now target many more architectures. See the [last release](https://github.com/aminueza/terraform-provider-minio/releases/tag/v1.6.0), for example.
