### PR TITLE
Update terraform version to 1.5.7 in GitHub Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
         run: docker-compose up -d minio secondminio thirdminio fourthminio
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4.7
+          terraform_version: 1.5.7
           terraform_wrapper: false
       - name: Install Task
         uses: arduino/setup-task@v1


### PR DESCRIPTION
As we already stated it's supported, in the Readme.
https://github.com/aminueza/terraform-provider-minio/blob/f4464e51005c4cfd203e2357294311d912702911/README.md?plain=1#L44-L46