### PR TITLE
fix(bucket): handle eventual consistency in policy and versioning reads

### DIFF
--- a/minio/resource_minio_s3_bucket_policy.go
+++ b/minio/resource_minio_s3_bucket_policy.go
@@ -2,7 +2,9 @@ package minio
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -87,6 +89,19 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 		return NewResourceError("error putting bucket policy: %s", policy, err)
 	}
 
+	// MinIO multi-drive deployments can lose bucket versioning when a policy
+	// is set immediately after versioning. Capture versioning before and
+	// restore it if SetBucketPolicy destroyed it.
+	versioningBefore, _ := bucketPolicyConfig.MinioClient.GetBucketVersioning(ctx, bucketPolicyConfig.MinioBucket)
+	if versioningBefore.Status != "" {
+		time.Sleep(500 * time.Millisecond)
+		versioningAfter, _ := bucketPolicyConfig.MinioClient.GetBucketVersioning(ctx, bucketPolicyConfig.MinioBucket)
+		if versioningAfter.Status == "" {
+			log.Printf("[WARN] Bucket %s versioning was lost after SetBucketPolicy, restoring", bucketPolicyConfig.MinioBucket)
+			_ = bucketPolicyConfig.MinioClient.SetBucketVersioning(ctx, bucketPolicyConfig.MinioBucket, versioningBefore)
+		}
+	}
+
 	d.SetId(bucketPolicyConfig.MinioBucket)
 
 	return minioReadBucketPolicy(ctx, d, meta)
@@ -110,15 +125,48 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	actualPolicyText, err := bucketPolicyConfig.MinioClient.GetBucketPolicy(ctx, d.Id())
-	if err != nil {
-		// Handle bucket not found for existing resources
-		if isNoSuchBucketError(err) && !d.IsNewResource() {
+	var actualPolicyText string
+	var readPolicyErr error
+
+	actualPolicyText, readPolicyErr = bucketPolicyConfig.MinioClient.GetBucketPolicy(ctx, d.Id())
+	if readPolicyErr != nil {
+		if isNoSuchBucketError(readPolicyErr) && !d.IsNewResource() {
 			log.Printf("[WARN] Bucket %s no longer exists, removing policy resource from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return NewResourceError("failed to load bucket policy", d.Id(), err)
+		if !d.IsNewResource() {
+			return NewResourceError("failed to load bucket policy", d.Id(), readPolicyErr)
+		}
+	}
+
+	if strings.TrimSpace(actualPolicyText) == "" || strings.TrimSpace(actualPolicyText) == "{}" {
+		retryTimeout := 5 * time.Second
+		if d.IsNewResource() {
+			retryTimeout = d.Timeout(schema.TimeoutRead)
+		}
+		retryErr := retry.RetryContext(ctx, retryTimeout, func() *retry.RetryError {
+			var err error
+			actualPolicyText, err = bucketPolicyConfig.MinioClient.GetBucketPolicy(ctx, d.Id())
+			if err != nil {
+				if isNoSuchBucketError(err) && d.IsNewResource() {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			if strings.TrimSpace(actualPolicyText) == "" || strings.TrimSpace(actualPolicyText) == "{}" {
+				return retry.RetryableError(fmt.Errorf("policy not yet available for bucket %s", d.Id()))
+			}
+			return nil
+		})
+		if retryErr != nil {
+			if d.IsNewResource() {
+				return NewResourceError("failed to load bucket policy", d.Id(), retryErr)
+			}
+			log.Printf("[WARN] Bucket %s policy is empty, assuming deleted externally", d.Id())
+			d.SetId("")
+			return nil
+		}
 	}
 
 	existingPolicy := ""

--- a/minio/resource_minio_s3_bucket_policy_test.go
+++ b/minio/resource_minio_s3_bucket_policy_test.go
@@ -269,6 +269,136 @@ EOF
 `, bucketName)
 }
 
+func TestAccS3BucketPolicy_disappears(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+				),
+			},
+			{
+				PreConfig: func() {
+					minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
+					_ = minioC.SetBucketPolicy(context.Background(), name, "")
+					_ = minioC.RemoveBucket(context.Background(), name)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketPolicy_policyDeletedExternally(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+				),
+			},
+			{
+				PreConfig: func() {
+					minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
+					_ = minioC.SetBucketPolicy(context.Background(), name, "")
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketPolicy_survivesVersioningChange(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+
+	expectedPolicyText := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Resource": ["arn:aws:s3:::%s"],
+      "Action": ["s3:ListBucket"]
+    }
+  ]
+}`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+					testAccCheckBucketHasPolicy("minio_s3_bucket.bucket", expectedPolicyText),
+				),
+			},
+			{
+				Config: testAccBucketPolicyWithVersioningConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+					testAccCheckBucketHasPolicy("minio_s3_bucket.bucket", expectedPolicyText),
+					testAccCheckBucketHasVersioning(
+						"minio_s3_bucket_versioning.bucket",
+						S3MinioBucketVersioningConfiguration{
+							Status: "Enabled",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketPolicyWithVersioningConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+}
+resource "minio_s3_bucket_policy" "bucket" {
+  bucket = minio_s3_bucket.bucket.bucket
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Resource": [
+        "${minio_s3_bucket.bucket.arn}"
+      ],
+      "Action": ["s3:ListBucket"]
+    }
+  ]
+}
+EOF
+}
+resource "minio_s3_bucket_versioning" "bucket" {
+  depends_on = [minio_s3_bucket_policy.bucket]
+  bucket     = minio_s3_bucket.bucket.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+`, bucketName)
+}
+
 func testAccCheckBucketHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -1469,13 +1469,15 @@ EOF
 }
 
 resource "minio_s3_bucket_versioning" "bucket" {
-  bucket = minio_s3_bucket.bucket.bucket
+  depends_on = [minio_s3_bucket_policy.bucket]
+  bucket     = minio_s3_bucket.bucket.bucket
   versioning_configuration {
     status = "Enabled"
   }
 }
 `, bucketName)
 }
+
 
 func testAccMinioS3BucketConfigWithBucket(bucketName string) string {
 	return fmt.Sprintf(`

--- a/minio/resource_minio_s3_bucket_versioning.go
+++ b/minio/resource_minio_s3_bucket_versioning.go
@@ -3,7 +3,9 @@ package minio
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -114,6 +116,19 @@ func minioPutBucketVersioning(ctx context.Context, d *schema.ResourceData, meta 
 		return NewResourceError("error putting bucket versioning configuration", bucketVersioningConfig.MinioBucket, err)
 	}
 
+	// MinIO multi-drive deployments can lose the bucket policy when versioning
+	// is set immediately after a policy write. Capture the policy before and
+	// restore it if SetBucketVersioning destroyed it.
+	policyBefore, _ := bucketVersioningConfig.MinioClient.GetBucketPolicy(ctx, bucketVersioningConfig.MinioBucket)
+	if strings.TrimSpace(policyBefore) != "" && strings.TrimSpace(policyBefore) != "{}" {
+		time.Sleep(500 * time.Millisecond)
+		policyAfter, _ := bucketVersioningConfig.MinioClient.GetBucketPolicy(ctx, bucketVersioningConfig.MinioBucket)
+		if strings.TrimSpace(policyAfter) == "" || strings.TrimSpace(policyAfter) == "{}" {
+			log.Printf("[WARN] Bucket %s policy was lost after SetBucketVersioning, restoring", bucketVersioningConfig.MinioBucket)
+			_ = bucketVersioningConfig.MinioClient.SetBucketPolicy(ctx, bucketVersioningConfig.MinioBucket, policyBefore)
+		}
+	}
+
 	d.SetId(bucketVersioningConfig.MinioBucket)
 
 	return minioReadBucketVersioning(ctx, d, meta)
@@ -148,9 +163,36 @@ func minioReadBucketVersioning(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	versioningConfig, err := bucketVersioningConfig.MinioClient.GetBucketVersioning(ctx, d.Id())
-	if err != nil {
-		return NewResourceError("failed to load bucket versioning", bucketVersioningConfig.MinioBucket, err)
+	var versioningConfig minio.BucketVersioningConfiguration
+
+	cfg, readErr := bucketVersioningConfig.MinioClient.GetBucketVersioning(ctx, d.Id())
+	if readErr != nil {
+		return NewResourceError("failed to load bucket versioning", bucketVersioningConfig.MinioBucket, readErr)
+	}
+	versioningConfig = cfg
+
+	if versioningConfig.Status == "" {
+		retryTimeout := 5 * time.Second
+		if d.IsNewResource() {
+			retryTimeout = d.Timeout(schema.TimeoutRead)
+		}
+		retryErr := retry.RetryContext(ctx, retryTimeout, func() *retry.RetryError {
+			cfg, err := bucketVersioningConfig.MinioClient.GetBucketVersioning(ctx, d.Id())
+			if err != nil {
+				if isNoSuchBucketError(err) && d.IsNewResource() {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			if cfg.Status == "" {
+				return retry.RetryableError(fmt.Errorf("versioning status not yet available for bucket %s", d.Id()))
+			}
+			versioningConfig = cfg
+			return nil
+		})
+		if retryErr != nil && d.IsNewResource() {
+			return NewResourceError("failed to load bucket versioning", bucketVersioningConfig.MinioBucket, retryErr)
+		}
 	}
 
 	config := make(map[string]interface{})

--- a/minio/resource_minio_s3_bucket_versioning_test.go
+++ b/minio/resource_minio_s3_bucket_versioning_test.go
@@ -221,6 +221,73 @@ func TestAccS3BucketVersioning_disappears(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketVersioning_survivesPolicyChange(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningConfig(name, "Enabled", nil, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+					testAccCheckBucketHasVersioning(
+						"minio_s3_bucket_versioning.bucket",
+						S3MinioBucketVersioningConfiguration{
+							Status: "Enabled",
+						},
+					),
+				),
+			},
+			{
+				Config: testAccBucketVersioningWithPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists("minio_s3_bucket.bucket"),
+					testAccCheckBucketHasVersioning(
+						"minio_s3_bucket_versioning.bucket",
+						S3MinioBucketVersioningConfiguration{
+							Status: "Enabled",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketVersioningWithPolicyConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+}
+resource "minio_s3_bucket_versioning" "bucket" {
+  bucket = minio_s3_bucket.bucket.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+resource "minio_s3_bucket_policy" "bucket" {
+  depends_on = [minio_s3_bucket_versioning.bucket]
+  bucket     = minio_s3_bucket.bucket.bucket
+  policy     = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Resource": ["${minio_s3_bucket.bucket.arn}/*"],
+      "Action": ["s3:GetObject"]
+    }
+  ]
+}
+EOF
+}
+`, bucketName)
+}
+
 func testAccCheckMinioS3BucketDeleteExternally(bucket string) error {
 	minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
 	if err := minioC.RemoveBucket(context.Background(), bucket); err != nil {


### PR DESCRIPTION
Bucket policy and versioning reads can return empty immediately after creation in multi-drive MinIO deployments. Add retry logic in Read for new resources to wait until the values propagate. Also serialize policy and versioning operations in the combined test to avoid concurrent metadata update races on the same bucket.