### PR TITLE
fix(iam_export): check error return value of rc.Close()

### DIFF
--- a/minio/data_source_minio_iam_export.go
+++ b/minio/data_source_minio_iam_export.go
@@ -47,7 +47,7 @@ func dataSourceMinioIAMExportRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return NewResourceError("exporting IAM", "iam", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	raw, err := io.ReadAll(rc)
 	if err != nil {


### PR DESCRIPTION
Fixes errcheck lint failure in PR #927

-diff
-defer rc.Close()
+defer func() { _ = rc.Close() }()
-