### PR TITLE
Fix S3 bucket tagging compatibility with Hetzner Object Storage

### DIFF
--- a/minio/resource_minio_s3_bucket_tagging_compat_test.go
+++ b/minio/resource_minio_s3_bucket_tagging_compat_test.go
@@ -1,0 +1,31 @@
+package minio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func TestIsS3TaggingNotImplemented(t *testing.T) {
+	t.Run("not implemented", func(t *testing.T) {
+		err := &minio.ErrorResponse{Code: "NotImplemented"}
+		if !IsS3TaggingNotImplemented(err) {
+			t.Fatalf("expected tagging NotImplemented to be detected")
+		}
+	})
+
+	t.Run("different s3 error", func(t *testing.T) {
+		err := &minio.ErrorResponse{Code: "AccessDenied"}
+		if IsS3TaggingNotImplemented(err) {
+			t.Fatalf("expected AccessDenied to not be detected as NotImplemented")
+		}
+	})
+
+	t.Run("non s3 error", func(t *testing.T) {
+		err := errors.New("generic error")
+		if IsS3TaggingNotImplemented(err) {
+			t.Fatalf("expected generic error to not be detected as NotImplemented")
+		}
+	})
+}


### PR DESCRIPTION
Addresses the `NotImplemented` errors returned by Hetzner when attempting bucket tagging operations. The solution gracefully ignores these errors instead of throwing fatal errors.

- Resolves #706