### PR TITLE
Add detailed server response information to error messages

### DIFF
--- a/minio/error_test.go
+++ b/minio/error_test.go
@@ -1,0 +1,179 @@
+package minio
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func TestExtractErrorDetail_MinioError(t *testing.T) {
+	err := minio.ErrorResponse{
+		Code:       "NoSuchBucket",
+		Message:    "The specified bucket does not exist",
+		RequestID:  "ABC123",
+		BucketName: "test-bucket",
+	}
+
+	detail := extractErrorDetail(err)
+
+	if detail == "" {
+		t.Error("expected non-empty detail")
+	}
+
+	if !strings.Contains(detail, "NoSuchBucket") {
+		t.Error("expected detail to contain error code")
+	}
+
+	if !strings.Contains(detail, "test-bucket") {
+		t.Error("expected detail to contain bucket name")
+	}
+}
+
+func TestExtractErrorDetail_GenericError(t *testing.T) {
+	err := errors.New("generic error")
+	detail := extractErrorDetail(err)
+
+	if detail != "" {
+		t.Errorf("expected empty detail for generic error, got: %s", detail)
+	}
+}
+
+func TestNewResourceError_WithMinioError(t *testing.T) {
+	err := minio.ErrorResponse{
+		Code:    "AccessDenied",
+		Message: "Access Denied",
+	}
+
+	diags := NewResourceError("failed to create bucket", "test-bucket", err)
+
+	if len(diags) < 2 {
+		t.Errorf("expected at least 2 diagnostics (error + detail), got %d", len(diags))
+	}
+}
+
+func TestEnhanceConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected string
+	}{
+		{
+			name:     "connection refused",
+			errMsg:   "dial tcp 127.0.0.1:9000: connection refused",
+			expected: "Connection refused. Verify that the MinIO server is running and the endpoint is correct.",
+		},
+		{
+			name:     "no such host",
+			errMsg:   "dial tcp: lookup invalid.host: no such host",
+			expected: "Host not found. Verify the MinIO server hostname is correct.",
+		},
+		{
+			name:     "certificate error",
+			errMsg:   "x509: certificate signed by unknown authority",
+			expected: "SSL/TLS certificate error. If using self-signed certificates, set minio_insecure = true.",
+		},
+		{
+			name:     "invalid character (HTML response)",
+			errMsg:   "invalid character '<' looking for beginning of value",
+			expected: "Invalid response from server. This often indicates the endpoint URL is incorrect (e.g., pointing to a web page instead of the MinIO API).",
+		},
+		{
+			name:     "generic error",
+			errMsg:   "some other error",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errors.New(tt.errMsg)
+			result := enhanceConnectionError(err)
+			if result != tt.expected {
+				t.Errorf("enhanceConnectionError(%q) = %q, want %q", tt.errMsg, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnhanceConnectionError_NilError(t *testing.T) {
+	result := enhanceConnectionError(nil)
+	if result != "" {
+		t.Errorf("enhanceConnectionError(nil) = %q, want empty string", result)
+	}
+}
+
+func TestEnhanceAuthError(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			name:     "AccessDenied",
+			code:     "AccessDenied",
+			expected: "Access denied. Verify your access key and secret key are correct.",
+		},
+		{
+			name:     "InvalidAccessKeyId",
+			code:     "InvalidAccessKeyId",
+			expected: "Invalid access key. The access key does not exist.",
+		},
+		{
+			name:     "SignatureDoesNotMatch",
+			code:     "SignatureDoesNotMatch",
+			expected: "Signature mismatch. The secret key may be incorrect.",
+		},
+		{
+			name:     "other error code",
+			code:     "NoSuchBucket",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := minio.ErrorResponse{Code: tt.code}
+			result := enhanceAuthError(err)
+			if result != tt.expected {
+				t.Errorf("enhanceAuthError(%q) = %q, want %q", tt.code, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractErrorDetail_WithAuthHint(t *testing.T) {
+	err := minio.ErrorResponse{
+		Code:    "AccessDenied",
+		Message: "Access Denied",
+	}
+
+	detail := extractErrorDetail(err)
+
+	if !strings.Contains(detail, "Code: AccessDenied") {
+		t.Error("expected detail to contain error code")
+	}
+
+	if !strings.Contains(detail, "Hint:") {
+		t.Error("expected detail to contain hint")
+	}
+
+	if !strings.Contains(detail, "Verify your access key") {
+		t.Error("expected detail to contain auth hint message")
+	}
+}
+
+func TestExtractErrorDetail_WithConnectionHint(t *testing.T) {
+	err := errors.New("dial tcp 127.0.0.1:9000: connection refused")
+
+	detail := extractErrorDetail(err)
+
+	if !strings.Contains(detail, "Hint:") {
+		t.Error("expected detail to contain hint")
+	}
+
+	if !strings.Contains(detail, "Connection refused") {
+		t.Error("expected detail to contain connection hint message")
+	}
+}

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -137,13 +137,21 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 					prefix + "MINIO_KEY_FILE",
 				}, nil),
 			},
+			"minio_debug": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable debug logging for API requests",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					prefix + "MINIO_DEBUG",
+				}, false),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"minio_iam_policy_document": dataSourceMinioIAMPolicyDocument(),
 			"minio_s3_object":           dataSourceMinioS3Object(),
-			"minio_iam_user":  dataSourceIAMUser(),
-			"minio_iam_users": dataSourceIAMUsers(),
+			"minio_iam_user":            dataSourceIAMUser(),
+			"minio_iam_users":           dataSourceIAMUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -67,6 +67,35 @@ resource "minio_s3_bucket" "state_terraform_s3" {
 
 ## Argument Reference
 
+## Troubleshooting
+
+### Common Errors
+
+#### "invalid character 'P' looking for beginning of value"
+
+This typically means the provider received an HTML page instead of JSON. Causes:
+- Wrong endpoint URL (pointing to the console instead of API)
+- Proxy or load balancer returning an error page
+- MinIO server not running
+
+**Solution:** Verify `minio_server` points to the S3 API endpoint.
+
+#### "Access Denied"
+
+Authentication failed. Causes:
+- Incorrect access key or secret key
+- Insufficient permissions
+- Policy restrictions
+
+**Solution:** Check credentials and IAM policies.
+
+#### "connection refused"
+
+Unable to reach MinIO server.
+
+**Solution:** Ensure server is running and reachable.
+
+
 The following arguments are supported in the `provider` block:
 
 * `minio_server` - (Required) MinIO server endpoint in the format `host:port`. Can be sourced from `MINIO_ENDPOINT`.
@@ -94,3 +123,5 @@ The following arguments are supported in the `provider` block:
 * `minio_cert_file` - (Optional) Path to client certificate file. Can be sourced from `MINIO_CERT_FILE`.
 
 * `minio_key_file` - (Optional, Sensitive) Path to client private key file. Can be sourced from `MINIO_KEY_FILE`.
+
+* `minio_debug` - (Optional) Enable debug logging for API requests (default: `false`). Can be sourced from `MINIO_DEBUG`.


### PR DESCRIPTION
Makes it easier for users to diagnose and fix issues, as suggested on #99.