### PR TITLE
fix(kms): fix minio_kms_key import by adding ImportStateIdFunc

### DIFF
--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -15,7 +15,13 @@ func resourceMinioKMSKey() *schema.Resource {
 		ReadContext:   minioReadKMSKey,
 		DeleteContext: minioDeleteKMSKey,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				if err := d.Set("key_id", d.Id()); err != nil {
+					return nil, err
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -43,14 +43,12 @@ func testAccCheckMinioKMSKeyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		status, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
+		_, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("error checking KMS key: %w", err)
+			return nil
 		}
 
-		if status.KeyID == "" {
-			return fmt.Errorf("KMS key %s still exists", rs.Primary.ID)
-		}
+		return fmt.Errorf("KMS key %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -1,0 +1,91 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccMinioKMSKey_basic(t *testing.T) {
+	keyID := fmt.Sprintf("tfacc-kms-key-%d", acctest.RandInt())
+	resourceName := "minio_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioKMSKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioKMSKeyConfig(keyID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioKMSKeyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key_id", keyID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMinioKMSKeyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*S3MinioClient).S3Admin
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "minio_kms_key" {
+			continue
+		}
+
+		status, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking KMS key: %w", err)
+		}
+
+		if status.KeyID == "" {
+			return fmt.Errorf("KMS key %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMinioKMSKeyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no KMS key ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*S3MinioClient).S3Admin
+
+		status, err := conn.GetKeyStatus(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading KMS key: %w", err)
+		}
+
+		if status.KeyID != rs.Primary.ID {
+			return fmt.Errorf("KMS key not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccMinioKMSKeyConfig(keyID string) string {
+	return fmt.Sprintf(`
+resource "minio_kms_key" "test" {
+  key_id = "%s"
+}
+`, keyID)
+}


### PR DESCRIPTION
Rebased from #918 onto current main.

## Changes
- Replaces `schema.ImportStatePassthroughContext` with a custom `StateContext` that sets `key_id` from `d.Id()` during import, fixing perpetual drift after `terraform import`
- Adds acceptance tests for basic CRUD and import scenarios
- **Note:** the `testAccCheckMinioKMSKeyDestroy` helper has been corrected per the review comment on #918 — the original had inverted logic (treated a successful `GetKeyStatus` call as destruction, and errors as "still exists")

- Closes #917 and #918