### PR TITLE
typo: fix The name of environment variable in the configuration file …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ authentication, in this order, and explained below:
 
 ### Static API Key
 
-Static credentials can be provided by adding the `minio-server`, `minio_user` and `minio_password` variables in-line in the
+Static credentials can be provided by adding the `minio_server`, `minio_user` and `minio_password` variables in-line in the
 Minio provider block:
 
 Usage:


### PR DESCRIPTION
The name of the environment variable in the description on the front page of the Provider document is incorrect

This PR implements the following changes:
 fix The name of environment variable in the configuration file

![image](https://user-images.githubusercontent.com/12819457/227452191-0287e67c-d8d6-43fa-b868-dab7fb806d46.png)





