### PR TITLE
Add support for Tags in minio_ilm_policy resource

### DIFF
--- a/docs/resources/ilm_policy.md
+++ b/docs/resources/ilm_policy.md
@@ -22,7 +22,12 @@ resource "minio_ilm_policy" "bucket-lifecycle-rules" {
 
   rule {
     id         = "expire-7d"
-    expiration = 7
+    expiration = "7d"
+    filter     = "prefix/"
+
+    tags = {
+      "app"  = "myapp"
+    }
   }
 }
 ```
@@ -47,7 +52,8 @@ Required:
 Optional:
 
 - **expiration** (String) The expiration as a duration (5d), date (1970-01-01), or "DeleteMarker"
-- **filter** (String)
+- **filter** (String) Correspond to "prefix" value
+- **tags** (Map of String) List of tags to use in filter
 
 Read-Only:
 


### PR DESCRIPTION
# Add support for Tags in minio_ilm_policy resource

This PR implements the following changes:

* Add a "tags" argument to the "rule" block, to set the tags of the rule filter
* Following the [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html), this PR implements the different XML formatting when using "filter" argument only (prefix), and when using "tags" with it
* Add acceptance tests for these two cases

## Reference
 - See also: #384 