### PR TITLE
ci(deps): bump aquasecurity/trivy-action from 0.35.0 to 0.36.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         id: trivy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         continue-on-error: true
         with:
           scan-type: "fs"


### PR DESCRIPTION
Rebased from #910 onto current main (which includes the `golang.org/x/exp/slices` → stdlib `slices` fix from #919).

The previous CI run on #910 had a single transient `SignatureDoesNotMatch` failure in `TestAccMinioS3Bucket_migrateBucketToBucketPrefix_incompatibleForcesReplacement`. The retry logic for that error is already in the test; the retries were exhausted due to CI environment flakiness that day. This run is expected to pass cleanly.

- Closes #910