### PR TITLE
Add support for object locking in minio_s3_bucket resource.

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -38,6 +38,7 @@ output "minio_url" {
 - **force_destroy** (Boolean)
 - **id** (String) The ID of this resource.
 - **quota** (Number) The limit of the amount of data in the bucket (bytes).
+- **object_locking** (Boolean) - Whether object locking should be enabled for the bucket.
 
 ### Read-Only
 

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -9,14 +9,15 @@ func BucketConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucket {
 	m := meta.(*S3MinioClient)
 
 	return &S3MinioBucket{
-		MinioClient:       m.S3Client,
-		MinioAdmin:        m.S3Admin,
-		MinioRegion:       m.S3Region,
-		MinioAccess:       m.S3UserAccess,
-		MinioBucket:       d.Get("bucket").(string),
-		MinioBucketPrefix: d.Get("bucket_prefix").(string),
-		MinioACL:          d.Get("acl").(string),
-		MinioForceDestroy: d.Get("force_destroy").(bool),
+		MinioClient:          m.S3Client,
+		MinioAdmin:           m.S3Admin,
+		MinioRegion:          m.S3Region,
+		MinioAccess:          m.S3UserAccess,
+		MinioBucket:          d.Get("bucket").(string),
+		MinioBucketPrefix:    d.Get("bucket_prefix").(string),
+		MinioACL:             d.Get("acl").(string),
+		MinioForceDestroy:    d.Get("force_destroy").(bool),
+		ObjectLockingEnabled: d.Get("object_locking").(bool),
 	}
 }
 

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -33,14 +33,15 @@ type S3MinioClient struct {
 
 // S3MinioBucket defines minio config
 type S3MinioBucket struct {
-	MinioClient       *minio.Client
-	MinioAdmin        *madmin.AdminClient
-	MinioRegion       string
-	MinioBucket       string
-	MinioBucketPrefix string
-	MinioACL          string
-	MinioAccess       string
-	MinioForceDestroy bool
+	MinioClient          *minio.Client
+	MinioAdmin           *madmin.AdminClient
+	MinioRegion          string
+	MinioBucket          string
+	MinioBucketPrefix    string
+	MinioACL             string
+	MinioAccess          string
+	MinioForceDestroy    bool
+	ObjectLockingEnabled bool
 }
 
 // S3MinioBucketPolicy defines bucket policy config

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -161,6 +161,7 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 
 	_ = d.Set("arn", bucketArn(d.Id()))
 	_ = d.Set("bucket_domain_name", bucketDomainName(d.Id(), bucketURL))
+	_ = d.Set("object_locking", bucketConfig.ObjectLockingEnabled)
 
 	return nil
 }

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -72,6 +72,12 @@ func resourceMinioBucket() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"object_locking": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -109,8 +115,10 @@ func minioCreateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	err := bucketConfig.MinioClient.MakeBucket(ctx, bucket, minio.MakeBucketOptions{
-		Region: region,
+		Region:        region,
+		ObjectLocking: bucketConfig.ObjectLockingEnabled,
 	})
+
 	if err != nil {
 		log.Printf("%s", NewResourceErrorStr("unable to create bucket", bucket, err))
 		return NewResourceError("unable to create bucket", bucket, err)

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -36,6 +36,8 @@ func TestAccMinioS3Bucket_basic(t *testing.T) {
 						resourceName, "bucket_domain_name", testAccBucketDomainName(rInt)),
 					resource.TestCheckResourceAttr(
 						resourceName, "acl", testAccBucketACL(acl)),
+					resource.TestCheckResourceAttr(
+						resourceName, "object_locking", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
This PR implements the option to enable object locking with `minio_s3_bucket` resource type. There's a new option `object_locking`, that can be specified for these resources.

Default behavior did not change, and object locking defaults to false.

## Reference
 - Resolves: #452