### PR TITLE
fix(resource/iam_idp_openid): allow unknown value for client_secret_wo during plan

### DIFF
--- a/minio/resource_minio_iam_idp_openid.go
+++ b/minio/resource_minio_iam_idp_openid.go
@@ -38,16 +38,6 @@ func resourceMinioIAMIdpOpenId() *schema.Resource {
 				return fmt.Errorf("one of client_secret or client_secret_wo must be provided")
 			}
 
-			_, hasVersionWO := d.GetOk("client_secret_wo_version")
-			if hasSecretWO && !hasVersionWO {
-				return fmt.Errorf("client_secret_wo_version must be provided when client_secret_wo is set")
-			}
-
-			hasSecretWOVersionChange := d.HasChange("client_secret_wo_version") && hasVersionWO
-			if hasSecretWOVersionChange && !hasSecretWO {
-				return fmt.Errorf("client_secret_wo must be provided when client_secret_wo_version changes")
-			}
-
 			return nil
 		},
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Summary
Applies the same fix as #899 to the OpenID resource, which had the identical plan-time anti-pattern. Ephemeral/unknown values for `client_secret_wo` (e.g. from Vault) were treated as missing and failed at plan time.

The removed checks are redundant — `RequiredWith` on the schema covers the "declared together" case, and the apply-time check in the Update function (`resource_minio_iam_idp_openid.go:292`) still blocks rotations with a missing secret value.

## Test plan
- [ ] `terraform plan` succeeds when `client_secret_wo` is sourced from an ephemeral resource
- [ ] Existing OpenID tests continue to pass
- [ ] Apply-time enforcement still rejects version bumps without a real secret