### PR TITLE
feat: add assume_role_with_web_identity and document STS auth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,71 @@ The following arguments are supported in the `provider` block:
 
 * `skip_bucket_tagging` - (Optional) Skip bucket tagging API calls. Useful when your S3-compatible endpoint does not support tagging (default: `false`). Can be sourced from `MINIO_SKIP_BUCKET_TAGGING`.
 
+* `assume_role` - (Optional) Configuration block for STS AssumeRole. See [Assume Role](#assume-role) below.
+
+* `assume_role_with_web_identity` - (Optional) Configuration block for OIDC-based authentication. See [Web Identity](#assume-role-with-web-identity) below.
+
+## Assume Role
+
+Use `assume_role` to exchange static credentials for short-lived STS session credentials:
+
+```terraform
+provider "minio" {
+  minio_server   = "minio.example.com"
+  minio_user     = var.access_key
+  minio_password = var.secret_key
+  minio_ssl      = true
+
+  assume_role {
+    role_arn         = "arn:minio:iam:::role/terraform"
+    session_name     = "terraform"
+    duration_seconds = 3600
+  }
+}
+```
+
+### Assume Role Arguments
+
+* `role_arn` - (Optional) ARN of the role to assume. Can be sourced from `MINIO_ASSUME_ROLE_ARN`.
+* `session_name` - (Optional) Session name (default: `terraform`).
+* `duration_seconds` - (Optional) Session duration in seconds (default: `3600`).
+* `policy` - (Optional) IAM policy JSON to scope down permissions.
+* `external_id` - (Optional) External ID for cross-account assumption.
+
+## Assume Role with Web Identity
+
+Use `assume_role_with_web_identity` for passwordless authentication with OIDC tokens from CI/CD platforms like GitHub Actions or GitLab CI:
+
+```terraform
+provider "minio" {
+  minio_server = "minio.example.com"
+  minio_ssl    = true
+
+  assume_role_with_web_identity {
+    web_identity_token = var.oidc_token
+  }
+}
+```
+
+Or using a token file (common in Kubernetes):
+
+```terraform
+provider "minio" {
+  minio_server = "minio.example.com"
+  minio_ssl    = true
+
+  assume_role_with_web_identity {
+    web_identity_token_file = "/var/run/secrets/tokens/minio"
+  }
+}
+```
+
+### Web Identity Arguments
+
+* `web_identity_token` - (Optional, Sensitive) OIDC/JWT token. Can be sourced from `MINIO_WEB_IDENTITY_TOKEN`.
+* `web_identity_token_file` - (Optional) Path to token file. Can be sourced from `MINIO_WEB_IDENTITY_TOKEN_FILE`.
+* `duration_seconds` - (Optional) Session duration in seconds (default: `3600`).
+
 ## LDAP Integration
 
 This provider supports attaching IAM policies to LDAP users and groups. Before using LDAP resources, ensure your MinIO server is configured with LDAP authentication.

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -180,6 +180,16 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		}
 	}
 
+	if v, ok := d.GetOk("assume_role_with_web_identity"); ok {
+		wiList := v.([]interface{})
+		if len(wiList) > 0 {
+			wi := wiList[0].(map[string]interface{})
+			cfg.WebIdentityToken = wi["web_identity_token"].(string)
+			cfg.WebIdentityTokenFile = wi["web_identity_token_file"].(string)
+			cfg.WebIdentityDuration = wi["duration_seconds"].(int)
+		}
+	}
+
 	return cfg
 }
 

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -64,6 +64,36 @@ func (config *S3MinioConfig) NewClient() (interface{}, error) {
 		log.Printf("[DEBUG] Using STS AssumeRole credentials (role=%s, session=%s)", config.AssumeRoleARN, config.AssumeRoleSessionName)
 	}
 
+	if config.WebIdentityToken != "" || config.WebIdentityTokenFile != "" {
+		scheme := "http"
+		if config.S3SSL {
+			scheme = "https"
+		}
+		stsEndpoint := fmt.Sprintf("%s://%s", scheme, config.S3HostPort)
+
+		getToken := func() (*credentials.WebIdentityToken, error) {
+			token := config.WebIdentityToken
+			if token == "" && config.WebIdentityTokenFile != "" {
+				data, err := os.ReadFile(config.WebIdentityTokenFile)
+				if err != nil {
+					return nil, fmt.Errorf("reading web identity token file: %w", err)
+				}
+				token = string(data)
+			}
+			return &credentials.WebIdentityToken{
+				Token:  token,
+				Expiry: config.WebIdentityDuration,
+			}, nil
+		}
+
+		wiCreds, err := credentials.NewSTSWebIdentity(stsEndpoint, getToken)
+		if err != nil {
+			return nil, fmt.Errorf("failed to assume role with web identity: %w", err)
+		}
+		minioCredentials = wiCreds
+		log.Printf("[DEBUG] Using STS WebIdentity credentials")
+	}
+
 	// Initialize S3 client
 	minioClient, err := minio.New(config.S3HostPort, &minio.Options{
 		Creds:     minioCredentials,

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -31,6 +31,10 @@ type S3MinioConfig struct {
 	AssumeRoleDuration    int
 	AssumeRolePolicy      string
 	AssumeRoleExternalID  string
+
+	WebIdentityToken     string
+	WebIdentityTokenFile string
+	WebIdentityDuration  int
 }
 
 // S3MinioClient defines default minio

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -183,6 +183,35 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 					},
 				},
 			},
+			"assume_role_with_web_identity": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Use STS AssumeRoleWithWebIdentity to obtain credentials from an OIDC token (e.g., GitHub Actions, GitLab CI).",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"web_identity_token": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: "OIDC/JWT token for web identity authentication.",
+							DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_WEB_IDENTITY_TOKEN", ""),
+						},
+						"web_identity_token_file": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Path to a file containing the OIDC/JWT token.",
+							DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_WEB_IDENTITY_TOKEN_FILE", ""),
+						},
+						"duration_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3600,
+							Description: "Duration in seconds for the session (default: 3600).",
+						},
+					},
+				},
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -100,6 +100,71 @@ The following arguments are supported in the `provider` block:
 
 * `skip_bucket_tagging` - (Optional) Skip bucket tagging API calls. Useful when your S3-compatible endpoint does not support tagging (default: `false`). Can be sourced from `MINIO_SKIP_BUCKET_TAGGING`.
 
+* `assume_role` - (Optional) Configuration block for STS AssumeRole. See [Assume Role](#assume-role) below.
+
+* `assume_role_with_web_identity` - (Optional) Configuration block for OIDC-based authentication. See [Web Identity](#assume-role-with-web-identity) below.
+
+## Assume Role
+
+Use `assume_role` to exchange static credentials for short-lived STS session credentials:
+
+```terraform
+provider "minio" {
+  minio_server   = "minio.example.com"
+  minio_user     = var.access_key
+  minio_password = var.secret_key
+  minio_ssl      = true
+
+  assume_role {
+    role_arn         = "arn:minio:iam:::role/terraform"
+    session_name     = "terraform"
+    duration_seconds = 3600
+  }
+}
+```
+
+### Assume Role Arguments
+
+* `role_arn` - (Optional) ARN of the role to assume. Can be sourced from `MINIO_ASSUME_ROLE_ARN`.
+* `session_name` - (Optional) Session name (default: `terraform`).
+* `duration_seconds` - (Optional) Session duration in seconds (default: `3600`).
+* `policy` - (Optional) IAM policy JSON to scope down permissions.
+* `external_id` - (Optional) External ID for cross-account assumption.
+
+## Assume Role with Web Identity
+
+Use `assume_role_with_web_identity` for passwordless authentication with OIDC tokens from CI/CD platforms like GitHub Actions or GitLab CI:
+
+```terraform
+provider "minio" {
+  minio_server = "minio.example.com"
+  minio_ssl    = true
+
+  assume_role_with_web_identity {
+    web_identity_token = var.oidc_token
+  }
+}
+```
+
+Or using a token file (common in Kubernetes):
+
+```terraform
+provider "minio" {
+  minio_server = "minio.example.com"
+  minio_ssl    = true
+
+  assume_role_with_web_identity {
+    web_identity_token_file = "/var/run/secrets/tokens/minio"
+  }
+}
+```
+
+### Web Identity Arguments
+
+* `web_identity_token` - (Optional, Sensitive) OIDC/JWT token. Can be sourced from `MINIO_WEB_IDENTITY_TOKEN`.
+* `web_identity_token_file` - (Optional) Path to token file. Can be sourced from `MINIO_WEB_IDENTITY_TOKEN_FILE`.
+* `duration_seconds` - (Optional) Session duration in seconds (default: `3600`).
+
 ## LDAP Integration
 
 This provider supports attaching IAM policies to LDAP users and groups. Before using LDAP resources, ensure your MinIO server is configured with LDAP authentication.


### PR DESCRIPTION
Add OIDC-based authentication via assume_role_with_web_identity for passwordless CI/CD (GitHub Actions, GitLab CI, Kubernetes). Supports both inline tokens and token files.

Update provider documentation with examples for both assume_role and assume_role_with_web_identity authentication methods.