### PR TITLE
fix(test): build madmin client from env in KMS key PreCheck

### DIFF
--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -3,21 +3,37 @@ package minio
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/minio/madmin-go/v3"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func testAccPreCheckKMSKey(t *testing.T) {
 	t.Helper()
 	testAccPreCheckKMS(t)
 
-	admin := testAccKmsProvider.Meta().(*S3MinioClient).S3Admin
-	testKey := fmt.Sprintf("tfacc-precheck-%d", acctest.RandInt())
+	endpoint := os.Getenv("KMS_MINIO_ENDPOINT")
+	user := os.Getenv("KMS_MINIO_USER")
+	pass := os.Getenv("KMS_MINIO_PASSWORD")
+	if endpoint == "" || user == "" || pass == "" {
+		t.Skip("KMS_MINIO_ENDPOINT/USER/PASSWORD not set; skipping KMS key tests")
+	}
 
+	admin, err := madmin.NewWithOptions(endpoint, &madmin.Options{
+		Creds:  credentials.NewStaticV4(user, pass, ""),
+		Secure: os.Getenv("KMS_MINIO_ENABLE_HTTPS") == "true",
+	})
+	if err != nil {
+		t.Fatalf("creating KMS admin client: %v", err)
+	}
+
+	testKey := fmt.Sprintf("tfacc-precheck-%d", acctest.RandInt())
 	if err := admin.CreateKey(context.Background(), testKey); err != nil {
 		if strings.Contains(err.Error(), "not supported") {
 			t.Skip("CreateKey is not supported (static KEK mode); skipping KMS key tests")


### PR DESCRIPTION
## Summary
CI on `main` currently fails every run with:

\`\`\`
panic: interface conversion: interface {} is nil, not *minio.S3MinioClient
    at testAccPreCheckKMSKey (resource_minio_kms_key_test.go:18)
\`\`\`

The precheck called \`testAccKmsProvider.Meta().(*S3MinioClient)\`, but PreCheck runs **before** the SDK test framework calls \`Configure\` on the provider, so \`Meta()\` is nil and the type assertion panics.

Replaced the broken access with a one-off \`madmin\` client built straight from the same \`KMS_MINIO_*\` env vars the \`kmsminio\` provider reads. The post-apply Check/Destroy callbacks still use \`testAccKmsProvider.Meta()\` — that's correct because the test framework has configured the provider by the time those run.

## Test plan
Verified locally against the docker compose stack (kmsminio runs in static-KEK mode, so the precheck correctly skips):

\`\`\`
=== RUN   TestAccMinioKMSKey_basic
    resource_minio_kms_key_test.go:51: CreateKey is not supported (static KEK mode); skipping KMS key tests
--- SKIP: TestAccMinioKMSKey_basic (0.03s)
PASS
\`\`\`

No more panic. With a real KES backend the precheck would proceed past the skip and the existing test logic kicks in unchanged.