### PR TITLE
fix: resolve open Scorecard security alerts (token permissions, vulnerabilities, fuzzing)

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -19,11 +19,13 @@ on:
         default: "patch"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create and push git tags
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.version.outputs.new }}
@@ -107,6 +109,8 @@ jobs:
 
   release:
     needs: create-tag
+    permissions:
+      contents: write  # required by the release workflow to create GitHub releases and upload assets
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.create-tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,13 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create GitHub releases and upload release assets
     timeout-minutes: 30
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}

--- a/minio/fuzz_test.go
+++ b/minio/fuzz_test.go
@@ -1,0 +1,63 @@
+package minio
+
+import (
+	"testing"
+)
+
+// FuzzNormalizeAndCompareJSONPolicies verifies that NormalizeAndCompareJSONPolicies
+// never panics on arbitrary JSON-like input, including malformed documents.
+func FuzzNormalizeAndCompareJSONPolicies(f *testing.F) {
+	// Seed corpus: representative policy documents
+	f.Add(`{"Version":"2012-10-17","Statement":[]}`, `{"Version":"2012-10-17","Statement":[]}`)
+	f.Add(``, `{"Version":"2012-10-17","Statement":[]}`)
+	f.Add(`{}`, `{}`)
+	f.Add(
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":"arn:aws:s3:::bucket/*"}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+	)
+	f.Add(`not-json`, `also-not-json`)
+	f.Add(`{"Version":"2012-10-17"}`, ``)
+
+	f.Fuzz(func(t *testing.T, oldPolicy, newPolicy string) {
+		// Must not panic regardless of input
+		_, _ = NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy)
+	})
+}
+
+// FuzzParseBandwidthLimit verifies that ParseBandwidthLimit never panics on
+// arbitrary bandwidth string values, including malformed ones.
+func FuzzParseBandwidthLimit(f *testing.F) {
+	// Seed corpus: valid and invalid bandwidth strings
+	f.Add("100MB")
+	f.Add("1GB")
+	f.Add("500k")
+	f.Add("0")
+	f.Add("")
+	f.Add("invalid")
+	f.Add("9999999999999999999999TB")
+	f.Add("-1MB")
+
+	f.Fuzz(func(t *testing.T, bandwidthStr string) {
+		target := map[string]any{
+			"bandwidth_limit": bandwidthStr,
+		}
+		// Must not panic regardless of input
+		_, _, _ = ParseBandwidthLimit(target)
+	})
+}
+
+// FuzzHashcodeString verifies that HashcodeString never panics and always
+// returns a non-negative value for any string input.
+func FuzzHashcodeString(f *testing.F) {
+	f.Add("")
+	f.Add("bucket-name")
+	f.Add("arn:aws:iam::123456789012:root")
+	f.Add("\x00\xff\xfe")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		result := HashcodeString(s)
+		if result < 0 {
+			t.Errorf("HashcodeString(%q) returned negative value: %d", s, result)
+		}
+	})
+}

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,7 @@
+[[IgnoredVulns]]
+id = "GO-2022-0635"
+reason = "This vulnerability affects the deprecated AWS S3 Crypto SDK (S3EncryptionClient, in-band key negotiation). This provider does not use the S3 encryption client — only standard S3 API operations are used. Confirmed not reachable by govulncheck."
+
+[[IgnoredVulns]]
+id = "GO-2022-0646"
+reason = "This vulnerability affects the deprecated AWS S3 Crypto SDK (S3EncryptionClient, AES-CBC padding oracle). This provider does not use the S3 encryption client — only standard S3 API operations are used. Confirmed not reachable by govulncheck."


### PR DESCRIPTION
Addresses all open GitHub code scanning alerts from OpenSSF Scorecard:

| Alert | Severity | Status | Fix |
|-------|----------|--------|-----|
| [#83](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/83) – Vulnerabilities (GO-2022-0635, GO-2022-0646) | High | ✅ Fixed in this PR | Add `osv-scanner.toml` to suppress — AWS S3 Crypto SDK not used by this provider |
| [#81](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/81) – Token-Permissions (`release.yml`) | High | ✅ Fixed in this PR | Move `contents: write` from top-level to job-level |
| [#79](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/79) – Token-Permissions (`create-release-tag.yml`) | High | ✅ Fixed in this PR | Move `contents: write` from top-level to job-level |
| [#112](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/112) – Fuzzing | Medium | ✅ Fixed in this PR | Add three Go fuzz targets in `minio/fuzz_test.go` |
| [#127](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/127) – Token-Permissions (`docs.yml`) | High | ✅ Dismissed | `generate-docs` job requires `contents: write` at job level to auto-commit docs; top-level is already `read` — minimum viable permission, dismissed as won't fix |
| [#117](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/117) – CII Best Practices | Low | ✅ Dismissed | Project does not plan to register for an OpenSSF badge |