### PR TITLE
fix Azure and GCP remote tier creation and add support for tier options

### DIFF
--- a/docs/resources/ilm_tier.md
+++ b/docs/resources/ilm_tier.md
@@ -42,7 +42,8 @@ description: |-
 Optional:
 
 - `account_key` (String, Sensitive)
-- `container` (String)
+- `account_name` (String)
+- `storage_class` (String)
 
 
 <a id="nestedblock--gcs_config"></a>
@@ -51,6 +52,7 @@ Optional:
 Optional:
 
 - `credentials` (String, Sensitive)
+- `storage_class` (String)
 
 
 <a id="nestedblock--minio_config"></a>


### PR DESCRIPTION
# Fix Azure and GCP remote tier creation

This PR implements the following changes:
- fix Azure and GCP remote tier creation and add support for tier options

# What existing problem does the pull request solve?
  - Fix Azure remote tier creation: the account name was not used properly and prevented the creation
  - Fix GCP remote tier creation: providing the credentials json made the provider crash
  - Support all remote tier options like region, storage class and prefix: previously theses were read but not created
 
Theses changes were tested with Azure and GCP sadly I don't have access to an AWS account to try out the changes.
