### PR TITLE
Preparation for Release v1.20.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
         run: docker-compose up -d minio
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4.7
+          terraform_version: 1.5.7
           terraform_wrapper: false
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -158,7 +158,7 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 			expiration = "DeleteMarker"
 		} else if r.Expiration.Days != 0 {
 			expiration = fmt.Sprintf("%dd", r.Expiration.Days)
-		} else {
+		} else if !r.Expiration.IsNull() {
 			expiration = r.Expiration.Date.Format("2006-01-02")
 		}
 

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -106,6 +106,8 @@ func TestAccILMPolicy_expireNoncurrentVersion(t *testing.T) {
 					testAccCheckMinioILMPolicyExists(resourceName, &lifecycleConfig),
 					testAccCheckMinioLifecycleConfigurationValid(&lifecycleConfig),
 					resource.TestCheckResourceAttr(
+						resourceName, "rule.0.expiration", ""),
+					resource.TestCheckResourceAttr(
 						resourceName, "rule.0.noncurrent_version_expiration_days", "5"),
 				),
 			},
@@ -242,7 +244,6 @@ resource "minio_ilm_policy" "rule4" {
   bucket = "${minio_s3_bucket.bucket4.id}"
   rule {
 	id = "expireNoncurrentVersion"
-	expiration = "5d"
 	noncurrent_version_expiration_days = 5
   }
 }


### PR DESCRIPTION
Cherry-picking these two commits to `v1` branch:

- Fix null expiration date handling (#545)
- Update terraform version to 1.5.7 in GitHub Action (#540)