### PR TITLE
fix(replication): prefer canonical bandwidth_limit when legacy key is empty

### DIFF
--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -245,6 +245,7 @@ Required:
 Optional:
 
 - `bandwidth_limit` (String) Maximum bandwidth in byte per second that MinIO can used when syncronysing this target. Minimum is 100MB
+- `bandwidth_limt` (String, Deprecated) Deprecated: use 'bandwidth_limit' instead. Will be removed in a future major version.
 - `disable_proxy` (Boolean) Disable proxy for this target
 - `health_check_period` (String) Period where the health of this target will be checked. This must be a valid duration, such as `5s` or `2m`
 - `path` (String) Path of the Minio endpoint. This is useful if MinIO API isn't served on at the root, e.g for `example.com/minio/`, the path would be `/minio/`

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -1041,6 +1041,27 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 				t.Errorf("Expected bandwidth to be %d, got %d", expectedBandwidth, bandwidth)
 			}
 		}
+
+		// Regression: the Terraform SDK materializes every declared schema
+		// field into the target map, so "bandwidth_limt" is always present as
+		// "" for users who only set the canonical "bandwidth_limit". An empty
+		// legacy value must not shadow the canonical one.
+		{
+			target := map[string]interface{}{
+				"bandwidth_limt":  "",
+				"bandwidth_limit": "400M",
+			}
+
+			bandwidth, ok, _ := ParseBandwidthLimit(target)
+			if !ok {
+				t.Fatalf("Expected bandwidth to be parsed successfully")
+			}
+
+			expectedBandwidth := uint64(400000000) // 400M (from bandwidth_limit)
+			if bandwidth != expectedBandwidth {
+				t.Errorf("Expected bandwidth to be %d, got %d", expectedBandwidth, bandwidth)
+			}
+		}
 	})
 }
 

--- a/minio/utils.go
+++ b/minio/utils.go
@@ -225,8 +225,14 @@ func ParseBandwidthLimit(target map[string]any) (uint64, bool, diag.Diagnostics)
 	var limitValue string
 	var errs diag.Diagnostics
 
-	// Check for legacy attribute first (with typo)
-	if legacyLimitValue, ok = target["bandwidth_limt"].(string); ok {
+	// Prefer the legacy attribute only when it is explicitly set to a non-empty
+	// value. Since "bandwidth_limt" is now declared in the schema (to surface a
+	// deprecation warning instead of an "Unsupported argument" error), the
+	// Terraform SDK materializes it as "" for users who never set it. Treating
+	// empty-string as "unset" lets the canonical "bandwidth_limit" field take
+	// effect in that common case, while still honouring an explicitly-set
+	// legacy value for backward compatibility.
+	if legacyLimitValue, ok = target["bandwidth_limt"].(string); ok && legacyLimitValue != "" {
 		bandwidthStr = legacyLimitValue
 	} else if limitValue, ok = target["bandwidth_limit"].(string); ok {
 		bandwidthStr = limitValue


### PR DESCRIPTION
## Summary

- Fixes a latent bug introduced by #879: since `bandwidth_limt` is now declared in the schema, the Terraform SDK materializes it as `""` for users who only set the canonical `bandwidth_limit`. The legacy-first precedence in `ParseBandwidthLimit` treated the empty string as a match, causing `bandwidth_limit` to be silently ignored (resolved to 0).
- Requires the legacy value to be **non-empty** before it takes precedence over the canonical key.
- Adds a regression sub-test covering the empty-legacy + canonical scenario.

Follows up on #879 and relates to #868.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./minio/ -run TestAccS3BucketReplication_attribute_migration -v` passes (including the new regression case)
