### PR TITLE
fix(accesskey): suppress drift for secret_key_wo

### DIFF
--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -177,11 +177,8 @@ func resourceMinioAccessKey() *schema.Resource {
 				Description: "Version identifier for the secret key. Change this value to trigger a secret key rotation. Can be a hash, version number, timestamp, or any string that changes when the secret changes.",
 			},
 			"secret_key_wo_version": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 				RequiredWith: []string{
 					"secret_key_wo",

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -148,6 +148,15 @@ func resourceMinioAccessKey() *schema.Resource {
 					"secret_key_version",
 				},
 				Description: "Write-only secret key for the access key.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Id() == "" {
+						return false
+					}
+					if d.HasChange("secret_key_wo_version") {
+						return false
+					}
+					return true
+				},
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					if v != "" {
@@ -168,8 +177,11 @@ func resourceMinioAccessKey() *schema.Resource {
 				Description: "Version identifier for the secret key. Change this value to trigger a secret key rotation. Can be a hash, version number, timestamp, or any string that changes when the secret changes.",
 			},
 			"secret_key_wo_version": {
-				Type:         schema.TypeInt,
-				Optional:     true,
+				Type:     schema.TypeInt,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 				ValidateFunc: validation.IntAtLeast(1),
 				RequiredWith: []string{
 					"secret_key_wo",

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -487,6 +487,32 @@ func TestAccMinioAccessKey_writeOnlySecretTransition(t *testing.T) {
 	})
 }
 
+func TestAccMinioAccessKey_writeOnlySecretNoDrift(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "minio_accesskey.test"
+	secretKey := acctest.RandString(40)
+	accessKey := acctest.RandString(20)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAccessKeyConfigWithWriteOnlyVersion(rName, accessKey, secretKey, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "secret_key", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_key_wo"),
+				),
+			},
+			{
+				Config:             testAccMinioAccessKeyConfigWithWriteOnlyVersion(rName, accessKey, secretKey, 1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func testAccMinioAccessKeyConfigWithVersion(rName, accessKey, secretKey, version string) string {
 	return fmt.Sprintf(`
 resource "minio_iam_user" "test" {


### PR DESCRIPTION
## Summary

- Add `DiffSuppressFunc` to `secret_key_wo` to prevent perpetual diffs after resource creation
- Add new acceptance test `TestAccMinioAccessKey_writeOnlySecretNoDrift` that verifies no drift is detected when using `secret_key_wo`

Note: `secret_key_wo_version` intentionally has no `DiffSuppressFunc` — it is a regular integer field (not write-only) that is stored in state and must track changes to trigger secret rotation.

Resolves #939