### PR TITLE
fix(kms): fix minio_kms_key import by adding ImportStateIdFunc

### DIFF
--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -15,7 +15,13 @@ func resourceMinioKMSKey() *schema.Resource {
 		ReadContext:   minioReadKMSKey,
 		DeleteContext: minioDeleteKMSKey,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				if err := d.Set("key_id", d.Id()); err != nil {
+					return nil, err
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -41,7 +41,7 @@ func minioCreateKMSKey(ctx context.Context, d *schema.ResourceData, meta interfa
 	keyID := keyConfig.MinioKMSKeyID
 
 	if err := keyConfig.MinioAdmin.CreateKey(ctx, keyID); err != nil {
-		return NewResourceError("error creating service account", keyID, err)
+		return NewResourceError("error creating KMS key", keyID, err)
 	}
 
 	d.SetId(keyID)

--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -1,0 +1,88 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccMinioKMSKey_basic(t *testing.T) {
+	keyID := fmt.Sprintf("tfacc-kms-key-%d", acctest.RandInt())
+	resourceName := "minio_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckKMS(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioKMSKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioKMSKeyConfig(keyID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioKMSKeyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key_id", keyID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMinioKMSKeyDestroy(s *terraform.State) error {
+	conn := testAccKmsProvider.Meta().(*S3MinioClient).S3Admin
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "minio_kms_key" {
+			continue
+		}
+
+		_, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("KMS key %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMinioKMSKeyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no KMS key ID is set")
+		}
+
+		conn := testAccKmsProvider.Meta().(*S3MinioClient).S3Admin
+
+		status, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading KMS key: %w", err)
+		}
+
+		if status.KeyID != rs.Primary.ID {
+			return fmt.Errorf("KMS key not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccMinioKMSKeyConfig(keyID string) string {
+	return fmt.Sprintf(`
+resource "minio_kms_key" "test" {
+  provider = "kmsminio"
+  key_id   = "%s"
+}
+`, keyID)
+}

--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -10,12 +11,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func testAccPreCheckKMSKey(t *testing.T) {
+	t.Helper()
+	testAccPreCheckKMS(t)
+
+	admin := testAccKmsProvider.Meta().(*S3MinioClient).S3Admin
+	testKey := fmt.Sprintf("tfacc-precheck-%d", acctest.RandInt())
+
+	if err := admin.CreateKey(context.Background(), testKey); err != nil {
+		if strings.Contains(err.Error(), "not supported") {
+			t.Skip("CreateKey is not supported (static KEK mode); skipping KMS key tests")
+		}
+	} else {
+		_ = admin.DeleteKey(context.Background(), testKey)
+	}
+}
+
 func TestAccMinioKMSKey_basic(t *testing.T) {
 	keyID := fmt.Sprintf("tfacc-kms-key-%d", acctest.RandInt())
 	resourceName := "minio_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckKMS(t) },
+		PreCheck:          func() { testAccPreCheckKMSKey(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioKMSKeyDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Description
Fixes the `minio_kms_key` import functionality. Previously, importing a KMS key would result in perpetual drift because the `key_id` attribute was never properly set in state during import.

## Root Cause
The resource used `schema.ImportStatePassthroughContext` which only sets `d.Id()` to the imported value. However, the Read function extracted the key ID via `KMSKeyConfig(d, meta)` → `getOptionalField(d, "key_id", "")`, which returned empty on import since the `key_id` attribute was never set in state.

This caused:
1. `d.Id()` set to imported key ID
2. `d.Get("key_id")` returns empty (never set)
3. `GetKeyStatus("")` fails
4. Read sets `d.SetId("")` (resource not found)
5. Terraform thinks resource doesn't exist → perpetual create on every plan

## Changes
- Added custom `ImportStateIdFunc` to `minio_kms_key` resource that sets `key_id` from `d.Id()` during import
- Added acceptance tests covering basic CRUD and import scenarios

## Testing
```bash
# Run the new acceptance tests
TF_ACC=1 go test -v ./minio -run TestAccMinioKMSKey_basic
```

## Related Issue
Resolves https://github.com/aminueza/terraform-provider-minio/issues/917