### PR TITLE
Add fields to minio_s3_bucket_versioning

### DIFF
--- a/docs/resources/s3_bucket_versioning.md
+++ b/docs/resources/s3_bucket_versioning.md
@@ -41,3 +41,8 @@ resource "minio_s3_bucket_versioning" "bucket" {
 Required:
 
 - `status` (String) Versioning status, one of "Enabled", "Suspended".
+
+Optional:
+
+- `exclude_folders` (Boolean)
+- `excluded_prefixes` (List of String)

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -51,7 +51,9 @@ type S3MinioBucketPolicy struct {
 
 // S3MinioBucketVersioningConfiguration defines bucket versioning config
 type S3MinioBucketVersioningConfiguration struct {
-	Status string
+	Status           string
+	ExcludedPrefixes []string
+	ExcludeFolders   bool
 }
 
 // S3MinioBucketVersioning defines bucket versioning


### PR DESCRIPTION
Adds `exclude_folders` and `excluded_prefixes` fields to `minio_s3_bucket_versioning` resource to cover missing functionality. Initially I'd planned on including `mfa_delete` as well because it's in the client, but after some initial troubleshooting it looks like it isn't currently supported on the server:

https://github.com/minio/minio/blob/52221db7ef4944fa0a2e0b133c760687ca8fe66e/internal/bucket/versioning/versioning.go#L53

The other fields look like they're working fine though, but wanted to flag that

## Reference

 - Closes #370 