### PR TITLE
fix: Allow for lowercase token in ldap dn

### DIFF
--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	LDAPGroupDistinguishedNamePattern = regexp.MustCompile(`^(?:((?:(?:CN|OU)=[^,]+,?)+),)+((?:DC=[^,]+,?)+)$`)
+	LDAPGroupDistinguishedNamePattern = regexp.MustCompile(`^(?:((?:(?:CN|cn|OU|ou)=[^,]+,?)+),)+((?:(?:DC|dc)=[^,]+,?)+)$`)
 	StaticGroupNamePattern            = regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`)
 )
 

--- a/minio/resource_minio_iam_group_test.go
+++ b/minio/resource_minio_iam_group_test.go
@@ -22,6 +22,8 @@ func TestValidateMinioIamGroupName(t *testing.T) {
 		"test.123,user",
 		"testuser@minio",
 		"test+user@minio.io",
+		"CN=ADMINS,OU=Groups,DC=gr-u,DC=it",
+		"cn=ADMINS,ou=Groups,dc=gr-u,dc=it",
 	}
 
 	for _, minioName := range minioValidNames {

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	LDAPUserDistinguishedNamePattern = regexp.MustCompile(`^(?:(CN=([^,]*)),)+(?:((?:(?:CN|OU)=[^,]+,?)+),)+((?:DC=[^,]+,?)+)$`)
+	LDAPUserDistinguishedNamePattern = regexp.MustCompile(`^(?:((?:CN|cn)=([^,]*)),)+(?:((?:(?:CN|cn|OU|ou)=[^,]+,?)+),)+((?:(?:DC|dc)=[^,]+,?)+)$`)
 	StaticUserNamePattern            = regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`)
 )
 

--- a/minio/resource_minio_iam_user_test.go
+++ b/minio/resource_minio_iam_user_test.go
@@ -27,6 +27,7 @@ func TestValidateMinioIamUserName(t *testing.T) {
 		"testuser@minio",
 		"test+user@minio.io",
 		"CN=Backup Operators,CN=Builtin,DC=gr-u,DC=it",
+		"cn=Backup Operators,cn=Builtin,dc=gr-u,dc=it",
 		"CN=View-Only Organization Management,OU=Microsoft Exchange Security Groups,DC=gr-u,DC=it",
 	}
 


### PR DESCRIPTION
Minio recently changed behaviour by using case sensitive ldap queries. This makes it necessary to specify the distinguished name for user/group policy attachments exactly in the same case as the server.

This merge request updates the validation regex to allow for lowercase LDIF field names in the dn (e.g. CN=foo vs cn=foo).

The relevant Minio MR: https://github.com/minio/minio/pull/19358

As an alternative the regex could be made case insensitive with `(?i)^...` but then also something like `Cn=foo` or `cN=foo` would be valid.