### PR TITLE
Use the plugin version from the latest available repository tag when running tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@
 version: '3'
 
 vars:
-  PLUGIN_VERSION: 1.4.0
+  PLUGIN_VERSION: $(git describe --tags `git rev-list --tags --max-count=1` | sed 's/v//')
   OUTPUT_FILENAME: terraform-provider-minio
 
 tasks:


### PR DESCRIPTION
# Use the plugin version from the latest available repository tag when running tasks

To get rid of the static version number on `Taskfile.yml`.

To test, run `task install` and confirm if the version is set correctly in the path where the plugin is saved. For example:
```
❯ task install
Building and installing plugin in /home/gitpod/.local/share/terraform/plugins/registry.terraform.io/aminueza/minio/1.6.0/linux_amd64/terraform-provider-minio
Done!
```