### PR TITLE
Add GitHub Action to automatically close stale issues and pull requests

### DIFF
--- a/.github/workflows/close-stale-issues-and-pull-requests.yml
+++ b/.github/workflows/close-stale-issues-and-pull-requests.yml
@@ -1,0 +1,21 @@
+name: "Close stale issues and pull requests"
+on:
+  schedule:
+    - cron: "0 14 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          stale-issue-message: "This issue has been automatically marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs. Please comment or remove the stale label to keep it open."
+          days-before-issue-close: 7
+          close-issue-message: "This issue has been closed due to prolonged inactivity. Feel free to reopen if you need more information or further assistance."
+          stale-issue-label: "stale"
+          days-before-pr-stale: 60
+          stale-pr-message: "This pull request has been marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs. Please comment or remove the stale label to keep it open."
+          days-before-pr-close: 7
+          close-pr-message: "This pull request has been closed due to prolonged inactivity. Feel free to reopen if you plan to continue your work."
+          stale-pr-label: "stale"


### PR DESCRIPTION
Implements automated housekeeping for inactive issues and PRs:
- Issues marked stale after 30 days, closed after 7 more days
- Pull requests marked stale after 60 days, closed after 7 more days
- Daily check at 14:00 UTC
- Custom warning messages before closure

This helps maintain repository cleanliness by reducing open but inactive items.