### PR TITLE
Fix importing minio_iam_group

### DIFF
--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -113,7 +113,7 @@ func minioReadGroup(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	iamGroupConfig := IAMGroupConfig(d, meta)
 
-	output, err := iamGroupConfig.MinioAdmin.GetGroupDescription(ctx, iamGroupConfig.MinioIAMName)
+	output, err := iamGroupConfig.MinioAdmin.GetGroupDescription(ctx, d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "group does not exist") {
 			log.Printf("[WARN] No IAM group by name (%s) found, removing from state", d.Id())

--- a/minio/resource_minio_iam_group_test.go
+++ b/minio/resource_minio_iam_group_test.go
@@ -77,6 +77,12 @@ func TestAccAWSGroup_Basic(t *testing.T) {
 					testAccCheckMinioGroupDisable(&conf, groupName2, status2),
 				),
 			},
+			{
+				ResourceName:            "minio_iam_group.test2",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_group", "force_destroy", "name"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Changes

- Updates the read operation for `minio_iam_group` to use `d.Id()` instead of referencing the group config so that importing works
- Updates the associated test to check whether or not import works by adding a step with `ImportState`

While updating this I noticed that the behavior of using a hidden `group_name` field in addition to `name` as well as only reading `group_name` in `minioReadGroup` seemed a bit odd. For now I just ignored the fields that aren't read to match the pattern from other test files. Would it make sense to refactor that in the future or am I missing something in the implementation?

## Closing issues

- Closes: #375 
