### PR TITLE
Fix service account login

### DIFF
--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -77,6 +77,7 @@ func ServiceAccountConfig(d *schema.ResourceData, meta interface{}) *S3MinioServ
 
 	return &S3MinioServiceAccountConfig{
 		MinioAdmin:       m.S3Admin,
+		MinioAccessKey:   d.Get("access_key").(string),
 		MinioTargetUser:  d.Get("target_user").(string),
 		MinioDisableUser: d.Get("disable_user").(bool),
 		MinioUpdateKey:   d.Get("update_secret").(bool),

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -24,6 +24,7 @@ func resourceMinioServiceAccount() *schema.Resource {
 			"target_user": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"disable_user": {
 				Type:        schema.TypeBool,
@@ -96,23 +97,6 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		if secretKey, err = generateSecretAccessKey(); err != nil {
 			return NewResourceError("error creating service account", d.Id(), err)
 		}
-	}
-
-	if d.HasChange(serviceAccountConfig.MinioTargetUser) {
-		on, nn := d.GetChange(serviceAccountConfig.MinioTargetUser)
-
-		log.Println("[DEBUG] Update service account:", serviceAccountConfig.MinioTargetUser)
-		err := serviceAccountConfig.MinioAdmin.DeleteServiceAccount(ctx, on.(string))
-		if err != nil {
-			return NewResourceError("error updating service account %s: %s", d.Id(), err)
-		}
-
-		_, err = serviceAccountConfig.MinioAdmin.AddServiceAccount(ctx, madmin.AddServiceAccountReq{AccessKey: nn.(string), SecretKey: secretKey})
-		if err != nil {
-			return NewResourceError("error updating service account %s: %s", d.Id(), err)
-		}
-
-		d.SetId(nn.(string))
 	}
 
 	serviceAccountStatus := ServiceAccountStatus{

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -2,10 +2,11 @@ package minio
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go"
 )
@@ -141,7 +142,7 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 		return NewResourceError("error reading service account %s: %s", d.Id(), err)
 	}
 
-	log.Printf("[WARN] (%v)", output)
+	log.Printf("[DEBUG] (%v)", output)
 
 	if _, ok := d.GetOk("access_key"); !ok {
 		_ = d.Set("access_key", d.Id())
@@ -177,11 +178,11 @@ func deleteMinioServiceAccount(ctx context.Context, serviceAccountConfig *S3Mini
 		if err != nil {
 			return err
 		}
-		if !Contains(serviceAccountList.Accounts, serviceAccountConfig.MinioAccessKey) {
-			return nil
+		if Contains(serviceAccountList.Accounts, serviceAccountConfig.MinioAccessKey) {
+			return fmt.Errorf("service account %s not deleted", serviceAccountConfig.MinioAccessKey)
 		}
 
-		return err
+		return nil
 	}
 	return nil
 }

--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -212,12 +212,18 @@ func testAccCheckMinioServiceAccountCanLogIn(n string) resource.TestCheckFunc {
 
 		// Check if we can log in
 		cfg := &S3MinioConfig{
-			S3HostPort:   os.Getenv("MINIO_ENDPOINT"),
-			S3UserAccess: rs.Primary.Attributes["access_key"],
-			S3UserSecret: rs.Primary.Attributes["secret_key"],
-			S3SSL:        map[string]bool{"true": true, "false": false}[os.Getenv("MINIO_ENABLE_HTTPS")],
+			S3APISignature: "v4",
+			S3HostPort:     os.Getenv("MINIO_ENDPOINT"),
+			S3UserAccess:   rs.Primary.Attributes["access_key"],
+			S3UserSecret:   rs.Primary.Attributes["secret_key"],
+			S3SSL:          map[string]bool{"true": true, "false": false}[os.Getenv("MINIO_ENABLE_HTTPS")],
 		}
-		return minioUIwebrpcLogin(cfg)
+		client, err := cfg.NewClient()
+		if err != nil {
+			return err
+		}
+		_, err = client.(*S3MinioClient).S3Client.ListBuckets(context.Background())
+		return err
 	}
 }
 

--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/minio/madmin-go"
@@ -15,7 +14,7 @@ import (
 func TestServiceAccount_basic(t *testing.T) {
 	var serviceAccount madmin.InfoServiceAccountResp
 
-	targetUser := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	targetUser := "minio"
 	status := "on"
 	resourceName := "minio_iam_service_account.test"
 
@@ -38,7 +37,7 @@ func TestServiceAccount_basic(t *testing.T) {
 func TestServiceAccount_Disable(t *testing.T) {
 	var serviceAccount madmin.InfoServiceAccountResp
 
-	targetUser := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	targetUser := "minio"
 	resourceName := "minio_iam_service_account.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -61,7 +60,7 @@ func TestServiceAccount_RotateAccessKey(t *testing.T) {
 	var serviceAccount madmin.InfoServiceAccountResp
 	var oldAccessKey string
 
-	targetUser := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	targetUser := "minio"
 	resourceName := "minio_iam_service_account.test3"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -107,7 +106,7 @@ func testAccMinioServiceAccountConfigDisabled(rName string) string {
 func testAccMinioServiceAccountConfigWithoutSecret(rName string) string {
 	return fmt.Sprintf(`
 resource "minio_iam_service_account" "test3" {
-  target_user          = %q
+  target_user = %q
 }
 `, rName)
 }
@@ -115,7 +114,7 @@ func testAccMinioServiceAccountConfigUpdateSecret(rName string) string {
 	return fmt.Sprintf(`
 resource "minio_iam_service_account" "test3" {
   update_secret = true
-  target_user          = %q
+  target_user   = %q
 }
 `, rName)
 }


### PR DESCRIPTION
Fixes problems unearthed by changes in #364

Changes:

* Use `ForceNew` on target user changes.  This just simplifies the code.
* Fix the test if the service account can log in.  This check cannot happen using the GUI, as service accounts can not log into it that way.  This rewrites the check to simply list all buckets and checks success.  It works by using the admin `minio` user as target user, which also removes the oddity of using a non-existent target user in the tests.
* Revise logic around failures deleting the service account, which could lead to hiding the real error.