### PR TITLE
Fixed group policy assign parameter typo

### DIFF
--- a/docs/resources/iam_group_policy_attachment.md
+++ b/docs/resources/iam_group_policy_attachment.md
@@ -56,7 +56,7 @@ output "minio_group" {
 # Example using an LDAP Group instead of a static MinIO group
 
 resource "minio_iam_group_policy_attachment" "developer" {
-  user_name   = "OU=Unit,DC=example,DC=com"
+  group_name  = "OU=Unit,DC=example,DC=com"
   policy_name = "${minio_iam_policy.test_policy.id}"
 }
 ```


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Fixed group policy assign parameter typo in the provider resource example usage docs

This PR implements the following changes:
- PR fixes a small copy and paste typo in the provider resource docs for `minio_iam_group_policy_attachment`, where in the example usage the parameter `user_name` instead of `group_name` was used
<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.

 # Please provide enough information so that others can review your pull request:

# Explain the details for making this change. What existing problem does the pull request solve?
-->
## Reference
<!--
Please be aware, that every pull-request/merge-request for needs an issue.
-->
 - Registry Link: [iam_group_policy_attachment](https://registry.terraform.io/providers/aminueza/minio/latest/docs/resources/iam_group_policy_attachment)