### PR TITLE
Double the MaxRetries for creating a bucket

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -33,7 +33,7 @@ type RetryConfig struct {
 
 func getRetryConfig() RetryConfig {
 	return RetryConfig{
-		MaxRetries:  3,
+		MaxRetries:  6,
 		MaxBackoff:  20 * time.Second,
 		BackoffBase: 2.0,
 	}


### PR DESCRIPTION
This allows up to 5 sleeps with maximum total wait of ~31 seconds, providing adequate time for slower backends without excessive delays for normal cases.

- Improves the solution for the issue [#658](https://github.com/aminueza/terraform-provider-minio/issues/658#issuecomment-3458837328).