### PR TITLE
Add minio_session_token configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,11 @@ provider minio {
   minio_secret_key   = "..."
 
   // optional
-  minio_region      = "..."
-  minio_api_version = "..."
-  minio_ssl         = "..."
-  minio_insecure    = "..."
+  minio_session_token = "..."
+  minio_region        = "..."
+  minio_api_version   = "..."
+  minio_ssl           = "..."
+  minio_insecure      = "..."
 }
 ```
 
@@ -78,6 +79,9 @@ The following arguments are supported in the `provider` block:
 
 - `minio_secret_key` - (Required) Minio Secret Key. It must be provided, but
   it can also be sourced from the `MINIO_SECRET_KEY` environment variable
+
+- `minio_session_token` - (Optional) Minio Session Token. It can also be sourced from
+  the `MINIO_SESSION_TOKEN` environment variable
 
 - `minio_region` - (Optional) Minio Region (`default: us-east-1`).
 

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -38,6 +38,7 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		S3Region:        d.Get("minio_region").(string),
 		S3UserAccess:    d.Get("minio_access_key").(string),
 		S3UserSecret:    d.Get("minio_secret_key").(string),
+		S3SessionToken:  d.Get("minio_session_token").(string),
 		S3APISignature:  d.Get("minio_api_version").(string),
 		S3SSL:           d.Get("minio_ssl").(bool),
 		S3SSLCACertFile: d.Get("minio_cert_file").(string),

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -13,6 +13,7 @@ type S3MinioConfig struct {
 	S3UserAccess    string
 	S3UserSecret    string
 	S3Region        string
+	S3SessionToken  string
 	S3APISignature  string
 	S3SSL           bool
 	S3SSLCACertFile string

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -41,6 +41,14 @@ func Provider() *schema.Provider {
 					"MINIO_SECRET_KEY",
 				}, nil),
 			},
+			"minio_session_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Minio Session Token",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"MINIO_SESSION_TOKEN",
+				}, ""),
+			},
 			"minio_api_version": {
 				Type:        schema.TypeString,
 				Optional:    true,


### PR DESCRIPTION
Adds `minio_session_token` configuration option to support using temporary credentials. I followed the recommended strategy from the issue comment, and I also updated the `minioAdmin` creation to use `NewWithOptions` to support configuring credentials with a session token. I didn't see anywhere else that needed updating, but I may have missed something.

The tests are passing, but I'm happy to add more. I just didn't see a clear place where provider configuration tests would fit. Let me know if there are any changes I should make, thanks!

## Closing issues

- Closes: #100 
