### PR TITLE
Add policy Argument to `minio_accesskey` Resource for Direct Policy Attachment #631

### DIFF
--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -28,6 +28,15 @@ resource "minio_accesskey" "disabled_key" {
   user   = minio_iam_user.example_user.name
   status = "disabled"
 }
+
+# Create an access key and attach a policy directly (policy name or JSON)
+resource "minio_accesskey" "with_policy" {
+  user   = minio_iam_user.example_user.name
+  access_key = "EXAMPLEKEY1"
+  secret_key = "mySuperSecretKey"
+  status     = "enabled"
+  policy     = file("path/to/policy.json") # or use a policy name or jsonencode block
+}
 ```
 
 ## Argument Reference
@@ -36,6 +45,7 @@ resource "minio_accesskey" "disabled_key" {
 - `access_key` (Optional) - The access key value. If omitted, MinIO generates one. Must be 8-20 characters when specified.
 - `secret_key` (Optional) - The secret key value. If omitted, MinIO generates one. Must be 8-40 characters when specified.
 - `status` (Optional) - The status of the access key (`enabled` or `disabled`). Defaults to `enabled`.
+- `policy` (Optional) - The policy to attach to the access key. Can be a policy name, a JSON document, or the contents of a file (e.g., `file("path/to/policy.json")`).
 
 ## Timeouts
 

--- a/examples/accesskey/main.tf
+++ b/examples/accesskey/main.tf
@@ -27,6 +27,24 @@ resource "minio_accesskey" "test_key" {
   # secret_key = "custom_secret_key"
 }
 
+resource "minio_accesskey" "test_key_with_policy" {
+  user   = minio_iam_user.test_user.name
+  status = "enabled"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+        ]
+        Effect   = "Allow"
+        Resource = ["arn:aws:s3:::*"]
+      }
+    ]
+  }) # Attach policy (use file() or jsonencode())
+}
+
 # If you want to attach a policy to the user
 resource "minio_iam_policy" "test_policy" {
   name = "test-policy"
@@ -57,5 +75,14 @@ output "access_key" {
 
 output "secret_key" {
   value     = minio_accesskey.test_key.secret_key
+  sensitive = true
+}
+
+output "access_key_with_policy" {
+  value = minio_accesskey.test_key_with_policy.access_key
+}
+
+output "secret_key_with_policy" {
+  value     = minio_accesskey.test_key_with_policy.secret_key
   sensitive = true
 }

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -202,7 +202,13 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	_ = d.Set("status", status)
 	_ = d.Set("access_key", accessKeyID)
-	_ = d.Set("policy", info.Policy)
+
+	policy := strings.TrimSpace(info.Policy)
+	if policy != "" && policy != "null" && policy != "{}" && policy != `{"Statement":null,"Version":""}` {
+		_ = d.Set("policy", policy)
+	} else {
+		_ = d.Set("policy", nil)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Overview
This PR adds support for a policy argument to the `minio_accesskey` Terraform resource, enabling direct attachment of a policy (either by name or as a JSON document) to an access key at creation or update time.

## Background  
When MinIO is configured with external authentication providers (such as LDAP), IAM users cannot be managed via the MinIO API. The only way to manage access for these users is by creating access keys and attaching policies directly to those keys. The MinIO `mc` CLI supports this, but the Terraform provider did not—until now.

## Enhancements
- Adds a `policy` argument to the `minio_accesskey` resource.
- Accepts either a policy name or a JSON policy document (inline or loaded from file).
- Applies the policy to the access key during creation and update, matching the behavior of `mc admin accesskey create ... --policy`.

## Example Usage
```hcl
resource "minio_accesskey" "custom_key" {
  user       = "ROOT_USER"
  access_key = "MINIO_ACCESS_KEY"
  secret_key = "mySuperSecretKey"
  status     = "enabled"
  policy     = file("path/to/policy.json") # or a policy name or inline JSON
}
```

### Reference
 - Resolves: #631 
