### PR TITLE
fix(bucket): non-empty plan when skip_bucket_tagging is enabled with tags

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -308,6 +308,7 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 	_ = d.Set("bucket_domain_name", bucketDomainName(d.Id(), bucketURL))
 
 	if shouldSkipBucketTagging(bucketConfig) {
+		preserveBucketTagsState(d)
 		return nil
 	}
 


### PR DESCRIPTION
When `skip_bucket_tagging = true` is set on the provider and a `minio_s3_bucket` resource declares `tags`, the Read function returned early without persisting the configured tags into state. This caused Terraform to detect a diff on every plan/refresh, producing a perpetually non-empty plan.

The fix calls `preserveBucketTagsState(d)` before the early return in `minioReadBucket`, matching the pattern already used in the `minio_s3_bucket_tags` sub-resource.

**Before:** `terraform plan` always showed tags as pending changes even though nothing changed.

**After:** State correctly retains the declared tags when tagging is skipped, resulting in a clean plan.

## Reference

- Resolves: #773 

## Closing issues

- Closes: #773 