### PR TITLE
Add `minio_accesskey` Terraform Resource for Managing MinIO Access Keys

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,12 +30,5 @@ jobs:
         uses: securego/gosec@master
         with:
           args: ./...
-      - name: Install Task
-        uses: arduino/setup-task@v1
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run install task
-        run: task install
       - name: Run tests
         run: docker compose run --rm test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,12 +30,6 @@ jobs:
         uses: securego/gosec@master
         with:
           args: ./...
-      - name: Build the Docker Compose stack
-        run: docker compose up -d minio secondminio thirdminio fourthminio
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.7
-          terraform_wrapper: false
       - name: Install Task
         uses: arduino/setup-task@v1
         with:
@@ -43,5 +37,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run install task
         run: task install
-      - name: Run test task
-        run: sudo apt install jq -y && sed "s/172.17.0.1/`docker network inspect bridge | jq -r .[].IPAM.Config[].Gateway`/" Taskfile.yml && task test
+      - name: Run tests
+        run: docker compose run --rm test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,25 +49,7 @@ tasks:
     silent: true
 
   test:
-    desc: Run the package tests.
-    env: 
-      TF_ACC: 0
-      MINIO_ENDPOINT: 172.17.0.1:9000
-      MINIO_USER: minio
-      MINIO_PASSWORD: minio123
-      MINIO_ENABLE_HTTPS: false
-      SECOND_MINIO_ENDPOINT: 172.17.0.1:9002
-      SECOND_MINIO_USER: minio
-      SECOND_MINIO_PASSWORD: minio321
-      SECOND_MINIO_ENABLE_HTTPS: false
-      THIRD_MINIO_ENDPOINT: 172.17.0.1:9004
-      THIRD_MINIO_USER: minio
-      THIRD_MINIO_PASSWORD: minio456
-      THIRD_MINIO_ENABLE_HTTPS: false
-      FOURTH_MINIO_ENDPOINT: 172.17.0.1:9006
-      FOURTH_MINIO_USER: minio
-      FOURTH_MINIO_PASSWORD: minio654
-      FOURTH_MINIO_ENABLE_HTTPS: false
+    desc: Run the package tests using Docker Compose.
     cmds:
-      - go test -v -cover ./minio
+      - docker compose run --rm test
     silent: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
+# Define MinIO image version to use across all services
+x-minio-image: &minio_image minio/minio:RELEASE.2025-04-22T22-12-26Z
+
 services:
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z-cpuv1
+    image: *minio_image
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -11,8 +14,14 @@ services:
       MINIO_NOTIFY_WEBHOOK_ENABLE_primary: "on"
       MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary: https://webhook.example.com
     command: server --console-address :9001 /data{0...3}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
   secondminio: #  This is used to test bucket replication
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z-cpuv1
+    image: *minio_image
     ports:
       - "9002:9000"
       - "9003:9001"
@@ -23,8 +32,14 @@ services:
       MINIO_NOTIFY_WEBHOOK_ENABLE_primary: "on"
       MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary: https://webhook.example.com
     command: server --console-address :9001 /data{0...3}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
   thirdminio: #  This is used to test bucket replication
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z-cpuv1
+    image: *minio_image
     ports:
       - "9004:9000"
       - "9005:9001"
@@ -35,8 +50,14 @@ services:
       MINIO_NOTIFY_WEBHOOK_ENABLE_primary: "on"
       MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary: https://webhook.example.com
     command: server --console-address :9001 /data{0...3}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
   fourthminio: #  This is used to test bucket replication
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z-cpuv1
+    image: *minio_image
     ports:
       - "9006:9000"
       - "9007:9001"
@@ -47,3 +68,60 @@ services:
       MINIO_NOTIFY_WEBHOOK_ENABLE_primary: "on"
       MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary: https://webhook.example.com
     command: server --console-address :9001 /data{0...3}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+  test:
+    image: golang:1.24
+    volumes:
+      - .:/app
+      - go-modules:/go/pkg/mod
+    working_dir: /app
+    command: bash -c "\
+      apt-get update && \
+      apt-get install -y unzip && \
+      wget -O terraform.zip https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip && \
+      unzip terraform.zip && \
+      mv terraform /usr/local/bin/ && \
+      rm terraform.zip && \
+      go mod download && \
+      go mod verify && \
+      echo 'Running tests...' && \
+      go test -v ./minio ${TEST_PATTERN:+-run $TEST_PATTERN}"
+    environment:
+      TF_ACC: "1"
+      TEST_PATTERN: "${TEST_PATTERN:-}"
+      MINIO_ENDPOINT: "minio:9000"
+      MINIO_USER: "minio"
+      MINIO_PASSWORD: "minio123"
+      MINIO_ENABLE_HTTPS: "false"
+      SECOND_MINIO_ENDPOINT: "secondminio:9000"
+      SECOND_MINIO_USER: "minio"
+      SECOND_MINIO_PASSWORD: "minio321"
+      SECOND_MINIO_ENABLE_HTTPS: "false"
+      THIRD_MINIO_ENDPOINT: "thirdminio:9000"
+      THIRD_MINIO_USER: "minio"
+      THIRD_MINIO_PASSWORD: "minio456"
+      THIRD_MINIO_ENABLE_HTTPS: "false"
+      FOURTH_MINIO_ENDPOINT: "fourthminio:9000"
+      FOURTH_MINIO_USER: "minio"
+      FOURTH_MINIO_PASSWORD: "minio654"
+      FOURTH_MINIO_ENABLE_HTTPS: "false"
+    depends_on:
+      minio:
+        condition: service_healthy
+      secondminio:
+        condition: service_healthy
+      thirdminio:
+        condition: service_healthy
+      fourthminio:
+        condition: service_healthy
+    profiles:
+      - test
+
+volumes:
+  go-modules:
+    # Persistent volume for Go modules to speed up subsequent test runs

--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -1,0 +1,43 @@
+# minio_accesskey Resource
+
+Manages a MinIO access key for a user via the MinIO `mc` CLI.
+
+## Example Usage
+
+```hcl
+resource "minio_accesskey" "example" {
+  user       = "myuser"
+  access_key = "AKIAEXAMPLEKEY"
+  secret_key = "mySuperSecretKey"
+  status     = "enabled" # or "disabled"
+}
+```
+
+## Argument Reference
+
+- `user` (Required) - The MinIO user for whom the access key is managed.
+- `access_key` (Optional) - The access key value. If omitted, MinIO generates one.
+- `secret_key` (Optional) - The secret key value. If omitted, MinIO generates one.
+- `status` (Optional) - The status of the access key (`enabled` or `disabled`). Defaults to `enabled`.
+
+## Attributes Reference
+
+- `id` - The access key ID.
+- `access_key` - The access key.
+- `secret_key` - The secret key.
+- `status` - The status of the access key.
+
+## Requirements
+
+- The `mc` CLI must be installed and available in your `$PATH`.
+- The `myminio` alias must be configured in `mc` to point to your MinIO server.
+
+Example alias setup:
+
+```sh
+mc alias set myminio http://localhost:9000 minioadmin minioadmin
+```
+
+## Caveats
+- This resource shells out to the `mc` CLI, so the provider host must have access to the CLI and proper permissions.
+- Output parsing is best-effort; if MinIO changes CLI output format, parsing may break.

--- a/examples/accesskey/main.tf
+++ b/examples/accesskey/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    minio = {
+      source = "aminueza/minio"
+    }
+  }
+}
+
+provider "minio" {
+  minio_server   = "localhost:9000"
+  minio_user     = "minioadmin"
+  minio_password = "minioadmin"
+  minio_ssl      = false
+}
+
+# Create a user first
+resource "minio_iam_user" "test_user" {
+  name = "test-user"
+}
+
+# Then create an accesskey for that user
+resource "minio_accesskey" "test_key" {
+  user   = minio_iam_user.test_user.name
+  status = "enabled"
+  # Optionally specify access_key and secret_key
+  # access_key = "custom_access_key"
+  # secret_key = "custom_secret_key"
+}
+
+# If you want to attach a policy to the user
+resource "minio_iam_policy" "test_policy" {
+  name = "test-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+        ]
+        Effect   = "Allow"
+        Resource = ["arn:aws:s3:::*"]
+      }
+    ]
+  })
+}
+
+resource "minio_iam_user_policy_attachment" "test_attachment" {
+  user_name   = minio_iam_user.test_user.name
+  policy_name = minio_iam_policy.test_policy.id
+}
+
+# Output the generated access and secret keys
+output "access_key" {
+  value = minio_accesskey.test_key.access_key
+}
+
+output "secret_key" {
+  value     = minio_accesskey.test_key.secret_key
+  sensitive = true
+}

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -174,6 +174,9 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_ilm_policy": resourceMinioILMPolicy(),
 			"minio_ilm_tier":   resourceMinioILMTier(),
 			"minio_kms_key":    resourceMinioKMSKey(),
+
+			// AccessKey Operations
+			"minio_accesskey": resourceMinioAccessKey(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -110,9 +110,6 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 		status = "disabled"
 	}
 	_ = d.Set("status", status)
-
-	// Set access_key to the ID for importing
-	// Secret key can't be retrieved from the API, so it remains unset during import
 	_ = d.Set("access_key", accessKeyID)
 
 	return nil

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -111,6 +111,10 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	_ = d.Set("status", status)
 
+	// Set access_key to the ID for importing
+	// Secret key can't be retrieved from the API, so it remains unset during import
+	_ = d.Set("access_key", accessKeyID)
+
 	return nil
 }
 

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v3"
 )
@@ -20,24 +23,55 @@ func resourceMinioAccessKey() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
 			"user": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The user for whom the access key is managed.",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v == "" {
+						errs = append(errs, fmt.Errorf("%q cannot be empty", key))
+					}
+					return
+				},
 			},
 			"access_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "The access key.",
+				Description: "The access key. If provided, must be between 8 and 20 characters.",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "" {
+						if len(v) < 8 || len(v) > 20 {
+							errs = append(errs, fmt.Errorf("%q must be between 8 and 20 characters when specified", key))
+						}
+					}
+					return
+				},
 			},
 			"secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The secret key.",
+				Description: "The secret key. If provided, must be between 8 and 40 characters.",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "" {
+						if len(v) < 8 || len(v) > 40 {
+							errs = append(errs, fmt.Errorf("%q must be between 8 and 40 characters when specified", key))
+						}
+					}
+					return
+				},
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -65,6 +99,11 @@ func minioCreateAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Creating accesskey for user %s", user)
 
+	_, err := client.S3Admin.GetUserInfo(ctx, user)
+	if err != nil {
+		return diag.Errorf("failed to create accesskey: user %s does not exist or cannot be accessed: %s", user, err)
+	}
+
 	req := madmin.AddServiceAccountReq{
 		SecretKey:  secretKey,
 		AccessKey:  accessKey,
@@ -73,12 +112,28 @@ func minioCreateAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 
 	creds, err := client.S3Admin.AddServiceAccount(ctx, req)
 	if err != nil {
-		return diag.Errorf("failed to create accesskey: %s", err)
+		returnErr := fmt.Errorf("failed to create accesskey: %w", err)
+		log.Printf("[ERROR] %s", returnErr)
+		return diag.FromErr(returnErr)
 	}
 
 	d.SetId(aws.StringValue(&creds.AccessKey))
 	_ = d.Set("access_key", creds.AccessKey)
 	_ = d.Set("secret_key", creds.SecretKey)
+
+	timeout := d.Timeout(schema.TimeoutCreate)
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		_, err := client.S3Admin.InfoServiceAccount(ctx, creds.AccessKey)
+		if err != nil {
+			return retry.RetryableError(
+				fmt.Errorf("waiting for accesskey %s to become available: %w", creds.AccessKey, err),
+			)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if status == "disabled" {
 		return minioUpdateAccessKey(ctx, d, meta)
@@ -93,11 +148,31 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 
 	log.Printf("[INFO] Reading accesskey %s", accessKeyID)
 
-	info, err := client.S3Admin.InfoServiceAccount(ctx, accessKeyID)
+	timeout := d.Timeout(schema.TimeoutRead)
+	var info madmin.InfoServiceAccountResp
+	var err error
+
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		info, err = client.S3Admin.InfoServiceAccount(ctx, accessKeyID)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "service account does not exist") {
+				log.Printf("[WARN] AccessKey %s no longer exists", accessKeyID)
+				d.SetId("")
+				return nil
+			}
+
+			return retry.RetryableError(fmt.Errorf("error reading accesskey %s: %w", accessKeyID, err))
+		}
+		return nil
+	})
+
 	if err != nil {
-		log.Printf("[WARN] Failed to read accesskey %s: %s", accessKeyID, err)
-		d.SetId("")
-		return diag.Errorf("failed to read accesskey: %s", err)
+		log.Printf("[ERROR] Failed to read accesskey %s after retries: %s", accessKeyID, err)
+		return diag.FromErr(err)
+	}
+
+	if d.Id() == "" {
+		return nil
 	}
 
 	parentUser := info.ParentUser
@@ -127,8 +202,45 @@ func minioUpdateAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 		newStatus = "off"
 	}
 
-	if err := client.S3Admin.UpdateServiceAccount(ctx, accessKeyID, madmin.UpdateServiceAccountReq{NewStatus: newStatus}); err != nil {
-		return diag.Errorf("failed to update accesskey status: %s", err)
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		err := client.S3Admin.UpdateServiceAccount(ctx, accessKeyID, madmin.UpdateServiceAccountReq{NewStatus: newStatus})
+		if err != nil {
+			if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "timeout") {
+				return retry.RetryableError(fmt.Errorf("transient error updating accesskey %s status: %w", accessKeyID, err))
+			}
+
+			return retry.NonRetryableError(fmt.Errorf("failed to update accesskey status: %w", err))
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Failed to update accesskey %s status after retries: %s", accessKeyID, err)
+		return diag.FromErr(err)
+	}
+
+	err = retry.RetryContext(ctx, 30*time.Second, func() *retry.RetryError {
+		info, err := client.S3Admin.InfoServiceAccount(ctx, accessKeyID)
+		if err != nil {
+			return retry.RetryableError(fmt.Errorf("error verifying accesskey %s status update: %w", accessKeyID, err))
+		}
+
+		actualStatus := "enabled"
+		if info.AccountStatus == "off" {
+			actualStatus = "disabled"
+		}
+
+		if actualStatus != status {
+			return retry.RetryableError(fmt.Errorf("accesskey %s status not yet updated (current: %s, expected: %s)",
+				accessKeyID, actualStatus, status))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return minioReadAccessKey(ctx, d, meta)
@@ -140,8 +252,54 @@ func minioDeleteAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Deleting accesskey %s", accessKeyID)
 
-	if err := client.S3Admin.DeleteServiceAccount(ctx, accessKeyID); err != nil {
-		return diag.Errorf("failed to delete accesskey: %s", err)
+	_, err := client.S3Admin.InfoServiceAccount(ctx, accessKeyID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "service account does not exist") {
+			log.Printf("[WARN] AccessKey %s no longer exists, removing from state", accessKeyID)
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error checking accesskey before deletion: %s", err)
+	}
+
+	timeout := d.Timeout(schema.TimeoutDelete)
+	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		err := client.S3Admin.DeleteServiceAccount(ctx, accessKeyID)
+		if err != nil {
+			if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "timeout") {
+				return retry.RetryableError(fmt.Errorf("transient error deleting accesskey %s: %w", accessKeyID, err))
+			}
+
+			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "service account does not exist") {
+				return nil
+			}
+
+			return retry.NonRetryableError(fmt.Errorf("failed to delete accesskey: %w", err))
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Failed to delete accesskey %s after retries: %s", accessKeyID, err)
+		return diag.FromErr(err)
+	}
+
+	err = retry.RetryContext(ctx, 30*time.Second, func() *retry.RetryError {
+		_, err := client.S3Admin.InfoServiceAccount(ctx, accessKeyID)
+		if err == nil {
+			return retry.RetryableError(fmt.Errorf("waiting for accesskey %s to be deleted", accessKeyID))
+		}
+
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "service account does not exist") {
+			return nil
+		}
+
+		return retry.RetryableError(fmt.Errorf("error checking if accesskey %s is deleted: %w", accessKeyID, err))
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Failed to confirm deletion of accesskey %s: %s", accessKeyID, err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -1,0 +1,208 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceMinioAccessKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: minioCreateAccessKey,
+		ReadContext:   minioReadAccessKey,
+		UpdateContext: minioUpdateAccessKey,
+		DeleteContext: minioDeleteAccessKey,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The user for whom the access key is managed.",
+			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The access key.",
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The secret key.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "enabled",
+				Description: "The status of the access key (enabled/disabled).",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					status := val.(string)
+					if status != "enabled" && status != "disabled" {
+						errs = append(errs, fmt.Errorf("%q must be either 'enabled' or 'disabled', got: %s", key, status))
+					}
+					return
+				},
+			},
+			"minio_alias": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "myminio",
+				Description: "The MinIO alias to use with mc CLI (must be configured in mc).",
+			},
+		},
+	}
+}
+
+func minioCreateAccessKey(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	user := d.Get("user").(string)
+	accessKey := d.Get("access_key").(string)
+	secretKey := d.Get("secret_key").(string)
+	minioAlias := d.Get("minio_alias").(string)
+
+	// Build mc admin accesskey create command
+	cmdArgs := []string{"admin", "accesskey", "create", minioAlias, user}
+	if accessKey != "" {
+		cmdArgs = append(cmdArgs, accessKey)
+	}
+	if secretKey != "" {
+		cmdArgs = append(cmdArgs, secretKey)
+	}
+
+	out, err := runMcCommand(cmdArgs...)
+	if err != nil {
+		return diag.Errorf("failed to create accesskey: %s - output: %s", err, out)
+	}
+
+	// Parse output to extract generated keys
+	// Example output:
+	// Access Key: AKIAEXAMPLEKEY
+	// Secret Key: mySuperSecretKey
+
+	// Only try to parse if keys weren't provided (MinIO would have generated them)
+	if accessKey == "" || secretKey == "" {
+		parsedAccessKey := ""
+		parsedSecretKey := ""
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, "Access Key:") {
+				parsedAccessKey = strings.TrimSpace(strings.TrimPrefix(line, "Access Key:"))
+			} else if strings.HasPrefix(line, "Secret Key:") {
+				parsedSecretKey = strings.TrimSpace(strings.TrimPrefix(line, "Secret Key:"))
+			}
+		}
+
+		if parsedAccessKey != "" {
+			d.SetId(parsedAccessKey)
+			_ = d.Set("access_key", parsedAccessKey)
+		}
+		if parsedSecretKey != "" {
+			_ = d.Set("secret_key", parsedSecretKey)
+		}
+	} else {
+		// If keys were provided, use those
+		d.SetId(accessKey)
+	}
+
+	// Apply status if needed
+	if d.Get("status").(string) == "disabled" {
+		return minioUpdateAccessKey(ctx, d, meta)
+	}
+
+	return minioReadAccessKey(ctx, d, meta)
+}
+
+func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	user := d.Get("user").(string)
+	minioAlias := d.Get("minio_alias").(string)
+	cmdArgs := []string{"admin", "accesskey", "info", minioAlias, user}
+	out, err := runMcCommand(cmdArgs...)
+	if err != nil {
+		log.Printf("[WARN] Failed to read accesskey for user %s: %s", user, err)
+		d.SetId("")
+		return diag.Errorf("failed to read accesskey: %s - output: %s", err, out)
+	}
+
+	// Example output:
+	// Access Key: AKIAEXAMPLEKEY
+	// Secret Key: mySuperSecretKey
+	// Status: enabled
+
+	accessKey := ""
+	secretKey := ""
+	status := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "Access Key:") {
+			accessKey = strings.TrimSpace(strings.TrimPrefix(line, "Access Key:"))
+		} else if strings.HasPrefix(line, "Secret Key:") {
+			secretKey = strings.TrimSpace(strings.TrimPrefix(line, "Secret Key:"))
+		} else if strings.HasPrefix(line, "Status:") {
+			status = strings.TrimSpace(strings.TrimPrefix(line, "Status:"))
+		}
+	}
+
+	if accessKey == "" {
+		log.Printf("[WARN] No access key found in output for user %s", user)
+		d.SetId("")
+		return diag.Errorf("access key not found in CLI output")
+	}
+
+	d.SetId(accessKey)
+	_ = d.Set("access_key", accessKey)
+	_ = d.Set("secret_key", secretKey)
+	_ = d.Set("status", status)
+	return nil
+}
+
+func minioUpdateAccessKey(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	user := d.Get("user").(string)
+	minioAlias := d.Get("minio_alias").(string)
+	status := d.Get("status").(string)
+	
+	log.Printf("[INFO] Updating accesskey for user %s with status %s", user, status)
+	cmdArgs := []string{"admin", "accesskey", "edit", minioAlias, user, "--status", status}
+	out, err := runMcCommand(cmdArgs...)
+	if err != nil {
+		return diag.Errorf("failed to update accesskey: %s - output: %s", err, out)
+	}
+	return minioReadAccessKey(ctx, d, meta)
+}
+
+func minioDeleteAccessKey(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	user := d.Get("user").(string)
+	minioAlias := d.Get("minio_alias").(string)
+	accessKey := d.Get("access_key").(string)
+	
+	log.Printf("[INFO] Deleting accesskey %s for user %s", accessKey, user)
+	cmdArgs := []string{"admin", "accesskey", "remove", minioAlias, user}
+	out, err := runMcCommand(cmdArgs...)
+	if err != nil {
+		return diag.Errorf("failed to delete accesskey: %s - output: %s", err, out)
+	}
+	d.SetId("")
+	return nil
+}
+
+// runMcCommand executes the mc CLI with the given arguments and returns output/error.
+func runMcCommand(args ...string) (string, error) {
+	// NOTE: Assumes 'mc' is in PATH and required alias is configured.
+	log.Printf("[DEBUG] Running command: mc %s", strings.Join(args, " "))
+	cmd := exec.Command("mc", args...)
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+	
+	if err != nil {
+		log.Printf("[ERROR] Command failed: %s\nOutput: %s", err, outputStr)
+		return outputStr, fmt.Errorf("command failed: %w, output: %s", err, outputStr)
+	}
+	
+	log.Printf("[DEBUG] Command output: %s", outputStr)
+	return outputStr, nil
+}
+

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -1,0 +1,123 @@
+package minio
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccMinioAccessKey_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "minio_accesskey.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAccessKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "access_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_key"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMinioAccessKey_update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "minio_accesskey.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAccessKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				Config: testAccMinioAccessKeyConfigDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMinioAccessKeyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "minio_iam_user" "test" {
+  name = %q
+}
+
+resource "minio_accesskey" "test" {
+  user = minio_iam_user.test.name
+  status = "enabled"
+}
+`, rName)
+}
+
+func testAccMinioAccessKeyConfigDisabled(rName string) string {
+	return fmt.Sprintf(`
+resource "minio_iam_user" "test" {
+  name = %q
+}
+
+resource "minio_accesskey" "test" {
+  user = minio_iam_user.test.name
+  status = "disabled"
+}
+`, rName)
+}
+
+func TestAccMinioAccessKey_customKeys(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "minio_accesskey.test"
+	customAccessKey := acctest.RandString(20)
+	customSecretKey := acctest.RandString(40)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAccessKeyConfigCustomKeys(rName, customAccessKey, customSecretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user", rName),
+					resource.TestCheckResourceAttr(resourceName, "access_key", customAccessKey),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", customSecretKey),
+				),
+			},
+		},
+	})
+}
+
+func testAccMinioAccessKeyConfigCustomKeys(rName, accessKey, secretKey string) string {
+	return fmt.Sprintf(`
+resource "minio_iam_user" "test" {
+  name = %q
+}
+
+resource "minio_accesskey" "test" {
+  user = minio_iam_user.test.name
+  access_key = %q
+  secret_key = %q
+}
+`, rName, accessKey, secretKey)
+}

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -26,9 +26,10 @@ func TestAccMinioAccessKey_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_key"},
 			},
 		},
 	})

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -441,7 +441,7 @@ func testAccBucketArn(randInt string) string {
 }
 
 func testAccBucketDomainName(randInt string) string {
-	return fmt.Sprintf("http://172.17.0.1:9000/minio/%s", randInt)
+	return fmt.Sprintf("http://minio:9000/minio/%s", testAccBucketName(randInt))
 }
 
 func testAccBucketACL(acl string) string {


### PR DESCRIPTION
### Overview

This PR introduces a new Terraform resource, `minio_accesskey`, enabling users to manage MinIO access keys natively through Terraform. The implementation leverages the MinIO Admin Go SDK (`madmin-go`) to interact with the MinIO Service Account API, providing a robust and reliable alternative to shelling out to the `mc` CLI.

### Key Features

- **Create, Read, Update, Delete (CRUD) Operations:**  
  Manage MinIO access keys programmatically for any user, including creation, status updates (enable/disable), and deletion.

- **Custom and Auto-Generated Credentials:**  
  Supports both user-specified (`access_key`, `secret_key`) and auto-generated credentials.

- **Status Management:**  
  Enable or disable access keys directly from Terraform using the `status` attribute.

- **Import Support:**  
  Existing access keys can be imported into Terraform state using their access key ID.

- **Validation and Error Handling:**  
  Includes input validation (length, required fields) and robust error handling with retry logic.

- **Documentation:**  
  Comprehensive documentation and usage examples are provided in [docs/resources/accesskey.md](cci:7://file:///Users/victor/Repositories/terraform-provider-minio/docs/resources/accesskey.md:0:0-0:0).

### Motivation

MinIO recently replaced Service Accounts with the Access Key model, but there was no Terraform-native way to manage these access keys. This PR resolves [issue #613](https://github.com/aminueza/terraform-provider-minio/issues/613) by providing first-class support for access key management, enabling full Infrastructure-as-Code workflows for MinIO deployments.

### Implementation Details

- Uses the `AddServiceAccount`, `InfoServiceAccount`, `UpdateServiceAccount`, and `DeleteServiceAccount` methods from the MinIO Admin Go SDK.
- Ensures compatibility with MinIO's policy-based access control (PBAC) and AWS IAM-like model.
- Does **not** require the `mc` CLI to be present in the environment.

### References

- [MinIO Policy-Based Access Control Documentation](https://min.io/docs/minio/linux/administration/identity-access-management/policy-based-access-control.html)
- [Issue #613: Add Terraform Resource to manage MinIO accesskey](https://github.com/aminueza/terraform-provider-minio/issues/613)