### PR TITLE
Fix: minio user data documentation

### DIFF
--- a/docs/data-sources/iam_user.md
+++ b/docs/data-sources/iam_user.md
@@ -12,3 +12,4 @@ data "minio_iam_user" "alice" {
 output "alice_status" {
   value = data.minio_iam_user.alice.status
 }
+```


### PR DESCRIPTION
docs: fix missing closing backticks in minio_iam_user example

This PR implements the following changes:
	•	Added the missing closing triple backticks (```) in the minio_iam_user data source documentation example.
	•	Ensures the HCL code block renders properly on the documentation site.

Reference
	•	N/A

(Optional) People
	•	@felladrin

Closing issues
	•	None
