### PR TITLE
feat: add docs config to check templates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,21 @@ jobs:
         run: |
           MISSING=0
 
-          # Extract resource names from ResourcesMap in provider.go
-          RESOURCES=$(grep -oP '"minio_\K[^"]+' minio/provider.go | sort)
+          # Extract resource and data source names from ResourcesMap and DataSourcesMap only
+          # Uses sed to isolate the map blocks, then greps for "minio_*" keys
+          RESOURCES=$(sed -n '/ResourcesMap:/,/^[[:space:]]*},$/p' minio/provider.go | grep -oP '"minio_\K[^"]+')
+          DATASOURCES=$(sed -n '/DataSourcesMap:/,/^[[:space:]]*},$/p' minio/provider.go | grep -oP '"minio_\K[^"]+')
 
           for name in $RESOURCES; do
-            if [ ! -f "templates/resources/${name}.md.tmpl" ] && [ ! -f "templates/data-sources/${name}.md.tmpl" ]; then
-              echo "::error::Missing doc template for 'minio_${name}'. Create templates/resources/${name}.md.tmpl or templates/data-sources/${name}.md.tmpl"
+            if [ ! -f "templates/resources/${name}.md.tmpl" ]; then
+              echo "::error::Missing doc template for resource 'minio_${name}'. Create templates/resources/${name}.md.tmpl"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          for name in $DATASOURCES; do
+            if [ ! -f "templates/data-sources/${name}.md.tmpl" ]; then
+              echo "::error::Missing doc template for data source 'minio_${name}'. Create templates/data-sources/${name}.md.tmpl"
               MISSING=$((MISSING + 1))
             fi
           done


### PR DESCRIPTION
# Add Docs CI workflow for template validation and auto-generation

This PR adds a GitHub Actions workflow that:
- Checks that every registered resource and data source has a matching doc template in `templates/`
- Auto-generates provider documentation using `tfplugindocs` and commits updates
- Validates markdown links across the repository

## Reference
- Resolves: #769

## Closing issues
- Closes: #769