### PR TITLE
Remove the max length enforcement for secret keys

### DIFF
--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -19,7 +19,7 @@ resource "minio_accesskey" "example" {
 resource "minio_accesskey" "custom_key" {
   user       = minio_iam_user.example_user.name
   access_key = "MINIO_ACCESS_KEY"  # Must be 8-20 characters
-  secret_key = "mySuperSecretKey"  # Must be 8-40 characters
+  secret_key = "mySuperSecretKey"  # Must be at least 8 characters
   status     = "enabled"
 }
 
@@ -34,7 +34,7 @@ resource "minio_accesskey" "disabled_key" {
 
 - `user` (Required) - The MinIO user for whom the access key is managed.
 - `access_key` (Optional) - The access key value. If omitted, MinIO generates one. Must be 8-20 characters when specified.
-- `secret_key` (Optional) - The secret key value. If omitted, MinIO generates one. Must be 8-40 characters when specified.
+- `secret_key` (Optional) - The secret key value. If omitted, MinIO generates one. Must be at least 8 characters when specified.
 - `status` (Optional) - The status of the access key (`enabled` or `disabled`). Defaults to `enabled`.
 
 ## Timeouts

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -62,12 +62,12 @@ func resourceMinioAccessKey() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The secret key. If provided, must be between 8 and 40 characters.",
+				Description: "The secret key. If provided, must be at least 8 characters.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					if v != "" {
-						if len(v) < 8 || len(v) > 40 {
-							errs = append(errs, fmt.Errorf("%q must be between 8 and 40 characters when specified", key))
+						if len(v) < 8 {
+							errs = append(errs, fmt.Errorf("%q must be at least 8 characters when specified", key))
 						}
 					}
 					return


### PR DESCRIPTION
- Resolves #638

As pointed out by @devsadds, MinIO has no max length enforcement for secret keys [[1](https://github.com/minio/minio/blob/a6c538c5a113a588d49b4f3af36ae3046cfa5ac6/internal/auth/credentials.go#L47-L50)].

Note that the auto-generated key is by default 40 characters on MinIO, so it is on terraform-provider-minio and will remain like that.

This PR is just a patch to remove the max length limit.