### PR TITLE
Download package dependencies during Gitpod Prebuild to reduce the time for the workspace to be ready

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,12 +5,16 @@ tasks:
       sed -i 's/http:\/\/localhost:8080/$API_BASE_URL/g' ${DOCKER_COMPOSE_GITPOD_PATH} &&
       export API_BASE_URL=`gp url 8080` &&
       docker-compose -f ${DOCKER_COMPOSE_GITPOD_PATH} up
-  - command: |
-      (cd /tmp && brew install hashicorp/tap/terraform go-task/tap/go-task minio-mc)
-      go get -v -t -d ./...
-      task install
-      gp ports await 9000 && gp ports await 8080 && gp ports await 8000
-      mc alias set local http://localhost:9000 minio minio123 && echo "MinIO Local Server Stats:" && mc admin info local
+  - init: go get -v -t -d ./...
+    command: >
+      (cd /tmp && brew install hashicorp/tap/terraform go-task/tap/go-task minio-mc) &&
+      task install &&
+      gp ports await 9000 &&
+      gp ports await 8080 &&
+      gp ports await 8000 &&
+      mc alias set local http://localhost:9000 minio minio123 &&
+      echo "MinIO Local Server Stats:" &&
+      mc admin info local
 
 ports:
   - port: 9000


### PR DESCRIPTION
# Description

Download package dependencies during Gitpod Prebuild to reduce the time for the workspace to be ready.

Reference: https://www.gitpod.io/docs/introduction/languages/go#start-up-tasks