### PR TITLE
test: add import tests for iam_user, ilm_policy, bucket_retention, user_group_membership

### DIFF
--- a/minio/resource_minio_iam_user_group_membership_test.go
+++ b/minio/resource_minio_iam_user_group_membership_test.go
@@ -24,6 +24,11 @@ func TestAccMinioIAMUserGroupMembership_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("minio_iam_user_group_membership.test", "groups.#", "2"),
 				),
 			},
+			{
+				ResourceName:      "minio_iam_user_group_membership.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/minio/resource_minio_iam_user_test.go
+++ b/minio/resource_minio_iam_user_test.go
@@ -74,6 +74,12 @@ func TestAccAWSUser_basic(t *testing.T) {
 					testAccCheckMinioUserAttributes(resourceName, name, status),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret", "update_secret", "disable_user", "force_destroy"},
+			},
 		},
 	})
 }

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -32,6 +32,11 @@ func TestAccILMPolicy_basic(t *testing.T) {
 					testAccCheckMinioLifecycleConfigurationValid(&lifecycleConfig),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/minio/resource_minio_s3_bucket_retention_test.go
+++ b/minio/resource_minio_s3_bucket_retention_test.go
@@ -29,6 +29,11 @@ func TestAccMinioBucketRetention_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validity_period", "30"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Add ImportState steps to existing acceptance tests that were missing import coverage. Verifies that terraform import works correctly for these resources.