### PR TITLE
Update terraform to v1.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - uses: dominikh/staticcheck-action@v1.2.0
         with:
           version: "2022.1.1"
@@ -38,7 +38,7 @@ jobs:
         run: docker-compose up -d minio
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.6
+          terraform_version: 1.3.3
           terraform_wrapper: false
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
       (cd /tmp && brew install hashicorp/tap/terraform go-task/tap/go-task minio-mc)
       go get -v -t -d ./...
       task install
-      gp await-port 9000 && gp await-port 8080 && gp await-port 8000
+      gp ports await 9000 && gp ports await 8080 && gp ports await 8000
       mc alias set local http://localhost:9000 minio minio123 && echo "MinIO Local Server Stats:" && mc admin info local
 
 ports:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Made with <span style="color: #e25555;">&#9829;</span> using [Go](https://golang
 
 ## Supported Versions
 
-- Terraform v1.2
+- Terraform v1.3
 - Go v1.19
 
 It doesn't mean that this provider won't run on previous versions of Terraform or Go, though.


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Update terraform version

This PR implements the following changes:
- Updates terraform to version 1.3.3 in `.github/workflows/go.yml`
- Updates terraform version in Readme
- Updates a deprecated command in  `.gitpod.yml`

---

Although the provider still works fine for v1.2, I think we should stick with what's mentioned in the Readme:
https://github.com/aminueza/terraform-provider-minio/blob/eaa16871b3b6191f1a0454c2bad12b4d8e5a6e8e/README.md?plain=1#L52-L53

My concern is that someone willing to contribute could get demotivated to contribute to a project that requires backward compatibility. (I've seen a lot of problems with this aspect in other libraries/plugins/extensions projects.)