### PR TITLE
feat: INFRA-132 Fixed update user secret

### DIFF
--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -102,7 +102,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	var err error
 	secretKey := iamUserConfig.MinioSecret
 
-	if secretKey == "" {
+	if secretKey == "" || iamUserConfig.MinioUpdateKey {
 		if secretKey, err = generateSecretAccessKey(); err != nil {
 			return NewResourceError("error creating user", d.Id(), err)
 		}

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -129,7 +129,6 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		AccessKey: iamUserConfig.MinioIAMName,
 		SecretKey: secretKey,
 		Status:    madmin.AccountEnabled,
-
 	}
 
 	if iamUserConfig.MinioDisableUser {

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -155,7 +155,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		}
 	}
 
-	if iamUserConfig.MinioUpdateKey {
+	if iamUserConfig.MinioUpdateKey || d.HasChangeExcept(iamUserConfig.MinioSecret){
 		err := iamUserConfig.MinioAdmin.SetUser(ctx, userStatus.AccessKey, userStatus.SecretKey, userStatus.Status)
 		if err != nil {
 			return NewResourceError("error updating IAM User Key %s: %s", d.Id(), err)

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -101,7 +101,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	var err error
 	secretKey := iamUserConfig.MinioSecret
 
-	if secretKey == "" || iamUserConfig.MinioUpdateKey {
+	if secretKey == "" {
 		if secretKey, err = generateSecretAccessKey(); err != nil {
 			return NewResourceError("error creating user", d.Id(), err)
 		}

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -97,6 +97,7 @@ func minioCreateUser(ctx context.Context, d *schema.ResourceData, meta interface
 func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	iamUserConfig := IAMUserConfig(d, meta)
+	userStatus := UserStatus{}
 
 	var err error
 	secretKey := iamUserConfig.MinioSecret
@@ -124,10 +125,18 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		d.SetId(nn.(string))
 	}
 
-	userStatus := UserStatus{
-		AccessKey: iamUserConfig.MinioIAMName,
-		SecretKey: secretKey,
-		Status:    madmin.AccountEnabled,
+	if d.HasChangeExcept(iamUserConfig.MinioSecret ) {
+		userStatus = UserStatus{
+			AccessKey: iamUserConfig.MinioIAMName,
+			SecretKey: iamUserConfig.MinioSecret,
+			Status:    madmin.AccountEnabled,
+		}
+	}else{
+		userStatus = UserStatus{
+			AccessKey: iamUserConfig.MinioIAMName,
+			SecretKey: secretKey,
+			Status:    madmin.AccountEnabled,
+		}	
 	}
 
 	if iamUserConfig.MinioDisableUser {

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -97,7 +97,6 @@ func minioCreateUser(ctx context.Context, d *schema.ResourceData, meta interface
 func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	iamUserConfig := IAMUserConfig(d, meta)
-	userStatus := UserStatus{}
 
 	var err error
 	secretKey := iamUserConfig.MinioSecret
@@ -106,6 +105,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		if secretKey, err = generateSecretAccessKey(); err != nil {
 			return NewResourceError("error creating user", d.Id(), err)
 		}
+		_ = d.Set("secret", secretKey)
 	}
 
 	if d.HasChange(iamUserConfig.MinioIAMName) {
@@ -125,18 +125,11 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		d.SetId(nn.(string))
 	}
 
-	if d.HasChangeExcept(iamUserConfig.MinioSecret ) {
-		userStatus = UserStatus{
-			AccessKey: iamUserConfig.MinioIAMName,
-			SecretKey: iamUserConfig.MinioSecret,
-			Status:    madmin.AccountEnabled,
-		}
-	}else{
-		userStatus = UserStatus{
-			AccessKey: iamUserConfig.MinioIAMName,
-			SecretKey: secretKey,
-			Status:    madmin.AccountEnabled,
-		}	
+	userStatus := UserStatus{
+		AccessKey: iamUserConfig.MinioIAMName,
+		SecretKey: secretKey,
+		Status:    madmin.AccountEnabled,
+
 	}
 
 	if iamUserConfig.MinioDisableUser {
@@ -155,13 +148,11 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		}
 	}
 
-	if iamUserConfig.MinioUpdateKey || d.HasChangeExcept(iamUserConfig.MinioSecret){
+	if d.HasChange("secret") {
 		err := iamUserConfig.MinioAdmin.SetUser(ctx, userStatus.AccessKey, userStatus.SecretKey, userStatus.Status)
 		if err != nil {
 			return NewResourceError("error updating IAM User Key %s: %s", d.Id(), err)
 		}
-
-		_ = d.Set("secret", secretKey)
 	}
 
 	return minioReadUser(ctx, d, meta)

--- a/minio/resource_minio_iam_user_test.go
+++ b/minio/resource_minio_iam_user_test.go
@@ -153,6 +153,55 @@ func TestAccAWSUser_SettingAccessKey(t *testing.T) {
 	})
 }
 
+func TestAccAWSUser_UpdateAccessKey(t *testing.T) {
+	var user madmin.UserInfo
+	var oldAccessKey string
+
+	name := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	resourceName := "minio_iam_user.test5"
+
+	resource.ParallelTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: testAccProviders,
+			CheckDestroy:      testAccCheckMinioUserDestroy,
+			Steps: []resource.TestStep{
+					{
+							Config: testAccMinioUserConfigWithSecretOne(name),
+							Check: resource.ComposeTestCheckFunc(
+									testAccCheckMinioUserExists(resourceName, &user),
+									testAccCheckMinioUserExfiltrateAccessKey(resourceName, &oldAccessKey),
+									testAccCheckMinioUserCanLogIn(resourceName),
+							),
+					},
+					{
+							Config: testAccMinioUserConfigWithSecretTwo(name),
+							Check: resource.ComposeTestCheckFunc(
+									testAccCheckMinioUserExists(resourceName, &user),
+									testAccCheckMinioUserRotatesAccessKey(resourceName, &oldAccessKey),
+									testAccCheckMinioUserCanLogIn(resourceName),
+							),
+					},
+			},
+	})
+}
+
+func testAccMinioUserConfigWithSecretOne(rName string) string {
+	      return fmt.Sprintf(`
+	resource "minio_iam_user" "test5" {
+	  secret = "secret1234"
+	  name   = %q
+	}
+	`, rName)
+	}
+	func testAccMinioUserConfigWithSecretTwo(rName string) string {
+	       return fmt.Sprintf(`
+	resource "minio_iam_user" "test5" {
+	  secret = "secret4321"
+	  name   = %q
+	}
+	`, rName)
+}
+
 func testAccMinioUserConfig(rName string) string {
 	return fmt.Sprintf(`
 	resource "minio_iam_user" "test" {
@@ -323,7 +372,7 @@ func minioUIwebrpcLogin(cfg *S3MinioConfig) error {
 	requestData, _ := json.Marshal(loginData)
 
 	client := &http.Client{}
-	req, err := http.NewRequest("POST", "http://localhost:9001/login", strings.NewReader(string(requestData)))
+	req, err := http.NewRequest("POST", "http://localhost:9001/api/v1/login", strings.NewReader(string(requestData)))
 	if err != nil {
 		return err
 	}

--- a/minio/resource_minio_iam_user_test.go
+++ b/minio/resource_minio_iam_user_test.go
@@ -161,40 +161,40 @@ func TestAccAWSUser_UpdateAccessKey(t *testing.T) {
 	resourceName := "minio_iam_user.test5"
 
 	resource.ParallelTest(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
-			ProviderFactories: testAccProviders,
-			CheckDestroy:      testAccCheckMinioUserDestroy,
-			Steps: []resource.TestStep{
-					{
-							Config: testAccMinioUserConfigWithSecretOne(name),
-							Check: resource.ComposeTestCheckFunc(
-									testAccCheckMinioUserExists(resourceName, &user),
-									testAccCheckMinioUserExfiltrateAccessKey(resourceName, &oldAccessKey),
-									testAccCheckMinioUserCanLogIn(resourceName),
-							),
-					},
-					{
-							Config: testAccMinioUserConfigWithSecretTwo(name),
-							Check: resource.ComposeTestCheckFunc(
-									testAccCheckMinioUserExists(resourceName, &user),
-									testAccCheckMinioUserRotatesAccessKey(resourceName, &oldAccessKey),
-									testAccCheckMinioUserCanLogIn(resourceName),
-							),
-					},
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioUserConfigWithSecretOne(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioUserExists(resourceName, &user),
+					testAccCheckMinioUserExfiltrateAccessKey(resourceName, &oldAccessKey),
+					testAccCheckMinioUserCanLogIn(resourceName),
+				),
 			},
+			{
+				Config: testAccMinioUserConfigWithSecretTwo(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioUserExists(resourceName, &user),
+					testAccCheckMinioUserRotatesAccessKey(resourceName, &oldAccessKey),
+					testAccCheckMinioUserCanLogIn(resourceName),
+				),
+			},
+		},
 	})
 }
 
 func testAccMinioUserConfigWithSecretOne(rName string) string {
-	      return fmt.Sprintf(`
+	return fmt.Sprintf(`
 	resource "minio_iam_user" "test5" {
 	  secret = "secret1234"
 	  name   = %q
 	}
 	`, rName)
-	}
-	func testAccMinioUserConfigWithSecretTwo(rName string) string {
-	       return fmt.Sprintf(`
+}
+func testAccMinioUserConfigWithSecretTwo(rName string) string {
+	return fmt.Sprintf(`
 	resource "minio_iam_user" "test5" {
 	  secret = "secret4321"
 	  name   = %q


### PR DESCRIPTION
I have an existing minio user, when I try to update the secret for this user it's not working. the user still have the old password.

This PR implements the following changes:
```
func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

	iamUserConfig := IAMUserConfig(d, meta)

	var err error
	secretKey := iamUserConfig.MinioSecret

	if secretKey == "" || iamUserConfig.MinioUpdateKey {
		if secretKey, err = generateSecretAccessKey(); err != nil {
			return NewResourceError("error creating user", d.Id(), err)
		}
	}
the fix :

func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

	iamUserConfig := IAMUserConfig(d, meta)

	var err error
	secretKey := iamUserConfig.MinioSecret

---> if secretKey == "" {
		if secretKey, err = generateSecretAccessKey(); err != nil {
			return NewResourceError("error creating user", d.Id(), err)
		}
	}
```
## Reference

 - Resolves: #354

## Closing issues

- Closes: #354
