### PR TITLE
Update MinIO image in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: "3"
 services:
   minio:
-    image: docker.io/minio/minio:RELEASE.2022-03-26T06-49-28Z
+    image: docker.io/minio/minio:RELEASE.2022-10-21T22-37-48Z
     ports:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
-      MINIO_CI_CD: '1'
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+      MINIO_CI_CD: "1"
     command: server --console-address :9001 /data{0...3}
   adminio-ui:
     image: docker.io/rzrbld/adminio-ui:v1.93


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Update MinIO image in docker-compose.yml

Image was updated to `minio/minio:RELEASE.2022-10-21T22-37-48Z`.

Environment variables were also changed due to this warning from the latest version of MinIO:
```
WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
         Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
```