### PR TITLE
fix: gcs ilm tier region using prefix string instead of region string

### DIFF
--- a/minio/resource_minio_ilm_tier.go
+++ b/minio/resource_minio_ilm_tier.go
@@ -224,7 +224,7 @@ func minioCreateILMTier(ctx context.Context, d *schema.ResourceData, meta interf
 			gcsOptions = append(gcsOptions, madmin.GCSPrefix(d.Get("prefix").(string)))
 		}
 		if d.Get("region").(string) != "" {
-			gcsOptions = append(gcsOptions, madmin.GCSPrefix(d.Get("region").(string)))
+			gcsOptions = append(gcsOptions, madmin.GCSRegion(d.Get("region").(string)))
 		}
 		if _, ok := gcsConfig["storage_class"]; ok {
 			gcsOptions = append(gcsOptions, madmin.GCSStorageClass(gcsConfig["storage_class"].(string)))


### PR DESCRIPTION
# Fix GCS ilm tier region using prefix string instead of region string

This PR implements the following changes:
 - Fix to GCS ilm tier creation, region is using the prefix value instead of the region value.

## Reference
<!--
Please be aware, that every pull-request/merge-request for needs an issue.
-->
 - Resolves: #574 

## Closing issues

- Closes: #574 
