### PR TITLE
Add `repo-token` to avoid API Limit Reached error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run install task
         run: task install
       - name: Run test task


### PR DESCRIPTION
Add `repo-token` to avoid this API Limit Reached error: https://github.com/aminueza/terraform-provider-minio/actions/runs/4511651319/jobs/7944054765

Reference: https://github.com/arduino/setup-task#repo-token