### PR TITLE
Add configurable retry settings for MinIO bucket operations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,11 @@ provider minio {
   minio_region      = "..."
   minio_api_version = "..."
   minio_ssl         = "..."
+
+  // optional: tune for inconsistent backends (e.g., Hetzner)
+  minio_consistency_max_retries         = 3
+  minio_consistency_max_backoff_seconds = 20
+  minio_consistency_backoff_base        = 2.0
 }
 ```
 
@@ -69,18 +74,24 @@ resource "minio_s3_bucket" "state_terraform_s3" {
 
 The following arguments are supported in the `provider` block:
 
-* `minio_server` - (Required) Minio Host and Port. It must be provided, but
+- `minio_server` - (Required) Minio Host and Port. It must be provided, but
   it can also be sourced from the `MINIO_ENDPOINT` environment variable
 
-* `minio_user` - (Required) Minio User. It must be provided, but
+- `minio_user` - (Required) Minio User. It must be provided, but
   it can also be sourced from the `MINIO_USER` environment variable
 
-* `minio_password` - (Required) Minio Password. It must be provided, but
+- `minio_password` - (Required) Minio Password. It must be provided, but
   it can also be sourced from the `MINIO_PASSWORD` environment variable
 
-* `minio_region` - (Optional) Minio Region (`default: us-east-1`).
+- `minio_region` - (Optional) Minio Region (`default: us-east-1`).
 
-* `minio_api_version` - (Optional) Minio API Version (type: string, options: `v2` or `v4`, default: `v4`).
+- `minio_api_version` - (Optional) Minio API Version (type: string, options: `v2` or `v4`, default: `v4`).
 
-* `minio_ssl` - (Optional) Minio SSL enabled (default: `false`). It can also be sourced from the
+- `minio_ssl` - (Optional) Minio SSL enabled (default: `false`). It can also be sourced from the
   `MINIO_ENABLE_HTTPS` environment variable
+
+- `minio_consistency_max_retries` - (Optional) Maximum number of retries for bucket existence checks to handle eventual consistency issues in some MinIO implementations (default: `3`). It can also be sourced from the `MINIO_CONSISTENCY_MAX_RETRIES` environment variable
+
+- `minio_consistency_max_backoff_seconds` - (Optional) Maximum backoff per attempt in seconds for bucket existence checks (default: `20`). It can also be sourced from the `MINIO_CONSISTENCY_MAX_BACKOFF_SECONDS` environment variable
+
+- `minio_consistency_backoff_base` - (Optional) Exponential backoff base for bucket existence checks (default: `2.0`). It can also be sourced from the `MINIO_CONSISTENCY_BACKOFF_BASE` environment variable

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -40,6 +40,9 @@ func BucketConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucket {
 		MinioACL:             getOptionalField(d, "acl", "private").(string),
 		MinioForceDestroy:    getOptionalField(d, "force_destroy", false).(bool),
 		ObjectLockingEnabled: getOptionalField(d, "object_locking", false).(bool),
+		ConsistencyMaxRetries:        m.ConsistencyMaxRetries,
+		ConsistencyMaxBackoffSeconds: m.ConsistencyMaxBackoffSeconds,
+		ConsistencyBackoffBase:       m.ConsistencyBackoffBase,
 	}
 }
 
@@ -141,6 +144,9 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		S3SSLCertFile:   getOptionalField(d, "minio_cert_file", "").(string),
 		S3SSLKeyFile:    getOptionalField(d, "minio_key_file", "").(string),
 		S3SSLSkipVerify: getOptionalField(d, "minio_insecure", false).(bool),
+		ConsistencyMaxRetries:        getOptionalField(d, "minio_consistency_max_retries", 3).(int),
+		ConsistencyMaxBackoffSeconds: getOptionalField(d, "minio_consistency_max_backoff_seconds", 20).(int),
+		ConsistencyBackoffBase:       getOptionalField(d, "minio_consistency_backoff_base", 2.0).(float64),
 	}
 }
 

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -64,6 +64,9 @@ func (config *S3MinioConfig) NewClient() (interface{}, error) {
 		S3Region:     config.S3Region,
 		S3Client:     minioClient,
 		S3Admin:      minioAdmin,
+		ConsistencyMaxRetries:        config.ConsistencyMaxRetries,
+		ConsistencyMaxBackoffSeconds: config.ConsistencyMaxBackoffSeconds,
+		ConsistencyBackoffBase:       config.ConsistencyBackoffBase,
 	}, nil
 }
 

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -24,6 +24,9 @@ type S3MinioConfig struct {
 	S3SSLCertFile   string
 	S3SSLKeyFile    string
 	S3SSLSkipVerify bool
+	ConsistencyMaxRetries        int
+	ConsistencyMaxBackoffSeconds int
+	ConsistencyBackoffBase       float64
 }
 
 // S3MinioClient defines default minio
@@ -32,6 +35,9 @@ type S3MinioClient struct {
 	S3Region     string
 	S3Client     *minio.Client
 	S3Admin      *madmin.AdminClient
+	ConsistencyMaxRetries        int
+	ConsistencyMaxBackoffSeconds int
+	ConsistencyBackoffBase       float64
 }
 
 // S3MinioBucket defines minio config
@@ -45,6 +51,9 @@ type S3MinioBucket struct {
 	MinioAccess          string
 	MinioForceDestroy    bool
 	ObjectLockingEnabled bool
+	ConsistencyMaxRetries        int
+	ConsistencyMaxBackoffSeconds int
+	ConsistencyBackoffBase       float64
 }
 
 // S3MinioBucketPolicy defines bucket policy config

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -137,6 +137,30 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 					prefix + "MINIO_KEY_FILE",
 				}, nil),
 			},
+            "minio_consistency_max_retries": {
+                Type:        schema.TypeInt,
+                Optional:    true,
+                Description: "Maximum retries for bucket existence checks to handle eventual consistency",
+                DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+                    prefix + "MINIO_CONSISTENCY_MAX_RETRIES",
+                }, 3),
+            },
+            "minio_consistency_max_backoff_seconds": {
+                Type:        schema.TypeInt,
+                Optional:    true,
+                Description: "Maximum backoff per attempt in seconds for bucket existence checks",
+                DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+                    prefix + "MINIO_CONSISTENCY_MAX_BACKOFF_SECONDS",
+                }, 20),
+            },
+            "minio_consistency_backoff_base": {
+                Type:        schema.TypeFloat,
+                Optional:    true,
+                Description: "Exponential backoff base for bucket existence checks",
+                DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+                    prefix + "MINIO_CONSISTENCY_BACKOFF_BASE",
+                }, 2.0),
+            },
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -31,12 +31,63 @@ type RetryConfig struct {
 	BackoffBase float64
 }
 
-func getRetryConfig() RetryConfig {
-	return RetryConfig{
-		MaxRetries:  3,
-		MaxBackoff:  20 * time.Second,
-		BackoffBase: 2.0,
+func getRetryConfig(b *S3MinioBucket) RetryConfig {
+	maxRetries := b.ConsistencyMaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 3
 	}
+	maxBackoffSeconds := b.ConsistencyMaxBackoffSeconds
+	if maxBackoffSeconds <= 0 {
+		maxBackoffSeconds = 20
+	}
+	backoffBase := b.ConsistencyBackoffBase
+	if backoffBase <= 0 {
+		backoffBase = 2.0
+	}
+	return RetryConfig{
+		MaxRetries:  maxRetries,
+		MaxBackoff:  time.Duration(maxBackoffSeconds) * time.Second,
+		BackoffBase: backoffBase,
+	}
+}
+
+func waitForBucketVisible(ctx context.Context, existsFn func(context.Context) (bool, error), cfg RetryConfig, id string) (bool, error) {
+	var found bool
+	var err error
+	for i := 0; i < cfg.MaxRetries; i++ {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		found, err = existsFn(ctx)
+		if err != nil {
+			log.Printf("[ERROR] Error checking if bucket exists: %s", err)
+			return false, err
+		}
+		if found {
+			return true, nil
+		}
+		if i < cfg.MaxRetries-1 {
+			var jitter float64
+			var randomBytes [8]byte
+			if _, err := rand.Read(randomBytes[:]); err != nil {
+				jitter = 0.5
+			} else {
+				jitter = float64(binary.BigEndian.Uint64(randomBytes[:])) / float64(math.MaxUint64)
+			}
+			backoffSeconds := jitter * math.Pow(cfg.BackoffBase, float64(i))
+			sleep := minDuration(time.Duration(backoffSeconds*float64(time.Second)), cfg.MaxBackoff)
+			log.Printf("[DEBUG] Bucket [%s] not found on attempt %d/%d, retrying in %v...", id, i+1, cfg.MaxRetries, sleep)
+			time.Sleep(sleep)
+		}
+	}
+	return false, nil
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func resourceMinioBucket() *schema.Resource {
@@ -161,7 +212,10 @@ func minioCreateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	log.Printf("[DEBUG] Created bucket: [%s] in region: [%s]", bucket, region)
 
-	found, err := bucketConfig.MinioClient.BucketExists(ctx, bucket)
+	cfg := getRetryConfig(bucketConfig)
+	found, err := waitForBucketVisible(ctx, func(c context.Context) (bool, error) {
+		return bucketConfig.MinioClient.BucketExists(c, bucket)
+	}, cfg, bucket)
 	if err != nil {
 		log.Printf("[WARNING] Error verifying bucket creation: %s", err)
 	} else if !found {
@@ -176,44 +230,12 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Reading bucket [%s] in region [%s]", d.Id(), bucketConfig.MinioRegion)
 
-	// Retry logic to handle eventual consistency issues with some MinIO implementations
-	// (e.g., Hetzner's MinIO may report bucket as not existing immediately after creation)
-	// Use truncated exponential backoff with jitter as in AWS SDKs:
-	// seconds_to_sleep_i = min(b*r^i, MAX_BACKOFF)
-	// where b = random number between 0 and 1; r = 2; MAX_BACKOFF = 20 seconds for most SDKs
-	var found bool
-	var err error
-	retryConfig := getRetryConfig()
-
-	for i := 0; i < retryConfig.MaxRetries; i++ {
-		if ctx.Err() != nil {
-			return NewResourceError("context cancelled during bucket existence check", d.Id(), ctx.Err())
-		}
-
-		found, err = bucketConfig.MinioClient.BucketExists(ctx, d.Id())
-		if err != nil {
-			log.Printf("[ERROR] Error checking if bucket exists: %s", err)
-			return NewResourceError("error checking bucket existence", d.Id(), err)
-		}
-
-		if found {
-			break
-		}
-
-		if i < retryConfig.MaxRetries-1 {
-			var jitter float64
-			var randomBytes [8]byte
-			if _, err := rand.Read(randomBytes[:]); err != nil {
-				log.Printf("[WARNING] Failed to generate random jitter: %s", err)
-				jitter = 0.5
-			} else {
-				jitter = float64(binary.BigEndian.Uint64(randomBytes[:])) / float64(math.MaxUint64)
-			}
-			backoffSeconds := jitter * math.Pow(retryConfig.BackoffBase, float64(i))
-			sleep := min(time.Duration(backoffSeconds*float64(time.Second)), retryConfig.MaxBackoff)
-			log.Printf("[DEBUG] Bucket [%s] not found on attempt %d/%d, retrying in %v...", d.Id(), i+1, retryConfig.MaxRetries, sleep)
-			time.Sleep(sleep)
-		}
+	retryConfig := getRetryConfig(bucketConfig)
+	found, err := waitForBucketVisible(ctx, func(c context.Context) (bool, error) {
+		return bucketConfig.MinioClient.BucketExists(c, d.Id())
+	}, retryConfig, d.Id())
+	if err != nil {
+		return NewResourceError("error checking bucket existence", d.Id(), err)
 	}
 
 	if !found {

--- a/minio/resource_minio_s3_bucket_internal_test.go
+++ b/minio/resource_minio_s3_bucket_internal_test.go
@@ -1,0 +1,67 @@
+package minio
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitForBucketVisibleImmediate(t *testing.T) {
+	calls := 0
+	exists := func(ctx context.Context) (bool, error) {
+		calls++
+		return true, nil
+	}
+	cfg := RetryConfig{MaxRetries: 3, MaxBackoff: time.Millisecond, BackoffBase: 2.0}
+	found, err := waitForBucketVisible(context.Background(), exists, cfg, "bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestWaitForBucketVisibleDelayed(t *testing.T) {
+	calls := 0
+	exists := func(ctx context.Context) (bool, error) {
+		calls++
+		if calls < 3 {
+			return false, nil
+		}
+		return true, nil
+	}
+	cfg := RetryConfig{MaxRetries: 5, MaxBackoff: time.Millisecond, BackoffBase: 2.0}
+	found, err := waitForBucketVisible(context.Background(), exists, cfg, "bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true after retries")
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (2 false then true), got %d", calls)
+	}
+}
+
+func TestWaitForBucketVisibleNever(t *testing.T) {
+	calls := 0
+	exists := func(ctx context.Context) (bool, error) {
+		calls++
+		return false, nil
+	}
+	cfg := RetryConfig{MaxRetries: 4, MaxBackoff: time.Millisecond, BackoffBase: 2.0}
+	found, err := waitForBucketVisible(context.Background(), exists, cfg, "bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatalf("expected found=false after exhausting retries")
+	}
+	if calls != cfg.MaxRetries {
+		t.Fatalf("expected %d calls, got %d", cfg.MaxRetries, calls)
+	}
+}


### PR DESCRIPTION
The fix for issue #658 (inconsistency in bucket creation) introduced retry logic, but the hardcoded backoff window (~7-10s) is insufficient for some MinIO implementations like Hetzner's. A user report the "provider produced inconsistent result after apply" error returning.

The solution in this PR allows users to tune the retry behavior for specific backends without code changes.

Added three provider configuration fields with environment variable support:
- `minio_consistency_max_retries` (default: 3)
- `minio_consistency_max_backoff_seconds` (default: 20) 
- `minio_consistency_backoff_base` (default: 2.0)