### PR TITLE
Avoid the integer overflow in the bandwidth limit warning message

### DIFF
--- a/minio/utils.go
+++ b/minio/utils.go
@@ -226,7 +226,7 @@ func ParseBandwidthLimit(target map[string]any) (uint64, bool, diag.Diagnostics)
 
 	// Check if bandwidth exceeds maximum int64 value
 	if bandwidth > uint64(math.MaxInt64) {
-		log.Printf("[WARN] Configured bandwidth limit (%d) exceeds maximum supported value (%d)", bandwidth, math.MaxInt64)
+		log.Printf("[WARN] Configured bandwidth limit (%s) exceeds maximum supported value (%s)", humanize.Bytes(bandwidth), humanize.Bytes(uint64(math.MaxInt64)))
 	}
 
 	return bandwidth, true, nil


### PR DESCRIPTION
- Follow-up from https://github.com/aminueza/terraform-provider-minio/pull/632

Fix the error happening in the GoRelease script [[1](https://github.com/aminueza/terraform-provider-minio/actions/runs/15020645228/job/42208770091)]:
```
Error: minio/utils.go:229:104: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to log.Printf (overflows)
```