### PR TITLE
refactor: remove aws-sdk-go v1 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 toolchain go1.24.13
 
 require (
-	github.com/aws/aws-sdk-go v1.55.8
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/awspolicyequivalence v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
 github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
@@ -116,8 +114,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -223,7 +223,7 @@ type S3MinioIAMGroupAttachmentConfig struct {
 type S3MinioIAMGroupMembershipConfig struct {
 	MinioAdmin    *madmin.AdminClient
 	MinioIAMName  string
-	MinioIAMUsers []*string
+	MinioIAMUsers []string
 	MinioIAMGroup string
 }
 

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -183,7 +182,7 @@ func minioCreateAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 		return NewResourceError("creating access key", user, err)
 	}
 
-	d.SetId(aws.StringValue(&creds.AccessKey))
+	d.SetId(creds.AccessKey)
 	_ = d.Set("access_key", creds.AccessKey)
 
 	timeout := d.Timeout(schema.TimeoutCreate)

--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v3"
@@ -76,7 +75,7 @@ func minioCreateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 		return NewResourceError("error updating IAM Group %s: %s", d.Id(), err)
 	}
 
-	d.SetId(aws.StringValue(&iamGroupConfig.MinioIAMName))
+	d.SetId(iamGroupConfig.MinioIAMName)
 
 	return minioReadGroup(ctx, d, meta)
 }

--- a/minio/resource_minio_iam_group_membership.go
+++ b/minio/resource_minio_iam_group_membership.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v3"
 )
@@ -52,7 +50,7 @@ func minioCreateGroupMembership(ctx context.Context, d *schema.ResourceData, met
 
 	groupAddRemove := madmin.GroupAddRemove{
 		Group:    iamGroupMembershipConfig.MinioIAMGroup,
-		Members:  aws.StringValueSlice(iamGroupMembershipConfig.MinioIAMUsers),
+		Members:  iamGroupMembershipConfig.MinioIAMUsers,
 		IsRemove: false,
 	}
 
@@ -140,7 +138,7 @@ func minioDeleteGroupMembership(ctx context.Context, d *schema.ResourceData, met
 
 	groupAddRemove := madmin.GroupAddRemove{
 		Group:    iamGroupMembershipConfig.MinioIAMGroup,
-		Members:  aws.StringValueSlice(iamGroupMembershipConfig.MinioIAMUsers),
+		Members:  iamGroupMembershipConfig.MinioIAMUsers,
 		IsRemove: true,
 	}
 
@@ -152,14 +150,14 @@ func minioDeleteGroupMembership(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func userToADD(ctx context.Context, iamGroupMembershipConfig *S3MinioIAMGroupMembershipConfig, usersToAdd []*string) error {
+func userToADD(ctx context.Context, iamGroupMembershipConfig *S3MinioIAMGroupMembershipConfig, usersToAdd []string) error {
 	var users []string
 
 	groupDesc, _ := iamGroupMembershipConfig.MinioAdmin.GetGroupDescription(ctx, iamGroupMembershipConfig.MinioIAMGroup)
 
-	log.Printf("[WARN] Users to add before: %v and after: %v", groupDesc.Members, aws.StringValueSlice(usersToAdd))
+	log.Printf("[WARN] Users to add before: %v and after: %v", groupDesc.Members, usersToAdd)
 
-	users = append(groupDesc.Members, aws.StringValueSlice(usersToAdd)...)
+	users = append(groupDesc.Members, usersToAdd...)
 
 	groupAddRemove := madmin.GroupAddRemove{
 		Group:    iamGroupMembershipConfig.MinioIAMGroup,
@@ -175,11 +173,11 @@ func userToADD(ctx context.Context, iamGroupMembershipConfig *S3MinioIAMGroupMem
 	return nil
 }
 
-func userToRemove(ctx context.Context, iamGroupMembershipConfig *S3MinioIAMGroupMembershipConfig, usersToRemove []*string) error {
+func userToRemove(ctx context.Context, iamGroupMembershipConfig *S3MinioIAMGroupMembershipConfig, usersToRemove []string) error {
 
 	groupAddRemove := madmin.GroupAddRemove{
 		Group:    iamGroupMembershipConfig.MinioIAMGroup,
-		Members:  aws.StringValueSlice(usersToRemove),
+		Members:  usersToRemove,
 		IsRemove: true,
 	}
 

--- a/minio/resource_minio_iam_group_policy_test.go
+++ b/minio/resource_minio_iam_group_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -273,7 +272,7 @@ func testAccCheckIAMGroupPolicyExists(
 
 func testAccCheckMinioIAMGroupPolicyNameChanged(i, j *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(i) == aws.StringValue(j) {
+		if *i == *j {
 			return fmt.Errorf("the IAM Group Policy name did not change %s to %s", *i, *j)
 		}
 
@@ -283,7 +282,7 @@ func testAccCheckMinioIAMGroupPolicyNameChanged(i, j *string) resource.TestCheck
 
 func testAccCheckMinioIAMGroupPolicyNameExists(i *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(i) == "" {
+		if *i == "" {
 			return errors.New("the IAM Group Policy name does not exist")
 		}
 

--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/minio/madmin-go/v3"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -77,7 +76,7 @@ func minioCreatePolicy(ctx context.Context, d *schema.ResourceData, meta interfa
 		return NewResourceError("unable to create policy", name, err)
 	}
 
-	d.SetId(aws.StringValue(&name))
+	d.SetId(name)
 
 	return minioReadPolicy(ctx, d, meta)
 }

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v3"
 )
@@ -91,7 +90,7 @@ func minioCreateUser(ctx context.Context, d *schema.ResourceData, meta interface
 		return NewResourceError("error creating user", accessKey, err)
 	}
 
-	d.SetId(aws.StringValue(&accessKey))
+	d.SetId(accessKey)
 	_ = d.Set("secret", secretKey)
 
 	if iamUserConfig.MinioDisableUser {

--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,7 +38,7 @@ func minioCreateKMSKey(ctx context.Context, d *schema.ResourceData, meta interfa
 		return NewResourceError("error creating service account", keyID, err)
 	}
 
-	d.SetId(aws.StringValue(&keyID))
+	d.SetId(keyID)
 	_ = d.Set("key_id", d.Id())
 
 	return minioReadKMSKey(ctx, d, meta)

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -121,7 +120,7 @@ func minioCreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	accessKey := serviceAccount.AccessKey
 	secretKey := serviceAccount.SecretKey
 
-	d.SetId(aws.StringValue(&accessKey))
+	d.SetId(accessKey)
 	_ = d.Set("access_key", accessKey)
 	_ = d.Set("secret_key", secretKey)
 

--- a/minio/utils.go
+++ b/minio/utils.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/dustin/go-humanize"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -49,15 +48,14 @@ func Encode(value []byte) []byte {
 }
 
 // getStringList get array of strings
-func getStringList(listString []interface{}) []*string {
-	arrayString := make([]*string, 0, len(listString))
+func getStringList(listString []interface{}) []string {
+	var result []string
 	for _, v := range listString {
-		value, ret := v.(string)
-		if ret && value != "" {
-			arrayString = append(arrayString, aws.String(v.(string)))
+		if s, ok := v.(string); ok && s != "" {
+			result = append(result, s)
 		}
 	}
-	return arrayString
+	return result
 }
 
 // Contains check that an array has the given element


### PR DESCRIPTION
Replace all aws.StringValue, aws.StringValueSlice, and aws.String calls with plain Go equivalents. Change MinioIAMUsers from []*string to []string. Rewrite getStringList to return []string.

The aws-sdk-go v1 package (deprecated July 2025) is no longer a direct dependency.
