### PR TITLE
test(s3_bucket): use env-based client in Exists check to avoid credential pollution

### DIFF
--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -15,7 +15,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
+
+// newPrimaryS3ClientFromEnv builds a client from MINIO_* env vars, bypassing
+// testAccProvider.Meta(). Acceptance tests share testAccProvider as a
+// singleton, so a parallel test that configures it with bad credentials
+// (e.g. TestAccMinioS3Bucket_CredentialErrorDoesNotRemoveFromState) leaks
+// SignatureDoesNotMatch into other tests' Check callbacks.
+func newPrimaryS3ClientFromEnv() (*minio.Client, error) {
+	return minio.New(os.Getenv("MINIO_ENDPOINT"), &minio.Options{
+		Creds:  credentials.NewStaticV4(os.Getenv("MINIO_USER"), os.Getenv("MINIO_PASSWORD"), ""),
+		Secure: os.Getenv("MINIO_ENABLE_HTTPS") == "true",
+	})
+}
 
 func TestAccMinioS3Bucket_basic(t *testing.T) {
 	rInt := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
@@ -845,7 +858,10 @@ func testAccCheckMinioS3BucketExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
+		minioC, err := newPrimaryS3ClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("building env-based S3 client: %w", err)
+		}
 
 		maxRetries := 6
 		for i := 0; i < maxRetries; i++ {


### PR DESCRIPTION
## Summary
\`TestAccMinioS3Bucket_migrateBucketToBucketPrefix_incompatibleForcesReplacement\` fails in CI with:

\`\`\`
error checking bucket existence: The request signature we calculated does not match the signature you provided.
\`\`\`

### Root cause
\`TestAccMinioS3Bucket_CredentialErrorDoesNotRemoveFromState\` runs in parallel and reconfigures the shared \`testAccProvider\` singleton with \`minio_password = "wrong-password"\` for one of its steps. While that step is active, every other parallel test's \`Check\` callback that does \`testAccProvider.Meta().(*S3MinioClient).S3Client\` receives the bad-credentials client and fails auth.

The existing 6-attempt \`SignatureDoesNotMatch\` retry in \`testAccCheckMinioS3BucketExists\` was designed for transient eventual-consistency races, not for cross-test trample. ~3s total backoff isn't enough to outwait another test's full step.

### Fix
Build the S3 client straight from \`MINIO_*\` env vars in \`testAccCheckMinioS3BucketExists\`, bypassing the singleton entirely. Same pattern used in \#930 for the KMS key precheck.

The retry stays as a defense against real eventual-consistency races.

## Test plan
Verified both tests run green when scheduled in parallel:

\`\`\`
=== CONT  TestAccMinioS3Bucket_migrateBucketToBucketPrefix_incompatibleForcesReplacement
=== CONT  TestAccMinioS3Bucket_CredentialErrorDoesNotRemoveFromState
--- PASS: TestAccMinioS3Bucket_CredentialErrorDoesNotRemoveFromState (6.36s)
--- PASS: TestAccMinioS3Bucket_migrateBucketToBucketPrefix_incompatibleForcesReplacement (7.31s)
\`\`\`

## Out of scope (follow-up)
Other Check/Destroy helpers in this file (lines 783, 890, 1054, 1082, 1111, 1259) still use \`testAccProvider.Meta()\`. They have the same exposure but no current failure report. Migrating them all to the env-based helper is a larger sweep — happy to do it in a follow-up if maintainers want.