### PR TITLE
Fix updating minio_iam_user name

### DIFF
--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -27,6 +27,7 @@ func resourceMinioIAMUser() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateMinioIamUserName,
 			},
 			"force_destroy": {
@@ -105,23 +106,6 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		if secretKey, err = generateSecretAccessKey(); err != nil {
 			return NewResourceError("error creating user", d.Id(), err)
 		}
-	}
-
-	if d.HasChange(iamUserConfig.MinioIAMName) {
-		on, nn := d.GetChange(iamUserConfig.MinioIAMName)
-
-		log.Println("[DEBUG] Update IAM User:", iamUserConfig.MinioIAMName)
-		err := iamUserConfig.MinioAdmin.RemoveUser(ctx, on.(string))
-		if err != nil {
-			return NewResourceError("error updating IAM User %s: %s", d.Id(), err)
-		}
-
-		err = iamUserConfig.MinioAdmin.AddUser(ctx, nn.(string), secretKey)
-		if err != nil {
-			return NewResourceError("error updating IAM User %s: %s", d.Id(), err)
-		}
-
-		d.SetId(nn.(string))
 	}
 
 	userStatus := UserStatus{

--- a/minio/resource_minio_iam_user_test.go
+++ b/minio/resource_minio_iam_user_test.go
@@ -77,6 +77,35 @@ func TestAccAWSUser_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSUser_UpdateName(t *testing.T) {
+	var user madmin.UserInfo
+
+	name := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	status := "enabled"
+	resourceName := "minio_iam_user.test"
+	updatedName := fmt.Sprintf("test-user-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioUserConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioUserExists(resourceName, &user),
+				),
+			},
+			{
+				Config: testAccMinioUserConfig(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioUserAttributes(resourceName, updatedName, status),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSUser_DisableUser(t *testing.T) {
 	var user madmin.UserInfo
 


### PR DESCRIPTION
Changes

- Fixes the issue with updating `name` on `minio_iam_user` by using `ForceNew` for deleting and replacing a user when the username changes
- Refactors `minio_iam_user` to remove the custom logic that previously managed replacing a user when the username changedIt 
- Adds a test to verify that updating `name` for `minio_iam_user` runs successfully, which fails on the current code

## Reference

 - Closes #377