### PR TITLE
fix(ci): replace golang.org/x/exp/slices with stdlib slices

### DIFF
--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -22,7 +22,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/replication"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/rs/xid"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func resourceMinioBucketReplication() *schema.Resource {


### PR DESCRIPTION
- Replaces `golang.org/x/exp/slices` with the standard library `slices` package in `resource_minio_s3_bucket_replication.go`
- The `golang.org/x/exp/slices` package triggers a `govet` error (`cannot inline: type parameter inference is not yet supported`) in golangci-lint, blocking CI on unrelated PRs (e.g. #918)
- The stdlib `slices` package (available since Go 1.21) is a direct drop-in; the project targets Go 1.25 so no compatibility concern