### PR TITLE
Replace the `--rm-dist` goreleaser argument with `--clean`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reference: https://goreleaser.com/deprecations/#-rm-dist

As seen [here](https://github.com/aminueza/terraform-provider-minio/actions/runs/15020645228/job/42208770091):

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/24c3032d-39bf-431e-a8a0-7c0355a7a712" />
