### PR TITLE
fix minio_iam_user_policy_attachment: Error: Provider produced inconsistent result after apply (fix #494)

### DIFF
--- a/minio/resource_minio_iam_user_policy_attachment.go
+++ b/minio/resource_minio_iam_user_policy_attachment.go
@@ -13,6 +13,8 @@ import (
 	"github.com/minio/madmin-go"
 )
 
+var userPolicyAttachmentLock = NewMutexKV()
+
 func resourceMinioIAMUserPolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: minioCreateUserPolicyAttachment,
@@ -44,12 +46,16 @@ func minioCreateUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 	var policyName = d.Get("policy_name").(string)
 	minioAdmin := meta.(*S3MinioClient).S3Admin
 
+	userPolicyAttachmentLock.Lock(userName)
+	defer userPolicyAttachmentLock.Unlock(userName)
+
 	policies, err := minioReadUserPolicies(ctx, minioAdmin, userName)
 	if err != nil {
 		return err
 	}
 	if !Contains(policies, policyName) {
 		policies = append(policies, policyName)
+		log.Printf("[DEBUG] Attaching policy %s to user: %s (%v)", policyName, userName, policies)
 		err := minioAdmin.SetPolicy(ctx, strings.Join(policies, ","), userName, false)
 		if err != nil {
 			return NewResourceError("unable to Set User policy", userName+" "+policyName, err)
@@ -58,13 +64,19 @@ func minioCreateUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(id.PrefixedUniqueId(fmt.Sprintf("%s-", userName)))
 
-	return minioReadUserPolicyAttachment(ctx, d, meta)
+	return doMinioReadUserPolicyAttachment(ctx, d, meta, userName, policyName)
 }
-
 func minioReadUserPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	minioAdmin := meta.(*S3MinioClient).S3Admin
 	var userName = d.Get("user_name").(string)
 	var policyName = d.Get("policy_name").(string)
+
+	userPolicyAttachmentLock.Lock(userName)
+	defer userPolicyAttachmentLock.Unlock(userName)
+
+	return doMinioReadUserPolicyAttachment(ctx, d, meta, userName, policyName)
+}
+func doMinioReadUserPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}, userName, policyName string) diag.Diagnostics {
+	minioAdmin := meta.(*S3MinioClient).S3Admin
 
 	policies, errUser := minioReadUserPolicies(ctx, minioAdmin, userName)
 	if errUser != nil {
@@ -90,6 +102,9 @@ func minioDeleteUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 	var userName = d.Get("user_name").(string)
 	var policyName = d.Get("policy_name").(string)
 
+	userPolicyAttachmentLock.Lock(userName)
+	defer userPolicyAttachmentLock.Unlock(userName)
+
 	policies, err := minioReadUserPolicies(ctx, minioAdmin, userName)
 	if err != nil {
 		return err
@@ -100,6 +115,7 @@ func minioDeleteUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 		return nil
 	}
 
+	log.Printf("[DEBUG] Detaching policy %s from user: %s (%v)", policyName, userName, newPolicies)
 	errIam := minioAdmin.SetPolicy(ctx, strings.Join(newPolicies, ","), userName, false)
 	if errIam != nil {
 		return NewResourceError("unable to delete user policy", userName, errIam)
@@ -143,6 +159,9 @@ func minioReadUserPolicies(ctx context.Context, minioAdmin *madmin.AdminClient, 
 		if !isLDAPUser || !errUserIsResponse || !strings.EqualFold(errUserResponse.Code, "XMinioAdminNoSuchUser") {
 			return nil, NewResourceError("failed to load user Infos", userName, errUser)
 		}
+	}
+	if userInfo.PolicyName == "" {
+		return nil, nil
 	}
 	return strings.Split(userInfo.PolicyName, ","), nil
 }

--- a/minio/utils.go
+++ b/minio/utils.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"hash/crc32"
+	"log"
+	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -87,4 +89,49 @@ func HashcodeString(s string) int {
 	}
 	// v == MinInt
 	return 0
+}
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initialized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
 }


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Fix minio_iam_user_policy_attachment: Error: Provider produced inconsistent result after apply

This PR implements the following changes:
- Use locks to prevent concurrent policy attachments on same user/group
<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.

 # Please provide enough information so that others can review your pull request:

# Explain the details for making this change. What existing problem does the pull request solve?
-->
## Reference
<!--
Please be aware, that every pull-request/merge-request for needs an issue.
-->
 - Resolves: #494 

## Closing issues
<!--
Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
-->
- Closes: #494 
