### PR TITLE
fix(ilm): Treat NoSuchLifecycleConfiguration as not found

### DIFF
--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -523,5 +523,5 @@ func convertToStringMap(v interface{}) map[string]string {
 }
 
 func isNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), "The lifecycle configuration does not exist")
+	return strings.Contains(err.Error(), "The lifecycle configuration does not exist") || strings.Contains(err.Error(), "NoSuchLifecycleConfiguration")
 }


### PR DESCRIPTION
This change resolves an issue where applying an minio_ilm_policy fails on S3-compatible services like Hetzner Object Storage when no lifecycle policy is present on the bucket.

The provider currently fails with the error: Error: failed to get existing lifecycle: Error response code NoSuchLifecycleConfiguration.

This PR updates the isNotFoundError check to correctly identify NoSuchLifecycleConfiguration as a "not found" condition, allowing the provider to proceed as expected.
