### PR TITLE
Feature/objectLocking import issue fix

### DIFF
--- a/minio/import_minio_s3_buckets.go
+++ b/minio/import_minio_s3_buckets.go
@@ -22,15 +22,8 @@ func resourceMinioS3BucketImportState(
 	conn := meta.(*S3MinioClient).S3Client
 
 	bucketObjectLocking, _, _, _, err := conn.GetObjectLockConfig(ctx, d.Id())
-	if err != nil {
-		_ = d.Set("object_locking", false)
-	}
-
-	if bucketObjectLocking == "Enabled" {
-		_ = d.Set("object_locking", true)
-	} else {
-		_ = d.Set("object_locking", false)
-	}
+	object_locking := err == nil && bucketObjectLocking == "Enabled"
+	_ = d.Set("object_locking", object_locking)
 
 	pol, err := conn.GetBucketPolicy(ctx, d.Id())
 	if err != nil {

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -161,7 +161,6 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 
 	_ = d.Set("arn", bucketArn(d.Id()))
 	_ = d.Set("bucket_domain_name", bucketDomainName(d.Id(), bucketURL))
-	_ = d.Set("object_locking", bucketConfig.ObjectLockingEnabled)
 
 	return nil
 }

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -62,7 +62,7 @@ func TestAccMinioS3Bucket_objectLocking(t *testing.T) {
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioS3BucketConfigObjectEnabled(rInt),
+				Config: testAccMinioS3BucketConfigObjectLockingEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -438,7 +438,7 @@ resource "minio_s3_bucket" "bucket" {
 `, randInt)
 }
 
-func testAccMinioS3BucketConfigObjectEnabled(randInt string) string {
+func testAccMinioS3BucketConfigObjectLockingEnabled(randInt string) string {
 	return fmt.Sprintf(`
 resource "minio_s3_bucket" "bucket" {
   bucket = "%s"


### PR DESCRIPTION
This PR properly implements bucket importing when object locking is enabled in the bucket. Before this PR, it will always be imported with object locking set to false.

Also added a test to catch this issue early in the future.

## Reference

- Resolves: #457
 - See also: #453 

## Closing issues
- Closes: #457