### PR TITLE
Add Support '/' for resource 'minio_iam_policy'

### DIFF
--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -163,9 +163,9 @@ func validateIAMNamePolicy(v interface{}, k string) (ws []string, errors []error
 			"%q cannot be longer than 96 characters, name is limited to 128", k))
 	}
 
-	if !regexp.MustCompile(`^[\w+=,.@:-]*$`).MatchString(value) {
+	if !regexp.MustCompile(`^[\w+=,.@:/-]*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must match [\\w+=,.@:-]", k))
+			"%q must match [\\w+=,.@:/-]", k))
 	}
 	return
 }


### PR DESCRIPTION
The validation for IAM policy names has been updated to allow the "/" character, addressing the requirement for group paths in Minio policies.

Fixes #637