### PR TITLE
Add `CustomizeDiff` to support bucket-to-bucket_prefix migration without replacement

### DIFF
--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -245,13 +245,14 @@ Optional:
 - `bandwidth_limit` (String) Maximum bandwidth in byte per second that MinIO can used when syncronysing this target. Minimum is 100MB
 - `disable_proxy` (Boolean) Disable proxy for this target
 - `health_check_period` (String) Period where the health of this target will be checked. This must be a valid duration, such as `5s` or `2m`
-- `path` (String) Path of the Minio endpoint. This is usefull if MinIO API isn't served on at the root, e.g for `example.com/minio/`, the path would be `/minio/`
-- `path_style` (String) Whether to use path-style or virtual-hosted-syle request to this target (https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access). `auto` allows MinIO to chose automatically the appropriate option (Recommened)`
+- `path` (String) Path of the Minio endpoint. This is useful if MinIO API isn't served on at the root, e.g for `example.com/minio/`, the path would be `/minio/`
+- `path_style` (String) Whether to use path-style or virtual-hosted-syle request to this target (https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access). `auto` allows MinIO to chose automatically the appropriate option (Recommended)`
 - `region` (String) Region of the target MinIO. This will be used to generate the target ARN
 - `secret_key` (String, Sensitive) Secret key for the replication service account in the target MinIO. This is optional so it can be imported but prevent secret update
 - `secure` (Boolean) Whether to use HTTPS with this target (Recommended). Note that disabling HTTPS will yield Terraform warning for security reason`
 - `storage_class` (String) The storage class to use for the object on this target
-- `syncronous` (Boolean) Use synchronous replication.
+- `synchronous` (Boolean) Use synchronous replication.
+- `syncronous` (Boolean, Deprecated) Use synchronous replication.
 
 ## Import
 

--- a/examples/resources/minio_s3_bucket/resource.tf
+++ b/examples/resources/minio_s3_bucket/resource.tf
@@ -12,6 +12,18 @@ resource "minio_s3_bucket" "temporary_data" {
   force_destroy = true
 }
 
+# Bucket name prefix (create-only)
+resource "minio_s3_bucket" "customer" {
+  bucket_prefix = "customer-"
+  acl           = "private"
+}
+
+# Bucket name prefix for globally-unique buckets while keeping existing buckets via migration
+resource "minio_s3_bucket" "globally_unique_bucket" {
+  bucket_prefix = "globally-unique-bucket-"
+  acl           = "private"
+}
+
 output "minio_id" {
   value = minio_s3_bucket.state_terraform_s3.id
 }

--- a/templates/resources/s3_bucket.md.tmpl
+++ b/templates/resources/s3_bucket.md.tmpl
@@ -27,6 +27,24 @@ resource "minio_s3_bucket" "data_lake" {
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Notes
+
+- `bucket_prefix` is **create-only**. After a bucket exists in state, changes to `bucket_prefix` are ignored to avoid bucket replacement.
+- During a `bucket` -> `bucket_prefix` migration, `bucket_prefix` may not be persisted in state (it can show up as empty in `terraform state show`) because diffs are suppressed to preserve the existing bucket.
+- A migration from `bucket` to `bucket_prefix` can be done without replacement for an existing bucket when the current bucket name is compatible with the new prefix. For example:
+
+```terraform
+# Existing state
+resource "minio_s3_bucket" "customer" {
+  bucket = var.customer_name
+}
+
+# Migration (keeps existing bucket, new buckets use a generated suffix)
+resource "minio_s3_bucket" "customer" {
+  bucket_prefix = "${var.customer_name}-"
+}
+```
+
 ## Argument Reference
 
 - `tags` - (Optional) A map of tags to assign to the bucket. Tags are key-value pairs that help you organize and categorize your buckets.


### PR DESCRIPTION
### Problem

Some S3 backends (e.g. Hetzner) require bucket names to be globally unique. Users who provision per-customer environments often start with `bucket = var.customer_name`, but later need to switch to `bucket_prefix = "${var.customer_name}-"` so new buckets get a random suffix. Previously, switching to `bucket_prefix` would trigger **ForceNew** and Terraform would attempt to replace the bucket.

### Solution

Add support for migrating `minio_s3_bucket` configuration from bucket to `bucket_prefix` without forcing `bucket` replacement when the existing `bucket` name is compatible with the new prefix (e.g. `bucket="acme"` → `bucket_prefix="acme-"`). This enables using globally-unique bucket names for new customers while keeping existing customer buckets unchanged.

### Impact

- Resolves #746
- Existing buckets can be preserved when switching from bucket to bucket_prefix (no data migration / no replacement).
- New buckets created with bucket_prefix get a generated suffix, reducing collisions on globally-unique backends.

### How to use

```hcl
# Existing state
resource "minio_s3_bucket" "customer" {
  bucket = var.customer_name
}

# Migration (keeps existing bucket, new customers get unique name)
resource "minio_s3_bucket" "customer" {
  bucket_prefix = "${var.customer_name}-"
}
```