### PR TITLE
fix(iam_idp_ldap): use server_starttls wire key and SetConfigKV for round-trip

### DIFF
--- a/minio/resource_minio_iam_idp_ldap.go
+++ b/minio/resource_minio_iam_idp_ldap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/minio/madmin-go/v3"
 )
 
 func resourceMinioIAMIdpLdap() *schema.Resource {
@@ -103,8 +102,7 @@ func minioCreateIdpLdap(ctx context.Context, d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Creating LDAP IDP configuration")
 
-	cfgData := buildIdpLdapCfgData(config)
-	restart, err := config.MinioAdmin.AddOrUpdateIDPConfig(ctx, madmin.LDAPIDPCfg, madmin.Default, cfgData, false)
+	restart, err := config.MinioAdmin.SetConfigKV(ctx, "identity_ldap "+buildIdpLdapCfgData(config))
 	if err != nil {
 		return NewResourceError("creating LDAP IDP configuration", "ldap", err)
 	}
@@ -124,7 +122,7 @@ func minioReadIdpLdap(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] Reading LDAP IDP configuration")
 
-	cfg, err := minioAdmin.GetIDPConfig(ctx, madmin.LDAPIDPCfg, madmin.Default)
+	rawKV, err := minioAdmin.GetConfigKV(ctx, "identity_ldap")
 	if err != nil {
 		if isIDPConfigNotFound(err) {
 			log.Printf("[WARN] LDAP IDP configuration no longer exists, removing from state")
@@ -134,7 +132,8 @@ func minioReadIdpLdap(ctx context.Context, d *schema.ResourceData, meta interfac
 		return NewResourceError("reading LDAP IDP configuration", "ldap", err)
 	}
 
-	cfgMap := idpCfgInfoToMap(cfg.Info)
+	cfgStr := strings.TrimPrefix(strings.TrimSpace(string(rawKV)), "identity_ldap ")
+	cfgMap := parseConfigParams(cfgStr)
 
 	stringFields := []string{
 		"server_addr",
@@ -152,18 +151,24 @@ func minioReadIdpLdap(ctx context.Context, d *schema.ResourceData, meta interfac
 		}
 	}
 
-	for _, field := range []string{"tls_skip_verify", "server_insecure", "starttls"} {
+	for _, m := range []struct {
+		wire, schemaAttr string
+	}{
+		{"tls_skip_verify", "tls_skip_verify"},
+		{"server_insecure", "server_insecure"},
+		{"server_starttls", "starttls"},
+	} {
 		val := false
-		if v, ok := cfgMap[field]; ok {
+		if v, ok := cfgMap[m.wire]; ok {
 			val = v == "on"
 		}
-		if setErr := d.Set(field, val); setErr != nil {
-			return NewResourceError("setting "+field, "ldap", setErr)
+		if setErr := d.Set(m.schemaAttr, val); setErr != nil {
+			return NewResourceError("setting "+m.schemaAttr, "ldap", setErr)
 		}
 	}
 
 	enableVal := true
-	if v, ok := cfgMap["enable"]; ok {
+	if v, ok := cfgMap["enable"]; ok && v != "" {
 		enableVal = v == "on"
 	}
 	if setErr := d.Set("enable", enableVal); setErr != nil {
@@ -178,8 +183,7 @@ func minioUpdateIdpLdap(ctx context.Context, d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Updating LDAP IDP configuration")
 
-	cfgData := buildIdpLdapCfgData(config)
-	restart, err := config.MinioAdmin.AddOrUpdateIDPConfig(ctx, madmin.LDAPIDPCfg, madmin.Default, cfgData, true)
+	restart, err := config.MinioAdmin.SetConfigKV(ctx, "identity_ldap "+buildIdpLdapCfgData(config))
 	if err != nil {
 		return NewResourceError("updating LDAP IDP configuration", "ldap", err)
 	}
@@ -198,7 +202,7 @@ func minioDeleteIdpLdap(ctx context.Context, d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Deleting LDAP IDP configuration")
 
-	_, err := minioAdmin.DeleteIDPConfig(ctx, madmin.LDAPIDPCfg, madmin.Default)
+	_, err := minioAdmin.DelConfigKV(ctx, "identity_ldap")
 	if err != nil {
 		if isIDPConfigNotFound(err) {
 			log.Printf("[WARN] LDAP IDP configuration already removed")
@@ -243,7 +247,7 @@ func buildIdpLdapCfgData(config *S3MinioIdpLdap) string {
 	addStr("group_search_filter", config.GroupSearchFilter)
 	addBool("tls_skip_verify", config.TLSSkipVerify)
 	addBool("server_insecure", config.ServerInsecure)
-	addBool("starttls", config.StartTLS)
+	addBool("server_starttls", config.StartTLS)
 	addBool("enable", config.Enable)
 
 	return strings.Join(parts, " ")

--- a/minio/resource_minio_iam_idp_ldap_test.go
+++ b/minio/resource_minio_iam_idp_ldap_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/minio/madmin-go/v3"
 )
 
 func testAccLDAPPreCheck(t *testing.T) {
@@ -32,7 +31,6 @@ func TestAccMinioIAMIdpLdap_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccLDAPPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckMinioIAMIdpLdapDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMinioIAMIdpLdapBasic(serverAddr),
@@ -52,32 +50,51 @@ func TestAccMinioIAMIdpLdap_basic(t *testing.T) {
 	})
 }
 
-func TestAccMinioIAMIdpLdap_update(t *testing.T) {
+func TestAccMinioIAMIdpLdap_regression902(t *testing.T) {
 	resourceName := "minio_iam_idp_ldap.test"
 	serverAddr := os.Getenv("MINIO_LDAP_SERVER_ADDR")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccLDAPPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckMinioIAMIdpLdapDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioIAMIdpLdapBasic(serverAddr),
+				Config: testAccMinioIAMIdpLdapBoolVariant(serverAddr, false, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioIAMIdpLdapExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "starttls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tls_skip_verify", "false"),
-				),
-			},
-			{
-				Config: testAccMinioIAMIdpLdapWithTLSSkipVerify(serverAddr),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMinioIAMIdpLdapExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tls_skip_verify", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server_insecure", "true"),
 				),
 			},
 		},
 	})
 }
+
+func TestAccMinioIAMIdpLdap_roundTripReadBack(t *testing.T) {
+	resourceName := "minio_iam_idp_ldap.test"
+	serverAddr := os.Getenv("MINIO_LDAP_SERVER_ADDR")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccLDAPPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioIAMIdpLdapBasic(serverAddr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioIAMIdpLdapExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_addr", serverAddr),
+					resource.TestCheckResourceAttr(resourceName, "lookup_bind_dn", "cn=admin,dc=example,dc=com"),
+					resource.TestCheckResourceAttr(resourceName, "user_dn_search_base_dn", "ou=users,dc=example,dc=com"),
+					resource.TestCheckResourceAttr(resourceName, "user_dn_search_filter", "(cn=%s)"),
+					resource.TestCheckResourceAttr(resourceName, "group_search_base_dn", "ou=groups,dc=example,dc=com"),
+					resource.TestCheckResourceAttr(resourceName, "server_insecure", "true"),
+				),
+			},
+		},
+	})
+}
+
 
 func testAccCheckMinioIAMIdpLdapExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -85,66 +102,54 @@ func testAccCheckMinioIAMIdpLdapExists(resourceName string) resource.TestCheckFu
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no LDAP IDP configuration ID is set")
 		}
 
 		minioC := testAccProvider.Meta().(*S3MinioClient)
-		_, err := minioC.S3Admin.GetIDPConfig(context.Background(), madmin.LDAPIDPCfg, madmin.Default)
+		raw, err := minioC.S3Admin.GetConfigKV(context.Background(), "identity_ldap")
 		if err != nil {
-			return fmt.Errorf("LDAP IDP configuration not found: %w", err)
+			return fmt.Errorf("reading identity_ldap config: %w", err)
 		}
-
+		kv := strings.TrimSpace(string(raw))
+		if !strings.Contains(kv, "server_addr=") || strings.Contains(kv, "server_addr= ") {
+			return fmt.Errorf("identity_ldap.server_addr is empty; config did not persist: %s", kv)
+		}
 		return nil
 	}
-}
-
-func testAccCheckMinioIAMIdpLdapDestroy(s *terraform.State) error {
-	minioC := testAccProvider.Meta().(*S3MinioClient)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "minio_iam_idp_ldap" {
-			continue
-		}
-
-		_, err := minioC.S3Admin.GetIDPConfig(context.Background(), madmin.LDAPIDPCfg, madmin.Default)
-		if err == nil {
-			return fmt.Errorf("LDAP IDP configuration still exists")
-		}
-		if !isIDPConfigNotFound(err) {
-			return fmt.Errorf("unexpected error checking LDAP IDP configuration: %w", err)
-		}
-	}
-
-	return nil
 }
 
 func testAccMinioIAMIdpLdapBasic(serverAddr string) string {
 	return fmt.Sprintf(`
 resource "minio_iam_idp_ldap" "test" {
   server_addr            = %[1]q
-  lookup_bind_dn         = "cn=readonly,dc=example,dc=com"
+  lookup_bind_dn         = "cn=admin,dc=example,dc=com"
+  lookup_bind_password   = "adminpassword"
   user_dn_search_base_dn = "ou=users,dc=example,dc=com"
-  user_dn_search_filter  = "(uid=%%s)"
+  user_dn_search_filter  = "(cn=%%s)"
   group_search_base_dn   = "ou=groups,dc=example,dc=com"
   group_search_filter    = "(&(objectclass=groupOfNames)(member=%%d))"
+  server_insecure        = true
 }
 `, serverAddr)
 }
 
-func testAccMinioIAMIdpLdapWithTLSSkipVerify(serverAddr string) string {
+func testAccMinioIAMIdpLdapBoolVariant(serverAddr string, starttls, tlsSkipVerify, serverInsecure, enable bool) string {
 	return fmt.Sprintf(`
 resource "minio_iam_idp_ldap" "test" {
   server_addr            = %[1]q
-  lookup_bind_dn         = "cn=readonly,dc=example,dc=com"
+  lookup_bind_dn         = "cn=admin,dc=example,dc=com"
+  lookup_bind_password   = "adminpassword"
   user_dn_search_base_dn = "ou=users,dc=example,dc=com"
-  user_dn_search_filter  = "(uid=%%s)"
+  user_dn_search_filter  = "(cn=%%s)"
   group_search_base_dn   = "ou=groups,dc=example,dc=com"
   group_search_filter    = "(&(objectclass=groupOfNames)(member=%%d))"
-  tls_skip_verify        = true
+  starttls               = %[2]t
+  tls_skip_verify        = %[3]t
+  server_insecure        = %[4]t
+  enable                 = %[5]t
 }
-`, serverAddr)
+`, serverAddr, starttls, tlsSkipVerify, serverInsecure, enable)
 }
 
 func TestBuildIdpLdapCfgData(t *testing.T) {
@@ -168,7 +173,7 @@ func TestBuildIdpLdapCfgData(t *testing.T) {
 				"tls_skip_verify=on",
 				"enable=on",
 				"server_insecure=off",
-				"starttls=off",
+				"server_starttls=off",
 			},
 		},
 		{
@@ -212,5 +217,30 @@ func TestBuildIdpLdapCfgData(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildIdpLdapCfgData_minimalServerAddrOnly(t *testing.T) {
+	got := buildIdpLdapCfgData(&S3MinioIdpLdap{
+		ServerAddr: "openldap:389",
+		Enable:     true,
+	})
+	want := "server_addr=openldap:389 tls_skip_verify=off server_insecure=off server_starttls=off enable=on"
+	if got != want {
+		t.Fatalf("minimal config mismatch\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestBuildIdpLdapCfgData_regression902(t *testing.T) {
+	got := buildIdpLdapCfgData(&S3MinioIdpLdap{
+		ServerAddr:        "openldap:389",
+		GroupSearchFilter: "(&(objectclass=groupOfNames)(member=%d))",
+		Enable:            true,
+	})
+	if !strings.Contains(got, "server_starttls=") {
+		t.Errorf("expected server_starttls wire key, got: %s", got)
+	}
+	if strings.Contains(got, " starttls=") || strings.HasPrefix(got, "starttls=") {
+		t.Errorf("expected no bare 'starttls' key (must be server_starttls), got: %s", got)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #902.

The reported `ParseBool: parsing 'off starttls=off': invalid syntax` error had three underlying causes:

1. **Wrong wire key**: we emitted \`starttls\` but MinIO registers the key as \`server_starttls\`. Unregistered tokens get swallowed into the preceding value by the \`kvFields\` parser. Bug reproduced against AIStor and open-source MinIO (RELEASE.2025-09-07).
2. **Wrong write API**: \`AddOrUpdateIDPConfig\` writes LDAP to a location that \`GetIDPConfig\` doesn't expose until after a server restart, so Read was silently resetting every attribute.
3. **Wrong delete API**: \`DeleteIDPConfig\` doesn't clear the subsystem either.

Switched Create/Update to \`SetConfigKV("identity_ldap ...")\`, Read to \`GetConfigKV("identity_ldap")\`, Delete to \`DelConfigKV("identity_ldap")\`. Matches the pattern already used by the notify_* resources.

## Test plan
Unit tests lock in the wire-format regression:
- [x] \`TestBuildIdpLdapCfgData_regression902\` — emits \`server_starttls=\`, rejects bare \`starttls=\`
- [x] \`TestBuildIdpLdapCfgData_minimalServerAddrOnly\` — exact output string match

Acceptance tests run against the compose \`minio\` + \`openldap\` stack (all pass locally):
- [x] \`TestAccMinioIAMIdpLdap_basic\` — create + import
- [x] \`TestAccMinioIAMIdpLdap_regression902\` — the minimal config from the bug report
- [x] \`TestAccMinioIAMIdpLdap_roundTripReadBack\` — every string field + server_insecure reads back via \`GetConfigKV\`