### PR TITLE
Fix null expiration date handling

### DIFF
--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -158,7 +158,7 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 			expiration = "DeleteMarker"
 		} else if r.Expiration.Days != 0 {
 			expiration = fmt.Sprintf("%dd", r.Expiration.Days)
-		} else {
+		} else if !r.Expiration.IsNull() {
 			expiration = r.Expiration.Date.Format("2006-01-02")
 		}
 

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -106,6 +106,8 @@ func TestAccILMPolicy_expireNoncurrentVersion(t *testing.T) {
 					testAccCheckMinioILMPolicyExists(resourceName, &lifecycleConfig),
 					testAccCheckMinioLifecycleConfigurationValid(&lifecycleConfig),
 					resource.TestCheckResourceAttr(
+						resourceName, "rule.0.expiration", ""),
+					resource.TestCheckResourceAttr(
 						resourceName, "rule.0.noncurrent_version_expiration_days", "5"),
 				),
 			},
@@ -242,7 +244,6 @@ resource "minio_ilm_policy" "rule4" {
   bucket = "${minio_s3_bucket.bucket4.id}"
   rule {
 	id = "expireNoncurrentVersion"
-	expiration = "5d"
 	noncurrent_version_expiration_days = 5
   }
 }


### PR DESCRIPTION
# Fix null expiration date handling

Fixes an issue where null expiration dates were getting set in the state as `0001-01-01` instead of `nil`, causing an update for every plan or apply.

## Reference

 - Resolves: #543

## Closing issues

- Closes: #543
