### PR TITLE
Avoid forcing replacement of the bucket when setting a value for `object_locking`

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -76,7 +76,7 @@ func resourceMinioBucket() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
+				ForceNew: false,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes https://github.com/aminueza/terraform-provider-minio/issues/459