### PR TITLE
Parse service account user from LDAP str

### DIFF
--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/minio/madmin-go/v3"
+	"gotest.tools/v3/assert"
 )
 
 func TestServiceAccount_basic(t *testing.T) {
@@ -145,6 +146,12 @@ func TestServiceAccount_Policy(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestParseUserFromParentUser(t *testing.T) {
+	assert.Equal(t, "minio-user", parseUserFromParentUser("minio-user"))
+	assert.Equal(t, "minio-user", parseUserFromParentUser("CN = minio-user, DC=example,DC=org"))
+	assert.Equal(t, "minio-user", parseUserFromParentUser("cn=minio-user, DC=example"))
 }
 
 func testAccMinioServiceAccountConfig(rName string) string {


### PR DESCRIPTION
# Parse service account target user from LDAP string

The recent change in #525 to track `target_user` in state for `minio_service_account` is breaking for LDAP users. It looks like `madmin` is returning `ParentUser` as a full LDAP string such as `"CN=minio-user,DC=example,DC=org"` for `minio-user`.

This PR fixes that issue by attempting to parse each returned `ParentUser` string as an LDAP string, and if it fails return the string as-is. I saw some regex utilities for checking whether or not a string was LDAP, but it didn't look like they helped much with parsing, and since this ignores non-LDAP strings it felt simple enough to do this simply.

My big question is that I'm not sure how to test it other than the unit tests here. It looks like we don't have a ton of tools for testing LDAP users, so another set of eyes would be helpful

## Reference

 - Partially resolves: #544
