### PR TITLE
Fix group status handling

### DIFF
--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -137,11 +137,8 @@ func minioReadGroup(ctx context.Context, d *schema.ResourceData, meta interface{
 		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
 	}
 
-	if output.Status == string(madmin.GroupDisabled) {
-		d.Set("disable_group", true)
-	} else {
-		d.Set("disable_group", false)
-
+	if err := d.Set("disable_group", output.Status == string(madmin.GroupDisabled)); err != nil {
+		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
 	}
 
 	return nil
@@ -212,7 +209,7 @@ func minioStatusGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 	err := iamGroupConfig.MinioAdmin.SetGroupStatus(ctx, iamGroupConfig.MinioIAMName, minioGroupStatus)
 
 	if err != nil {
-		return fmt.Errorf("error when enable/disable IAM Group %s: %s", d.Id(), err)
+		return fmt.Errorf("error while enabling or disabling IAM Group %s: %s", d.Id(), err)
 	}
 
 	return nil

--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -196,6 +196,7 @@ func minioDeleteGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 }
 
 func minioStatusGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+
 	var minioGroupStatus madmin.GroupStatus
 
 	iamGroupConfig := IAMGroupConfig(d, meta)
@@ -211,7 +212,7 @@ func minioStatusGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 	err := iamGroupConfig.MinioAdmin.SetGroupStatus(ctx, iamGroupConfig.MinioIAMName, minioGroupStatus)
 
 	if err != nil {
-		return fmt.Errorf("error disabling IAM Group %s: %s", d.Id(), err)
+		return fmt.Errorf("error when enable/disable IAM Group %s: %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
# Fix disable_group option in "minio_iam_group" resource
This PR fixing the issue in the resource `minio_iam_group`.

`disable_group` option did not work correctly, it did not update the group status in the MinIO, even if you set it to true or false. 

## Reference
 - Resolves: #483

## Closing issues
- Closes: #483
