### PR TITLE
chore(tests): stop immediately on the first test failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         go mod download
         go mod verify
         echo 'Running tests...'
-        go test -v ./minio $${TEST_PATTERN:+-run $$TEST_PATTERN}
+        go test -v -failfast ./minio $${TEST_PATTERN:+-run $$TEST_PATTERN}
     environment:
       TF_ACC: "1"
       TEST_PATTERN: "${TEST_PATTERN:-}"


### PR DESCRIPTION
This will make us save time during CI workflows.

Note that this is also the command that runs when we execute `task test`.