### PR TITLE
Add delete marker support to minio_ilm_policy rules

### DIFF
--- a/docs/resources/ilm_policy.md
+++ b/docs/resources/ilm_policy.md
@@ -46,11 +46,9 @@ Required:
 
 Optional:
 
-- **expiration** (String)
+- **expiration** (String) The expiration as a duration (5d), date (1970-01-01), or "DeleteMarker"
 - **filter** (String)
 
 Read-Only:
 
 - **status** (String)
-
-


### PR DESCRIPTION
Adds support for `DeleteMarker` to `minio_ilm_policy` based on the [documentation from the issue](https://github.com/minio/minio/blob/master/docs/bucket/lifecycle/README.md#33-automatic-removal-of-delete-markers-with-no-other-versions) #384.

Adding `DeleteMarker` seemed simpler within the current setup than adding a new block, so I followed the pattern currently in place. I'm planning on looking into `NoncurrentVersionExpiration` in a separate PR

## Reference

 - Progress on #384 
