### PR TITLE
fix: Add the endpoint property to Amazon S3 config

### DIFF
--- a/minio/resource_minio_ilm_tier.go
+++ b/minio/resource_minio_ilm_tier.go
@@ -189,6 +189,9 @@ func minioCreateILMTier(ctx context.Context, d *schema.ResourceData, meta interf
 		if _, ok := s3Config["storage_class"]; ok {
 			s3Options = append(s3Options, madmin.S3StorageClass(s3Config["storage_class"].(string)))
 		}
+		if d.Get("endpoint").(string) != "" {
+			s3Options = append(s3Options, madmin.S3Endpoint(d.Get("endpoint").(string)))
+		}
 		tierConf, err = madmin.NewTierS3(
 			name,
 			s3Config["access_key"].(string),


### PR DESCRIPTION
This PR implements the following changes:
- Pass the `endpoint` argument to the MinIo client if the S3 tier is being used.

## Reference
Resolves #570

## People
@george-zubrienko, FYI

## Closing issues
- Closes: #570

