### PR TITLE
Implement the migration logic for the obsolete `bandwidth_limit` attribute

### DIFF
--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -127,7 +127,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
       bucket = minio_s3_bucket.my_bucket_in_b.bucket
       secure = false
       host = var.minio_server_b
-      bandwidth_limt = "100M"
+      bandwidth_limit = "100M"
       access_key = minio_iam_service_account.replication_in_b.access_key
       secret_key = minio_iam_service_account.replication_in_b.secret_key
     }
@@ -177,7 +177,7 @@ resource "minio_s3_bucket_replication" "replication_in_a" {
       bucket = minio_s3_bucket.my_bucket_in_a.bucket
       host = var.minio_server_a
       secure = false
-      bandwidth_limt = "100M"
+      bandwidth_limit = "100M"
       access_key = minio_iam_service_account.replication_in_a.access_key
       secret_key = minio_iam_service_account.replication_in_a.secret_key
     }
@@ -242,7 +242,7 @@ Required:
 
 Optional:
 
-- `bandwidth_limt` (String) Maximum bandwidth in byte per second that MinIO can used when syncronysing this target. Minimum is 100MB
+- `bandwidth_limit` (String) Maximum bandwidth in byte per second that MinIO can used when syncronysing this target. Minimum is 100MB
 - `disable_proxy` (Boolean) Disable proxy for this target
 - `health_check_period` (String) Period where the health of this target will be checked. This must be a valid duration, such as `5s` or `2m`
 - `path` (String) Path of the Minio endpoint. This is usefull if MinIO API isn't served on at the root, e.g for `example.com/minio/`, the path would be `/minio/`

--- a/examples/resources/minio_s3_bucket_replication/resource.tf
+++ b/examples/resources/minio_s3_bucket_replication/resource.tf
@@ -115,7 +115,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
       bucket = minio_s3_bucket.my_bucket_in_b.bucket
       secure = false
       host = var.minio_server_b
-      bandwidth_limt = "100M"
+      bandwidth_limit = "100M"
       access_key = minio_iam_service_account.replication_in_b.access_key
       secret_key = minio_iam_service_account.replication_in_b.secret_key
     }
@@ -165,7 +165,7 @@ resource "minio_s3_bucket_replication" "replication_in_a" {
       bucket = minio_s3_bucket.my_bucket_in_a.bucket
       host = var.minio_server_a
       secure = false
-      bandwidth_limt = "800M"
+      bandwidth_limit = "800M"
       health_check_period = "2m"
       access_key = minio_iam_service_account.replication_in_a.access_key
       secret_key = minio_iam_service_account.replication_in_a.secret_key

--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -175,7 +175,7 @@ func resourceMinioBucketReplication() *schema.Resource {
 										},
 										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9]+\s?[s|m|h]$`), "must be a valid golang duration"),
 									},
-									"bandwidth_limt": {
+									"bandwidth_limit": {
 										Type:        schema.TypeString,
 										Description: "Maximum bandwidth in byte per second that MinIO can used when syncronysing this target. Minimum is 100MB",
 										Optional:    true,
@@ -189,7 +189,7 @@ func resourceMinioBucketReplication() *schema.Resource {
 											if !ok {
 												diags = append(diags, diag.Diagnostic{
 													Severity: diag.Error,
-													Summary:  "expected type of bandwidth_limt to be string",
+													Summary:  "expected type of bandwidth_limit to be string",
 												})
 												return
 											}
@@ -202,7 +202,7 @@ func resourceMinioBucketReplication() *schema.Resource {
 											if err != nil {
 												diags = append(diags, diag.Diagnostic{
 													Severity: diag.Error,
-													Summary:  fmt.Sprintf("bandwidth_limt must be a positive value. It may use suffixes (k, m, g, ..) '%s'", v),
+													Summary:  fmt.Sprintf("bandwidth_limit must be a positive value. It may use suffixes (k, m, g, ..) '%s'", v),
 												})
 												return
 											}
@@ -211,7 +211,7 @@ func resourceMinioBucketReplication() *schema.Resource {
 											if bandwidth < minBandwidthLimit {
 												diags = append(diags, diag.Diagnostic{
 													Severity: diag.Error,
-													Summary:  fmt.Sprintf("When set, bandwidth_limt must be at least 100MBps '%s'", v),
+													Summary:  fmt.Sprintf("When set, bandwidth_limit must be at least 100MBps '%s'", v),
 												})
 
 											}
@@ -419,7 +419,7 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 		} else {
 			bwUint64 = uint64(remoteTarget.BandwidthLimit)
 		}
-		target["bandwidth_limt"] = humanize.Bytes(bwUint64) // Corrected key name and added safe conversion
+		target["bandwidth_limit"] = humanize.Bytes(bwUint64) // Corrected key name and added safe conversion
 		target["region"] = remoteTarget.Region
 		target["access_key"] = remoteTarget.Credentials.AccessKey
 
@@ -749,11 +749,20 @@ func getBucketReplicationConfig(v []interface{}) (result []S3MinioBucketReplicat
 		var bandwidthStr string
 		var bandwidth uint64
 		var err error
-		if bandwidthStr, ok = target["bandwidth_limt"].(string); ok {
+		var legacyLimitValue string
+		var limitValue string
+
+		if legacyLimitValue, ok = target["bandwidth_limt"].(string); ok {
+			bandwidthStr = legacyLimitValue
+		} else if limitValue, ok = target["bandwidth_limit"].(string); ok {
+			bandwidthStr = limitValue
+		}
+
+		if bandwidthStr != "" {
 			bandwidth, err = humanize.ParseBytes(bandwidthStr)
 			if err != nil {
 				log.Printf("[WARN] invalid bandwidth value %q: %v", result[i].Target.BandwidthLimit, err)
-				errs = append(errs, diag.Errorf("rule[%d].target.bandwidth_limt is invalid. Make sure to use k, m, g as preffix only", i)...)
+				errs = append(errs, diag.Errorf("rule[%d].target.bandwidth_limit is invalid. Make sure to use k, m, g as preffix only", i)...)
 			} else {
 				var bwLimit int64
 				if bandwidth > uint64(math.MaxInt64) {

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -77,7 +77,7 @@ resource "minio_s3_bucket_replication" "replication_in_all" {
         host = local.fourth_minio_host
         region = "us-west-2"
         secure = false
-        bandwidth_limt = "1G"
+        bandwidth_limit = "1G"
         access_key = minio_iam_service_account.replication_in_d.access_key
         secret_key = minio_iam_service_account.replication_in_d.secret_key
     }
@@ -174,7 +174,7 @@ resource "minio_s3_bucket_replication" "%s" {
         secure = false
         access_key = minio_iam_service_account.replication_in_%s.access_key
         secret_key = minio_iam_service_account.replication_in_%s.secret_key
-        bandwidth_limt = "1G"
+        bandwidth_limit = "1G"
     }
   }
 
@@ -301,7 +301,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
         bucket = minio_s3_bucket.my_bucket_in_b.bucket
         host = local.second_minio_host
         secure = false
-        bandwidth_limt = "100M"
+        bandwidth_limit = "100M"
         access_key = minio_iam_service_account.replication_in_b.access_key
         secret_key = minio_iam_service_account.replication_in_b.secret_key
     }
@@ -331,7 +331,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
             secure = false
             region = "eu-west-1"
             syncronous = true
-            bandwidth_limt = "100M"
+            bandwidth_limit = "100M"
             access_key = minio_iam_service_account.replication_in_b.access_key
             secret_key = minio_iam_service_account.replication_in_b.secret_key
         }
@@ -360,7 +360,7 @@ resource "minio_s3_bucket_replication" "replication_in_a" {
             host = local.primary_minio_host
             region = "eu-north-1"
             secure = false
-            bandwidth_limt = "800M"
+            bandwidth_limit = "800M"
             health_check_period = "2m"
             access_key = minio_iam_service_account.replication_in_a.access_key
             secret_key = minio_iam_service_account.replication_in_a.secret_key
@@ -515,7 +515,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
         bucket = minio_s3_bucket.my_bucket_in_b.bucket
         host = local.second_minio_host
         secure = false
-        bandwidth_limt = "150M"
+        bandwidth_limit = "150M"
         health_check_period = "5m"
         access_key = minio_iam_service_account.replication_in_b.access_key
         secret_key = minio_iam_service_account.replication_in_b.secret_key
@@ -582,7 +582,7 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
         bucket = minio_s3_bucket.my_bucket_in_b.bucket
         host = local.second_minio_host
         secure = false
-        bandwidth_limt = "150M"
+        bandwidth_limit = "150M"
         health_check_period = "5m"
         access_key = minio_iam_service_account.replication_in_b.access_key
         secret_key = minio_iam_service_account.replication_in_b.secret_key


### PR DESCRIPTION
**NOTE**: This change can be **breaking** for the users who use the `bandwidth_limt` attribute in configuration

Resolves #629

As discussed in the issue mentioned above, we need to implement a breaking change, which involves renaming the optional attribute bandwidth_limt to bandwidth_limit.

The logic for reading the new attribute is as follows:

1. Attempt to read bandwidth_limt; if not found, try to read bandwidth_limit.
2. Always write the new state with the bandwidth_limit attribute.

Regarding the versioning of this change, formally, it's a breaking change (users who use the old `bandwidth_limt` attribute must update their configuration to be able to plan new changes). But this attribute is optional and for users who don't use this attribute, the change will not be breaking.

This change was tested manually using the reproduction scenarios, provided in the issue:

- The configuration was applied to MinIO instance using the code from the main branch. The terraform state:
![image](https://github.com/user-attachments/assets/105d126b-05d9-4921-aeba-5c96029ff5db)
- The code was updated to handle the migration logic.
- The value of new `bandwidth_limit` attribute was changed and new configuration was applied:
![image](https://github.com/user-attachments/assets/4733bd62-ecad-4611-93cf-1ee48be9f934)
- The attribute was removed to test the default value:
![image](https://github.com/user-attachments/assets/1e7b638c-7ed1-4df5-8890-028cdeb85720)
 
