### PR TITLE
Fix an example value of `expiration`

### DIFF
--- a/examples/resources/minio_ilm_policy/resource.tf
+++ b/examples/resources/minio_ilm_policy/resource.tf
@@ -7,6 +7,6 @@ resource "minio_ilm_policy" "bucket-lifecycle-rules" {
 
   rule {
     id         = "expire-7d"
-    expiration = 7
+    expiration = "7d"
   }
 }


### PR DESCRIPTION
The `expiration` must be a duration, or "DeleteMarker" and can't be set `int`. https://github.com/aminueza/terraform-provider-minio/blob/85e98aa33b9ca0153a37df98fd8808f2776bddc1/minio/resource_minio_ilm_policy.go#L70-L72
