### PR TITLE
Consider the attachment resource as removed if the user is removed

### DIFF
--- a/examples/resources/minio_iam_user_policy_attachment/main.tf
+++ b/examples/resources/minio_iam_user_policy_attachment/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    minio = {
+      source  = "aminueza/minio"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "minio" {
+  minio_server   = var.minio_server
+  minio_region   = var.minio_region
+  minio_user     = var.minio_user
+  minio_password = var.minio_password
+}
+

--- a/examples/resources/minio_iam_user_policy_attachment/variables.tf
+++ b/examples/resources/minio_iam_user_policy_attachment/variables.tf
@@ -1,0 +1,19 @@
+variable "minio_region" {
+  description = "Default MINIO region"
+  default     = "us-east-1"
+}
+
+variable "minio_server" {
+  description = "Default MINIO host and port"
+  default     = "localhost:9000"
+}
+
+variable "minio_user" {
+  description = "MINIO user"
+  default     = "minio"
+}
+
+variable "minio_password" {
+  description = "MINIO password"
+  default     = "minio123"
+}

--- a/minio/resource_minio_iam_user_policy_attachment.go
+++ b/minio/resource_minio_iam_user_policy_attachment.go
@@ -158,8 +158,12 @@ func minioReadUserPolicies(ctx context.Context, minioAdmin *madmin.AdminClient, 
 
 		log.Printf("[DEBUG] UserPolicyAttachment: got an error, errUserIsResponse=%t, errUserResponse.Code=%s", errUserIsResponse, errUserResponse.Code)
 
-		if !isLDAPUser || !errUserIsResponse || !strings.EqualFold(errUserResponse.Code, "XMinioAdminNoSuchUser") {
-			return nil, NewResourceError("failed to load user Infos", userName, errUser)
+		if strings.EqualFold(errUserResponse.Code, "XMinioAdminNoSuchUser") {
+			return nil, nil
+		} else {
+			if !isLDAPUser || !errUserIsResponse {
+				return nil, NewResourceError("failed to load user Infos", userName, errUser)
+			}
 		}
 	}
 	if userInfo.PolicyName == "" {


### PR DESCRIPTION
## Main change
Resolves #614

Since the policy attachment in the MinIO API is an attribute of the user, we consider that if the user is removed, the policy attachment is removed as well.

## Additional changes
Added the `main.tf` and `variables.tf` to the `iam_user_policy_attachment` example to make it runnable with docker-compose stack from the repo.