### PR TITLE
Fix setting private bucket ACL

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -278,11 +278,9 @@ func minioSetBucketACL(ctx context.Context, bucketConfig *S3MinioBucket) diag.Di
 		return NewResourceError("unsupported ACL", bucketConfig.MinioACL, errors.New("(valid acl: private, public-write, public-read, public-read-write, public)"))
 	}
 
-	if policyString != "" {
-		if err := bucketConfig.MinioClient.SetBucketPolicy(ctx, bucketConfig.MinioBucket, policyString); err != nil {
-			log.Printf("%s", NewResourceErrorStr("unable to set bucket policy", bucketConfig.MinioBucket, err))
-			return NewResourceError("unable to set bucket policy", bucketConfig.MinioBucket, err)
-		}
+	if err := bucketConfig.MinioClient.SetBucketPolicy(ctx, bucketConfig.MinioBucket, policyString); err != nil {
+		log.Printf("%s", NewResourceErrorStr("unable to set bucket policy", bucketConfig.MinioBucket, err))
+		return NewResourceError("unable to set bucket policy", bucketConfig.MinioBucket, err)
 	}
 
 	return nil


### PR DESCRIPTION

# Fix setting of private bucket ACL

This PR implements the following changes:
- Allow for an empty bucket ACL (`private`). If the ACL is an empty string, `minio-go` removes the policy, making it a private ACL. Prior to this change, setting the ACL to `private` would result in a no-op.
