### PR TITLE
refactor: migrate deprecated InfoCannedPolicy and SetPolicy APIs

### DIFF
--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -167,7 +167,10 @@ func minioDeleteGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	if len(groupDesc.Policy) == 0 {
 		//delete group requires to set policy if it doesn't exist
-		_ = iamGroupConfig.MinioAdmin.SetPolicy(ctx, "readonly", d.Id(), true)
+		_, _ = iamGroupConfig.MinioAdmin.AttachPolicy(ctx, madmin.PolicyAssociationReq{
+			Policies: []string{"readonly"},
+			Group:    d.Id(),
+		})
 
 	}
 

--- a/minio/resource_minio_iam_group_policy.go
+++ b/minio/resource_minio_iam_group_policy.go
@@ -94,8 +94,8 @@ func minioReadGroupPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] Getting IAM Group Policy: %s", d.Id())
 
-	output, err := iAMGroupPolicyConfig.MinioAdmin.InfoCannedPolicy(ctx, policyName)
-	if output == nil {
+	info, err := iAMGroupPolicyConfig.MinioAdmin.InfoCannedPolicyV2(ctx, policyName)
+	if info == nil {
 		log.Printf("[WARN] No IAM group policy by name (%s) found, removing from state: %s", d.Id(), err)
 		d.SetId("")
 		return nil
@@ -105,7 +105,7 @@ func minioReadGroupPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 		return NewResourceError("[FATAL] Reading group policies failed", d.Id(), err)
 	}
 
-	if err := d.Set("policy", strings.TrimSpace(string(output))); err != nil {
+	if err := d.Set("policy", strings.TrimSpace(string(info.Policy))); err != nil {
 		return NewResourceError("[FATAL] Reading group policies failed", d.Id(), err)
 	}
 
@@ -144,8 +144,8 @@ func minioDeleteGroupPolicy(ctx context.Context, d *schema.ResourceData, meta in
 		return NewResourceError("[FATAL] Reading group policies failed", d.Id(), err)
 	}
 
-	policy, _ := iamPolicyConfig.MinioAdmin.InfoCannedPolicy(ctx, policyName)
-	if policy == nil {
+	info, _ := iamPolicyConfig.MinioAdmin.InfoCannedPolicyV2(ctx, policyName)
+	if info == nil {
 		return nil
 	}
 

--- a/minio/resource_minio_iam_group_policy_attachment.go
+++ b/minio/resource_minio_iam_group_policy_attachment.go
@@ -58,7 +58,10 @@ func minioCreateGroupPolicyAttachment(ctx context.Context, d *schema.ResourceDat
 	if !Contains(policies, policyName) {
 		log.Printf("[DEBUG] Attaching policy %s to group: %s", policyName, groupName)
 		policies = append(policies, policyName)
-		err := minioAdmin.SetPolicy(ctx, strings.Join(policies, ","), groupName, true)
+		_, err := minioAdmin.AttachPolicy(ctx, madmin.PolicyAssociationReq{
+			Policies: policies,
+			Group:    groupName,
+		})
 		if err != nil {
 			return NewResourceError("unable to attach group policy", groupName+" "+policyName, err)
 		}
@@ -116,7 +119,10 @@ func minioDeleteGroupPolicyAttachment(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	errIam := minioAdmin.SetPolicy(ctx, strings.Join(newPolicies, ","), groupName, true)
+	_, errIam := minioAdmin.AttachPolicy(ctx, madmin.PolicyAssociationReq{
+		Policies: newPolicies,
+		Group:    groupName,
+	})
 	if errIam != nil {
 		return NewResourceError("unable to delete user policy", groupName, errIam)
 	}

--- a/minio/resource_minio_iam_group_policy_test.go
+++ b/minio/resource_minio_iam_group_policy_test.go
@@ -206,7 +206,7 @@ func testAccCheckIAMGroupPolicyDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if output, _ := conn.InfoCannedPolicy(context.Background(), name); output != nil {
+		if info, _ := conn.InfoCannedPolicyV2(context.Background(), name); info != nil {
 			return fmt.Errorf("found IAM group policy, expected none %s: %s", name, err)
 
 		}
@@ -231,7 +231,7 @@ func testAccCheckIAMGroupPolicyDisappears(
 			return err
 		}
 
-		if output, _ := iamconn.InfoCannedPolicy(context.Background(), name); output != nil {
+		if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), name); info != nil {
 			err = iamconn.RemoveCannedPolicy(context.Background(), name)
 			if err != nil {
 				return err

--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -88,7 +88,7 @@ func minioReadPolicy(ctx context.Context, d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Getting IAM Policy: %s", d.Id())
 
-	output, err := iamPolicyConfig.MinioAdmin.InfoCannedPolicy(ctx, d.Id())
+	info, err := iamPolicyConfig.MinioAdmin.InfoCannedPolicyV2(ctx, d.Id())
 	if err != nil {
 		errResp := madmin.ErrorResponse{}
 		if errors.As(err, &errResp) {
@@ -106,7 +106,7 @@ func minioReadPolicy(ctx context.Context, d *schema.ResourceData, meta interface
 		return NewResourceError("setting policy name", d.Id(), err)
 	}
 
-	actualPolicyText := strings.TrimSpace(string(output))
+	actualPolicyText := strings.TrimSpace(string(info.Policy))
 	existingPolicy := ""
 	if v, ok := d.GetOk("policy"); ok {
 		existingPolicy = v.(string)

--- a/minio/resource_minio_iam_policy_test.go
+++ b/minio/resource_minio_iam_policy_test.go
@@ -229,7 +229,7 @@ func testAccCheckMinioIAMPolicyExists(resource string) resource.TestCheckFunc {
 
 		iamconn := testAccProvider.Meta().(*S3MinioClient).S3Admin
 
-		_, err := iamconn.InfoCannedPolicy(context.Background(), rs.Primary.ID)
+		_, err := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID)
 		return err
 	}
 }
@@ -242,7 +242,7 @@ func testAccCheckMinioIAMPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if output, _ := iamconn.InfoCannedPolicy(context.Background(), rs.Primary.ID); output != nil {
+		if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID); info != nil {
 			return fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID)
 		}
 
@@ -255,7 +255,7 @@ func testAccCheckMinioIAMPolicyDisappears(resource string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		iamconn := testAccProvider.Meta().(*S3MinioClient).S3Admin
 
-		if output, _ := iamconn.InfoCannedPolicy(context.Background(), resource); output == nil {
+		if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), resource); info == nil {
 
 			if err := iamconn.RemoveCannedPolicy(context.Background(), resource); err != nil {
 				return err

--- a/minio/resource_minio_iam_user_policy_attachment.go
+++ b/minio/resource_minio_iam_user_policy_attachment.go
@@ -58,7 +58,10 @@ func minioCreateUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 	if !Contains(policies, policyName) {
 		policies = append(policies, policyName)
 		log.Printf("[DEBUG] Attaching policy %s to user: %s (%v)", policyName, userName, policies)
-		err := minioAdmin.SetPolicy(ctx, strings.Join(policies, ","), userName, false)
+		_, err := minioAdmin.AttachPolicy(ctx, madmin.PolicyAssociationReq{
+			Policies: policies,
+			User:     userName,
+		})
 		if err != nil {
 			return NewResourceError("unable to Set User policy", userName+" "+policyName, err)
 		}
@@ -118,7 +121,10 @@ func minioDeleteUserPolicyAttachment(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[DEBUG] Detaching policy %s from user: %s (%v)", policyName, userName, newPolicies)
-	errIam := minioAdmin.SetPolicy(ctx, strings.Join(newPolicies, ","), userName, false)
+	_, errIam := minioAdmin.AttachPolicy(ctx, madmin.PolicyAssociationReq{
+		Policies: newPolicies,
+		User:     userName,
+	})
 	if errIam != nil {
 		return NewResourceError("unable to delete user policy", userName, errIam)
 	}


### PR DESCRIPTION
Replace all 11 deprecated madmin-go API calls:

- InfoCannedPolicy → InfoCannedPolicyV2 (returns *PolicyInfo instead of []byte)
- SetPolicy → AttachPolicy with PolicyAssociationReq (uses explicit User/Group fields instead of isGroup bool)

Zero deprecated API warnings remaining (excluding aws-sdk-go v1).