### PR TITLE
feat: add assume_role support to provider for STS temporary credentials

### DIFF
--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -149,7 +149,7 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		password = getOptionalField(d, "minio_secret_key", "").(string)
 	}
 
-	return &S3MinioConfig{
+	cfg := &S3MinioConfig{
 		S3HostPort:        getOptionalField(d, "minio_server", "").(string),
 		S3Region:          getOptionalField(d, "minio_region", "us-east-1").(string),
 		S3UserAccess:      user,
@@ -163,6 +163,24 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		S3SSLSkipVerify:   getOptionalField(d, "minio_insecure", false).(bool),
 		SkipBucketTagging: getOptionalField(d, "skip_bucket_tagging", false).(bool),
 	}
+
+	if v, ok := d.GetOk("assume_role"); ok {
+		assumeRoleList := v.([]interface{})
+		if len(assumeRoleList) > 0 {
+			ar := assumeRoleList[0].(map[string]interface{})
+			cfg.AssumeRoleARN = ar["role_arn"].(string)
+			cfg.AssumeRoleSessionName = ar["session_name"].(string)
+			cfg.AssumeRoleDuration = ar["duration_seconds"].(int)
+			if p, ok := ar["policy"].(string); ok {
+				cfg.AssumeRolePolicy = p
+			}
+			if e, ok := ar["external_id"].(string); ok {
+				cfg.AssumeRoleExternalID = e
+			}
+		}
+	}
+
+	return cfg
 }
 
 // ServiceAccountConfig creates configuration for MinIO service accounts.

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -39,6 +39,31 @@ func (config *S3MinioConfig) NewClient() (interface{}, error) {
 		return nil, fmt.Errorf("unsupported S3 API signature version %q: must be v2 or v4", config.S3APISignature)
 	}
 
+	if config.AssumeRoleARN != "" || config.AssumeRoleSessionName != "" {
+		scheme := "http"
+		if config.S3SSL {
+			scheme = "https"
+		}
+		stsEndpoint := fmt.Sprintf("%s://%s", scheme, config.S3HostPort)
+
+		stsCreds, err := credentials.NewSTSAssumeRole(stsEndpoint, credentials.STSAssumeRoleOptions{
+			AccessKey:       config.S3UserAccess,
+			SecretKey:       config.S3UserSecret,
+			SessionToken:    config.S3SessionToken,
+			RoleARN:         config.AssumeRoleARN,
+			RoleSessionName: config.AssumeRoleSessionName,
+			DurationSeconds: config.AssumeRoleDuration,
+			Policy:          config.AssumeRolePolicy,
+			ExternalID:      config.AssumeRoleExternalID,
+			Location:        config.S3Region,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to assume role: %w", err)
+		}
+		minioCredentials = stsCreds
+		log.Printf("[DEBUG] Using STS AssumeRole credentials (role=%s, session=%s)", config.AssumeRoleARN, config.AssumeRoleSessionName)
+	}
+
 	// Initialize S3 client
 	minioClient, err := minio.New(config.S3HostPort, &minio.Options{
 		Creds:     minioCredentials,

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -25,6 +25,12 @@ type S3MinioConfig struct {
 	S3SSLKeyFile      string
 	S3SSLSkipVerify   bool
 	SkipBucketTagging bool
+
+	AssumeRoleARN         string
+	AssumeRoleSessionName string
+	AssumeRoleDuration    int
+	AssumeRolePolicy      string
+	AssumeRoleExternalID  string
 }
 
 // S3MinioClient defines default minio

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -145,6 +145,44 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 					prefix + "MINIO_SKIP_BUCKET_TAGGING",
 				}, false),
 			},
+			"assume_role": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Use STS AssumeRole to obtain temporary credentials. When configured, the provider exchanges the static credentials for short-lived session credentials.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_arn": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "ARN of the role to assume.",
+							DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_ASSUME_ROLE_ARN", ""),
+						},
+						"session_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "terraform",
+							Description: "Session name for the assumed role.",
+						},
+						"duration_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3600,
+							Description: "Duration in seconds for the session (default: 3600).",
+						},
+						"policy": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "IAM policy in JSON format to scope down the assumed role permissions.",
+						},
+						"external_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "External ID for cross-account role assumption.",
+						},
+					},
+				},
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Add an optional assume_role block to the provider configuration that exchanges static credentials for short-lived STS session credentials via MinIO's AssumeRole API. Supports role_arn, session_name, duration, scoped policy, and external_id.

Disabled by default — existing configurations are unaffected. When the assume_role block is present, the provider calls credentials.NewSTSAssumeRole before creating the S3/admin clients.