### PR TITLE
fix: use the id property instead of name for read ilm tier

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           version: "2023.1.6"
           install-go: false
-      - name: Build the docker-compose stack
-        run: docker-compose up -d minio secondminio thirdminio fourthminio
+      - name: Build the Docker Compose stack
+        run: docker compose up -d minio secondminio thirdminio fourthminio
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.5.7

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ variable "minio_password" {
 For testing locally, run the docker compose to spin up a minio server:
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
 Access `http://localhost:8000` on your browser, apply your terraform templates and watch them going live.

--- a/minio/resource_minio_ilm_tier.go
+++ b/minio/resource_minio_ilm_tier.go
@@ -270,7 +270,7 @@ func minioCreateILMTier(ctx context.Context, d *schema.ResourceData, meta interf
 
 func minioReadILMTier(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*S3MinioClient).S3Admin
-	name := d.Get("name").(string)
+	name := d.Id()
 	tier, err := getTier(c, ctx, name)
 	if err != nil {
 		return NewResourceError("reading remote tier failed", name, err)


### PR DESCRIPTION
## Description

When terraform performs an import of a resource only the `id` property is available in the provider context. But the `minio_ilm_tier` resource uses the `name` property to get the tier from MinIO api (which is empty) and import of the ilm tier fails.

This PR implements the following changes:
- Use the `id` context property instead of `name` for reading the `minio_ilm_tier` resource

## Reference
Resolves #578
