### PR TITLE
Document `DeleteMarker` expiry in ilm policy

### DIFF
--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -42,6 +42,7 @@ func resourceMinioILMPolicy() *schema.Resource {
 						"expiration": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							Description:      "Value may be duration (5d), date (1970-01-01), or \"DeleteMarker\" to expire delete markers if `noncurrent_version_expiration_days` is used",
 							ValidateDiagFunc: validateILMExpiration,
 						},
 						"noncurrent_version_expiration_days": {


### PR DESCRIPTION
# Document `DeleteMarker` value for ilm policy's `expiration` field

This PR implements the following changes:

There was no mention for how to expire delete markers in the Terraform docs, this change rectifies it.

## Reference
<!--
Please be aware, that every pull-request/merge-request for needs an issue.
-->
 - Resolves: #557