### PR TITLE
fix(bucket): handle eventual consistency race conditions in bucket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,17 @@ variable "minio_password" {
 
 ## Testing
 
-For testing locally, run the docker compose to spin up a minio server:
+The project uses Docker Compose to run acceptance tests against multiple MinIO instances. Docker is required.
 
-```sh
-docker compose up
-```
+### Running Tests
 
-To run the acceptance tests:
+**Run all acceptance tests:**
 
 ```sh
 docker compose run --rm test
 ```
 
-Run a specific test by name pattern:
+**Run specific tests by pattern:**
 
 ```sh
 TEST_PATTERN=TestAccAWSUser_SettingAccessKey docker compose run --rm test

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -202,11 +202,31 @@ func minioCreateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 	_ = d.Set("bucket", bucket)
 	d.SetId(bucket)
 
+	timeout := d.Timeout(schema.TimeoutCreate)
+	waitTimeout := timeout - 30*time.Second
+	if waitTimeout < 30*time.Second {
+		waitTimeout = 30 * time.Second
+	}
+
+	if err := waitForBucketReady(ctx, bucketConfig.MinioClient, bucket, waitTimeout); err != nil {
+		return NewResourceError("error waiting for bucket to be ready after creation", bucket, err)
+	}
+
 	bucketConfig = BucketConfig(d, meta)
 
-	if errACL := minioSetBucketACL(ctx, bucketConfig); errACL != nil {
-		log.Printf("%s", NewResourceErrorStr("unable to create bucket", bucket, errACL))
-		return NewResourceError("[ACL] Unable to create bucket", bucket, errACL)
+	if err := retry.RetryContext(ctx, waitTimeout, func() *retry.RetryError {
+		if errACL := minioSetBucketACL(ctx, bucketConfig); errACL != nil {
+			for _, d := range errACL {
+				if strings.Contains(d.Summary, "NoSuchBucket") || strings.Contains(d.Summary, "does not exist") {
+					log.Printf("[DEBUG] Bucket %q not yet available for ACL, retrying...", bucket)
+					return retry.RetryableError(fmt.Errorf("%s", d.Summary))
+				}
+			}
+			return retry.NonRetryableError(fmt.Errorf("%s", errACL[0].Summary))
+		}
+		return nil
+	}); err != nil {
+		return NewResourceError("[ACL] Unable to create bucket", bucket, err)
 	}
 
 	log.Printf("[DEBUG] Created bucket: [%s] in region: [%s]", bucket, region)
@@ -220,19 +240,22 @@ func minioCreateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 			return NewResourceError("error creating bucket tags", bucket, err)
 		}
 
-		err = bucketConfig.MinioClient.SetBucketTagging(ctx, bucket, bucketTags)
-		if err != nil {
-			if !IsS3TaggingNotImplemented(err) {
-				return NewResourceError("error setting bucket tags", bucket, err)
+		if err := retry.RetryContext(ctx, waitTimeout, func() *retry.RetryError {
+			err := bucketConfig.MinioClient.SetBucketTagging(ctx, bucket, bucketTags)
+			if err != nil {
+				if IsS3TaggingNotImplemented(err) {
+					return nil
+				}
+				if isNoSuchBucketError(err) {
+					log.Printf("[DEBUG] Bucket %q not yet available for tagging, retrying...", bucket)
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
 			}
+			return nil
+		}); err != nil {
+			return NewResourceError("error setting bucket tags", bucket, err)
 		}
-	}
-
-	found, err := bucketConfig.MinioClient.BucketExists(ctx, bucket)
-	if err != nil {
-		log.Printf("[WARNING] Error verifying bucket creation: %s", err)
-	} else if !found {
-		log.Printf("[WARNING] Bucket [%s] not immediately visible after creation, proceeding anyway", bucket)
 	}
 
 	return minioUpdateBucket(ctx, d, meta)
@@ -582,6 +605,10 @@ func removeBucketPolicy(ctx context.Context, bucketConfig *S3MinioBucket) diag.D
 		errResp := minio.ToErrorResponse(err)
 
 		if errResp.Code == "NoSuchBucketPolicy" || errResp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+
+		if isNoSuchBucketError(err) {
 			return nil
 		}
 

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -1274,6 +1274,84 @@ func testAccCheckMinioS3BucketTagsRemoved(n string) resource.TestCheckFunc {
 	}
 }
 
+func TestIsCredentialError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errResp  minio.ErrorResponse
+		expected bool
+	}{
+		{
+			name:     "empty error response",
+			errResp:  minio.ErrorResponse{},
+			expected: false,
+		},
+		{
+			name: "AccessDenied error code",
+			errResp: minio.ErrorResponse{
+				Code:       "AccessDenied",
+				StatusCode: http.StatusForbidden,
+			},
+			expected: true,
+		},
+		{
+			name: "InvalidAccessKeyId error code",
+			errResp: minio.ErrorResponse{
+				Code:       "InvalidAccessKeyId",
+				StatusCode: http.StatusForbidden,
+			},
+			expected: true,
+		},
+		{
+			name: "SignatureDoesNotMatch error code",
+			errResp: minio.ErrorResponse{
+				Code:       "SignatureDoesNotMatch",
+				StatusCode: http.StatusForbidden,
+			},
+			expected: true,
+		},
+		{
+			name: "ExpiredToken error code",
+			errResp: minio.ErrorResponse{
+				Code: "ExpiredToken",
+			},
+			expected: true,
+		},
+		{
+			name: "403 status without known code",
+			errResp: minio.ErrorResponse{
+				Code:       "SomeUnknownCode",
+				StatusCode: http.StatusForbidden,
+			},
+			expected: true,
+		},
+		{
+			name: "NoSuchBucket is not a credential error",
+			errResp: minio.ErrorResponse{
+				Code:       "NoSuchBucket",
+				StatusCode: http.StatusNotFound,
+			},
+			expected: false,
+		},
+		{
+			name: "500 server error is not a credential error",
+			errResp: minio.ErrorResponse{
+				Code:       "InternalError",
+				StatusCode: http.StatusInternalServerError,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCredentialError(tt.errResp)
+			if result != tt.expected {
+				t.Errorf("isCredentialError(%v) = %v, want %v", tt.errResp, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsNoSuchBucketError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1337,6 +1415,66 @@ func TestIsNoSuchBucketError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAccMinioS3Bucket_withPolicyAndVersioning(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioS3BucketWithPolicyAndVersioning(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+					testAccCheckBucketHasVersioning(
+						"minio_s3_bucket_versioning.bucket",
+						S3MinioBucketVersioningConfiguration{
+							Status: "Enabled",
+						},
+					),
+					resource.TestCheckResourceAttr("minio_s3_bucket.bucket", "acl", "private"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMinioS3BucketWithPolicyAndVersioning(bucketName string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+  acl    = "private"
+}
+
+resource "minio_s3_bucket_policy" "bucket" {
+  bucket = minio_s3_bucket.bucket.bucket
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Resource": [
+        "${minio_s3_bucket.bucket.arn}"
+      ],
+      "Action": ["s3:ListBucket"]
+    }
+  ]
+}
+EOF
+}
+
+resource "minio_s3_bucket_versioning" "bucket" {
+  bucket = minio_s3_bucket.bucket.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+`, bucketName)
 }
 
 func testAccMinioS3BucketConfigWithBucket(bucketName string) string {


### PR DESCRIPTION
Fixes intermittent failures when creating multiple S3 resources (bucket, policy, versioning) together on cloud storage providers like Hetzner. The issue occurred because newly created buckets weren't immediately ready for additional operations.
 
- Resolves #839 by waiting for bucket to be fully available before proceeding with policies/versioning and retrying operations that fail due to timing issues
- Update `readme.md` as we don't need to run `docker compose up` before running `docker compose run --rm test` anymore.