### PR TITLE
Fix race condition when creating bucket and dependent resources

### DIFF
--- a/docs/resources/s3_bucket_policy.md
+++ b/docs/resources/s3_bucket_policy.md
@@ -44,9 +44,23 @@ resource "minio_s3_bucket_policy" "example" {
 - `bucket` (String) Name of the bucket
 - `policy` (String) Policy JSON string
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `delete` (String)
+- `read` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/s3_bucket_versioning.md
+++ b/docs/resources/s3_bucket_versioning.md
@@ -30,6 +30,10 @@ resource "minio_s3_bucket_versioning" "example" {
 - `bucket` (String) Name of the bucket
 - `versioning_configuration` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--versioning_configuration))
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
@@ -45,6 +49,17 @@ Optional:
 
 - `exclude_folders` (Boolean)
 - `excluded_prefixes` (List of String)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `delete` (String)
+- `read` (String)
+- `update` (String)
 
 ## Import
 

--- a/minio/resource_minio_s3_bucket_policy.go
+++ b/minio/resource_minio_s3_bucket_policy.go
@@ -3,8 +3,10 @@ package minio
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 )
@@ -17,6 +19,12 @@ func resourceMinioBucketPolicy() *schema.Resource {
 		DeleteContext: minioDeleteBucketPolicy,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"bucket": {
@@ -47,7 +55,33 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucketPolicyConfig.MinioBucket, policy)
 
-	err = bucketPolicyConfig.MinioClient.SetBucketPolicy(ctx, bucketPolicyConfig.MinioBucket, policy)
+	// Wait for bucket to be ready for eventual consistency
+	timeout := d.Timeout(schema.TimeoutCreate)
+	if d.Id() != "" {
+		timeout = d.Timeout(schema.TimeoutUpdate)
+	}
+	// Reserve time for the actual operation
+	waitTimeout := timeout - 30*time.Second
+	if waitTimeout < 30*time.Second {
+		waitTimeout = 30 * time.Second
+	}
+
+	if err := waitForBucketReady(ctx, bucketPolicyConfig.MinioClient, bucketPolicyConfig.MinioBucket, waitTimeout); err != nil {
+		return NewResourceError("error waiting for bucket to be ready", bucketPolicyConfig.MinioBucket, err)
+	}
+
+	// Retry SetBucketPolicy for transient NoSuchBucket errors
+	err = retry.RetryContext(ctx, waitTimeout, func() *retry.RetryError {
+		err := bucketPolicyConfig.MinioClient.SetBucketPolicy(ctx, bucketPolicyConfig.MinioBucket, policy)
+		if err != nil {
+			if isNoSuchBucketError(err) {
+				log.Printf("[DEBUG] Bucket %q not yet available for policy, retrying...", bucketPolicyConfig.MinioBucket)
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 
 	if err != nil {
 		return NewResourceError("error putting bucket policy: %s", policy, err)
@@ -55,7 +89,7 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(bucketPolicyConfig.MinioBucket)
 
-	return nil
+	return minioReadBucketPolicy(ctx, d, meta)
 }
 
 func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -63,8 +97,27 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] S3 bucket policy, read for bucket: %s", d.Id())
 
+	// For new resources, wait for bucket to be ready
+	if d.IsNewResource() {
+		timeout := d.Timeout(schema.TimeoutRead)
+		if err := waitForBucketReady(ctx, bucketPolicyConfig.MinioClient, d.Id(), timeout); err != nil {
+			if isNoSuchBucketError(err) {
+				log.Printf("[WARN] Bucket %s not found after waiting, removing policy resource from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return NewResourceError("error waiting for bucket to be ready", d.Id(), err)
+		}
+	}
+
 	actualPolicyText, err := bucketPolicyConfig.MinioClient.GetBucketPolicy(ctx, d.Id())
 	if err != nil {
+		// Handle bucket not found for existing resources
+		if isNoSuchBucketError(err) && !d.IsNewResource() {
+			log.Printf("[WARN] Bucket %s no longer exists, removing policy resource from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return NewResourceError("failed to load bucket policy", d.Id(), err)
 	}
 


### PR DESCRIPTION
Add retry logic to handle eventual consistency on backends like Hetzner where bucket-dependent resources (versioning, policy) may fail with `NoSuchBucket` errors when created in the same plan as the bucket.

- Fixes #709