### PR TITLE
fix: deprecate bandwidth_limt typo field in schema

### DIFF
--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -236,6 +236,15 @@ func resourceMinioBucketReplication() *schema.Resource {
 											return
 										},
 									},
+									"bandwidth_limt": {
+										// Deprecated misspelling of bandwidth_limit. Kept in the schema so
+										// existing configs do not error at plan time; the legacy value is read
+										// via ParseBandwidthLimit in utils.go. Remove in the next major version.
+										Type:        schema.TypeString,
+										Description: "Deprecated: use 'bandwidth_limit' instead. Will be removed in a future major version.",
+										Optional:    true,
+										Deprecated:  "Use 'bandwidth_limit' instead. This attribute will be removed in a future major version.",
+									},
 									"region": {
 										Type:        schema.TypeString,
 										Description: "Region of the target MinIO. This will be used to generate the target ARN",


### PR DESCRIPTION
## Summary

Closes part 1 of #868. Part 2 (`syncronous`) is already marked `Deprecated` in the schema at `minio/resource_minio_s3_bucket_replication.go:172`, so only `bandwidth_limt` needed the schema entry.

## Background

- #623 renamed `bandwidth_limt` to `bandwidth_limit`.
- #630 reverted to unblock users with the old key in state.
- #632 added `ParseBandwidthLimit` in `utils.go` that reads both keys from the raw map at resource-config-assembly time.

But the schema only declares `bandwidth_limit`. Terraform validates config against the schema *before* any helper runs, so today a user whose `.tf` still has `bandwidth_limt` sees:

```
Error: Unsupported argument
An argument named "bandwidth_limt" is not expected here.
```

That's a hard break, not a deprecation.

## Changes

`minio/resource_minio_s3_bucket_replication.go` - adds `bandwidth_limt` back as an Optional schema field with `Deprecated` set. Matches the existing `syncronous` deprecation message for consistency.

```go
"bandwidth_limt": {
    // Deprecated misspelling of bandwidth_limit...
    Type:        schema.TypeString,
    Optional:    true,
    Deprecated:  "Use 'bandwidth_limit' instead. This attribute will be removed in a future major version.",
},
```

No `Default` so `bandwidth_limit` stays authoritative when neither is set. `ParseBandwidthLimit` continues to consume the value from the raw map — no provider behavior change.

## Effect for users

| Before | After |
|--------|-------|
| `bandwidth_limt = "200M"` in .tf -> plan fails (unsupported argument) | Plan succeeds with a deprecation warning |
| `bandwidth_limit = "200M"` in .tf -> works | Works, unchanged |
| Both set | `bandwidth_limt` wins, same as today (ParseBandwidthLimit unchanged) |

## Testing

- `go vet ./...` is clean.
- `go test ./minio/` segfaults on my workstation during package init due to `github.com/shoenig/go-m1cpu` + Go 1.26 + Apple Silicon (reproducible on `main`); unrelated to this diff. CI runs on Linux x86 and the existing `ParseBandwidthLimit` unit tests (`resource_minio_s3_bucket_replication_test.go:993+`) already cover both keys.

## Scope

One schema field, 9 lines. Part 2 of the issue was already merged in a previous commit.