### PR TITLE
Use a loose version requirement, to make it runnable with the development version built with "task install" command

### DIFF
--- a/examples/serviceaccount/main.tf
+++ b/examples/serviceaccount/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     minio = {
       source = "aminueza/minio"
-      version = "= 1.6.0"
+      version = ">= 1.0.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
# Use a loose version requirement to make it runnable with the development version built with `task install` command

As mentioned here: https://github.com/aminueza/terraform-provider-minio/pull/355#discussion_r996281863