### PR TITLE
Change github action for markdown link checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,6 @@ jobs:
         uses: actions/checkout@v3
         with:
             fetch-depth: 1
-      
+
       - name: Markdown Link Validation
-        uses: nolte/github-action/markdown/validate@v0.1.0
-        with:
-          args: "--frail" # task fails if warnings exists.
+        uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For testing locally, run the docker compose to spin up a minio server:
 docker-compose up
 ```
 
-Access http://localhost:8000 on your browser, apply your terraform templates and watch them going live.
+Access localhost:8000 on your browser, apply your terraform templates and watch them going live.
 
 ## Usage
 


### PR DESCRIPTION
I noticed that in #421 there are some issues with the link validation action originally added in #43. It looks like there's a more actively maintained action that performs the same task that might be a better fit