### PR TITLE
Add name, description and expiration support for service accounts

### DIFF
--- a/docs/resources/iam_service_account.md
+++ b/docs/resources/iam_service_account.md
@@ -44,7 +44,10 @@ output "minio_password" {
 
 ### Optional
 
+- `description` (String) Description of service account (256 bytes max), can't be cleared once set
 - `disable_user` (Boolean) Disable service account
+- `expiration` (String) Expiration of service account. Must be between NOW+15min & NOW+365d
+- `name` (String) Name of service account (32 bytes max), can't be cleared once set
 - `policy` (String) policy of service account as encoded JSON string
 - `update_secret` (Boolean) rotate secret key
 

--- a/examples/serviceaccount/serviceaccount.tf
+++ b/examples/serviceaccount/serviceaccount.tf
@@ -3,6 +3,7 @@ resource "minio_iam_user" "test_user" {
 }
 
 resource "minio_iam_service_account" "test_service_account" {
+  name = "test-svc" # optional
   target_user = "test-user"
   policy = <<-EOF
     {

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -123,6 +123,9 @@ func ServiceAccountConfig(d *schema.ResourceData, meta interface{}) *S3MinioServ
 		MinioDisableUser: d.Get("disable_user").(bool),
 		MinioUpdateKey:   d.Get("update_secret").(bool),
 		MinioSAPolicy:    d.Get("policy").(string),
+		MinioName:        d.Get("name").(string),
+		MinioDescription: d.Get("description").(string),
+		MinioExpiration:  d.Get("expiration").(string),
 	}
 }
 

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -156,6 +156,9 @@ type S3MinioServiceAccountConfig struct {
 	MinioForceDestroy bool
 	MinioUpdateKey    bool
 	MinioIAMTags      map[string]string
+	MinioDescription  string
+	MinioName         string
+	MinioExpiration   string
 }
 
 // S3MinioIAMUserConfig defines IAM config

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -262,13 +262,19 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 		_ = d.Set("policy", output.Policy)
 	}
 
-	d.Set("name", output.Name)
-	d.Set("description", output.Description)
+	if err := d.Set("name", output.Name); err != nil {
+		return NewResourceError("reading service account failed", d.Id(), err)
+	}
+	if err := d.Set("description", output.Description); err != nil {
+		return NewResourceError("reading service account failed", d.Id(), err)
+	}
 
-	if output.Expiration == nil {
-		d.Set("expiration", "1970-01-01T00:00:00Z")
-	} else {
-		d.Set("expiration", output.Expiration.Format(time.RFC3339))
+	expiration := "1970-01-01T00:00:00Z"
+	if output.Expiration != nil {
+		expiration = output.Expiration.Format(time.RFC3339)
+	}
+	if err := d.Set("expiration", expiration); err != nil {
+		return NewResourceError("reading service account failed", d.Id(), err)
 	}
 
 	return nil

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -120,7 +120,6 @@ func minioCreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.StringValue(&accessKey))
 	_ = d.Set("access_key", accessKey)
 	_ = d.Set("secret_key", secretKey)
-	d.Set("expiration", serviceAccount.Expiration.Format(time.RFC3339))
 
 	if serviceAccountConfig.MinioDisableUser {
 		err = serviceAccountConfig.MinioAdmin.UpdateServiceAccount(ctx, accessKey, madmin.UpdateServiceAccountReq{NewStatus: "off"})
@@ -200,8 +199,6 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return NewResourceError("error updating service account name %s: %s", d.Id(), err)
 		}
-
-		_ = d.Set("name", serviceAccountConfig.MinioName)
 	}
 
 	if d.HasChange("description") {
@@ -214,8 +211,6 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return NewResourceError("error updating service account description %s: %s", d.Id(), err)
 		}
-
-		_ = d.Set("description", serviceAccountConfig.MinioDescription)
 	}
 
 	if d.HasChange("expiration") {
@@ -229,15 +224,12 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return NewResourceError("error updating service account expiration %s: %s", d.Id(), err)
 		}
-
-		_ = d.Set("expiration", serviceAccountConfig.MinioExpiration)
 	}
 
 	return minioReadServiceAccount(ctx, d, meta)
 }
 
 func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	serviceAccountConfig := ServiceAccountConfig(d, meta)
 
 	output, err := serviceAccountConfig.MinioAdmin.InfoServiceAccount(ctx, d.Id())

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/minio/madmin-go/v3"
 )
 
@@ -70,14 +71,14 @@ func resourceMinioServiceAccount() *schema.Resource {
 				Description:      "Name of service account (32 bytes max), can't be cleared once set",
 				Optional:         true,
 				DiffSuppressFunc: stringChangedToEmpty,
-				ValidateDiagFunc: validateMaxLength(32),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 32)),
 			},
 			"description": {
 				Type:             schema.TypeString,
 				Description:      "Description of service account (256 bytes max), can't be cleared once set",
 				Optional:         true,
 				DiffSuppressFunc: stringChangedToEmpty,
-				ValidateDiagFunc: validateMaxLength(256),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 256)),
 			},
 			"expiration": {
 				Type:             schema.TypeString,
@@ -381,21 +382,4 @@ func validateExpiration(val any, p cty.Path) diag.Diagnostics {
 	}
 
 	return diags
-}
-
-func validateMaxLength(maxlen int) schema.SchemaValidateDiagFunc {
-	return func(val any, p cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-
-		value := val.(string)
-		if len(value) > maxlen {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "String value too long",
-				Detail:   fmt.Sprintf("Byte length greater than %d", maxlen),
-			})
-		}
-
-		return diags
-	}
 }


### PR DESCRIPTION
# Add name, description and expiration support for service accounts

## Changes
Allows setting 3 new attributes on service accounts:
 - name: optional string
 - description: optional string
 - expiration: optional date, in RFC3339 format

## Compatibility
 All of these fields are optional, making it backward compatible.

Users may see a change on expiration from `null` to `1970-01-01T00:00:00Z` (which are equivalent), but only if something else is updated. As far as I know there is no way around this, since Terraform considers `null` as untracked while Minio sees it as either epoch for creations and as `no change` for updates.

## Remarks
I've included argument validation matching Minio's API requirements: 
- name must be 32 bytes max
- description must be 256 bytes max
- expiration must be between +15mn and +1y

Allowing invalid values to be sent to the API would throw relatively unclear errors, especially without verbose logging