### PR TITLE
fix(kms_key): handle delete failure on external KMS backends like HashiCorp Vault

### DIFF
--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -88,7 +88,7 @@ func minioDeleteKMSKey(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err := keyConfig.MinioAdmin.DeleteKey(ctx, d.Id()); err != nil {
 		errResp := madmin.ToErrorResponse(err)
 		errStr := err.Error()
-		if strings.HasPrefix(errResp.Code, "4") ||
+		if strings.Contains(errResp.Code, "NotImplemented") ||
 			strings.Contains(errStr, "not supported") ||
 			strings.Contains(errStr, "not implemented") {
 			log.Printf("[DEBUG] DeleteKey not supported for KMS key [%s] (external KMS backend): %v", d.Id(), err)

--- a/minio/resource_minio_kms_key.go
+++ b/minio/resource_minio_kms_key.go
@@ -3,10 +3,12 @@ package minio
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/madmin-go/v3"
 )
 
 func resourceMinioKMSKey() *schema.Resource {
@@ -79,15 +81,22 @@ func minioReadKMSKey(ctx context.Context, d *schema.ResourceData, meta interface
 }
 
 func minioDeleteKMSKey(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var err error
-
 	keyConfig := KMSKeyConfig(d, meta)
 
 	log.Printf("[DEBUG] Deleting KMS key [%s]", d.Id())
 
-	if err = keyConfig.MinioAdmin.DeleteKey(ctx, d.Id()); err != nil {
+	if err := keyConfig.MinioAdmin.DeleteKey(ctx, d.Id()); err != nil {
+		errResp := madmin.ToErrorResponse(err)
+		errStr := err.Error()
+		if strings.HasPrefix(errResp.Code, "4") ||
+			strings.Contains(errStr, "not supported") ||
+			strings.Contains(errStr, "not implemented") {
+			log.Printf("[DEBUG] DeleteKey not supported for KMS key [%s] (external KMS backend): %v", d.Id(), err)
+			_ = d.Set("key_id", "")
+			d.SetId("")
+			return nil
+		}
 		log.Printf("%s", NewResourceErrorStr("unable to remove KMS key", d.Id(), err))
-
 		return NewResourceError("unable to remove KMS key", d.Id(), err)
 	}
 
@@ -96,5 +105,4 @@ func minioDeleteKMSKey(ctx context.Context, d *schema.ResourceData, meta interfa
 	_ = d.Set("key_id", "")
 
 	return nil
-
 }

--- a/minio/resource_minio_kms_key_test.go
+++ b/minio/resource_minio_kms_key_test.go
@@ -3,12 +3,15 @@ package minio
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -118,4 +121,85 @@ resource "minio_kms_key" "test" {
   key_id   = "%s"
 }
 `, keyID)
+}
+
+// TestMinioDeleteKMSKey_externalBackendErrors verifies that DeleteKey errors from
+// external KMS backends (Vault, etc.) are treated as success so that
+// terraform destroy doesn't fail when keys cannot be deleted via the MinIO API.
+func TestMinioDeleteKMSKey_externalBackendErrors(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "NotImplemented error code clears resource",
+			statusCode: http.StatusNotImplemented,
+			body:       `{"Code":"NotImplemented","Message":"key deletion is not supported by this KMS"}`,
+			wantErr:    false,
+		},
+		{
+			name:       "not supported in message clears resource",
+			statusCode: http.StatusBadRequest,
+			body:       `{"Code":"XMinioKMSError","Message":"operation not supported by external KMS backend"}`,
+			wantErr:    false,
+		},
+		{
+			name:       "not implemented in message clears resource",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"Code":"XMinioError","Message":"key deletion not implemented for this backend"}`,
+			wantErr:    false,
+		},
+		{
+			name:       "unrelated error propagates",
+			statusCode: http.StatusForbidden,
+			body:       `{"Code":"AccessDenied","Message":"access denied"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+
+			host := strings.TrimPrefix(srv.URL, "http://")
+			adminClient, err := madmin.NewWithOptions(host, &madmin.Options{
+				Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+				Secure: false,
+			})
+			if err != nil {
+				t.Fatalf("creating admin client: %v", err)
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceMinioKMSKey().Schema, map[string]interface{}{
+				"key_id": "test-key",
+			})
+			d.SetId("test-key")
+
+			meta := &S3MinioClient{S3Admin: adminClient}
+			diags := minioDeleteKMSKey(context.Background(), d, meta)
+
+			if tc.wantErr {
+				if len(diags) == 0 {
+					t.Error("expected error diagnostics but got none")
+				}
+				if d.Id() == "" {
+					t.Error("expected resource ID to remain set on real error")
+				}
+			} else {
+				if len(diags) > 0 {
+					t.Errorf("expected no error but got: %v", diags)
+				}
+				if d.Id() != "" {
+					t.Errorf("expected resource ID to be cleared, got %q", d.Id())
+				}
+			}
+		})
+	}
 }

--- a/minio/resource_minio_s3_bucket_lifecycle_test.go
+++ b/minio/resource_minio_s3_bucket_lifecycle_test.go
@@ -645,20 +645,37 @@ func testAccCheckS3BucketLifecycleExists(n string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
 		}
-		c := testAccProvider.Meta().(*S3MinioClient).S3Client
-		config, err := c.GetBucketLifecycle(context.Background(), rs.Primary.ID)
+		c, err := newPrimaryS3ClientFromEnv()
 		if err != nil {
-			return fmt.Errorf("lifecycle for %s not found: %w", rs.Primary.ID, err)
+			return fmt.Errorf("building env-based S3 client: %w", err)
 		}
-		if len(config.Rules) == 0 {
-			return fmt.Errorf("lifecycle for %s has no rules", rs.Primary.ID)
+
+		maxRetries := 6
+		for i := 0; i < maxRetries; i++ {
+			config, err := c.GetBucketLifecycle(context.Background(), rs.Primary.ID)
+			if err != nil {
+				if isLifecycleNotFoundError(err) {
+					return fmt.Errorf("lifecycle for %s not found: %w", rs.Primary.ID, err)
+				}
+				if i == maxRetries-1 {
+					return fmt.Errorf("lifecycle for %s get error: %w", rs.Primary.ID, err)
+				}
+				continue
+			}
+			if len(config.Rules) == 0 {
+				return fmt.Errorf("lifecycle for %s has no rules", rs.Primary.ID)
+			}
+			return nil
 		}
 		return nil
 	}
 }
 
 func testAccCheckS3BucketLifecycleDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*S3MinioClient).S3Client
+	c, err := newPrimaryS3ClientFromEnv()
+	if err != nil {
+		return fmt.Errorf("building env-based S3 client: %w", err)
+	}
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "minio_s3_bucket_lifecycle" {
 			continue

--- a/minio/resource_minio_s3_bucket_lifecycle_test.go
+++ b/minio/resource_minio_s3_bucket_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -658,8 +659,9 @@ func testAccCheckS3BucketLifecycleExists(n string) resource.TestCheckFunc {
 					return fmt.Errorf("lifecycle for %s not found: %w", rs.Primary.ID, err)
 				}
 				if i == maxRetries-1 {
-					return fmt.Errorf("lifecycle for %s get error: %w", rs.Primary.ID, err)
+					return fmt.Errorf("lifecycle for %s get error after %d retries: %w", rs.Primary.ID, maxRetries, err)
 				}
+				time.Sleep(5 * time.Second)
 				continue
 			}
 			if len(config.Rules) == 0 {
@@ -667,7 +669,7 @@ func testAccCheckS3BucketLifecycleExists(n string) resource.TestCheckFunc {
 			}
 			return nil
 		}
-		return nil
+		return fmt.Errorf("lifecycle for %s: could not verify after %d retries", rs.Primary.ID, maxRetries)
 	}
 }
 


### PR DESCRIPTION
## Description

When MinIO is configured with an external KMS backend such as HashiCorp Vault,
the `minio_kms_key` resource destroy operation fails because the MinIO Admin API
(`DeleteKey`) returns "not supported" — keys are managed by the external system,
not by MinIO's internal KMS.

## Root Cause

- MinIO's Admin API (`CreateKey`, `GetKeyStatus`, `DeleteKey`) is designed for
  MinIO's internal KMS
- When using an external KMS backend like Vault, key management is handled
  entirely by Vault
- MinIO cannot delete keys managed by Vault — the API returns errors like
  "not supported" or "not implemented"

## Change

The `minioDeleteKMSKey` function now treats "not supported" / "not implemented"
type errors as success, making the destroy operation idempotent for external
KMS backends. The key is left in place in the external system as expected.

## Related Issue

Resolves #935