### PR TITLE
fix(accesskey): add DiffSuppressFunc to secret_key_wo to prevent configuration drift

### DIFF
--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -135,29 +135,38 @@ func resourceMinioAccessKey() *schema.Resource {
 					return
 				},
 			},
-			"secret_key_wo": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				WriteOnly: true,
-				Sensitive: true,
-				RequiredWith: []string{
-					"secret_key_wo_version",
-				},
-				ConflictsWith: []string{
-					"secret_key",
-					"secret_key_version",
-				},
-				Description: "Write-only secret key for the access key.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if v != "" {
-						if len(v) < 8 {
-							errs = append(errs, fmt.Errorf("%q must be at least 8 characters when specified", key))
-						}
-					}
-					return
-				},
+"secret_key_wo": {
+			Type:      schema.TypeString,
+			Optional:  true,
+			WriteOnly: true,
+			Sensitive: true,
+			RequiredWith: []string{
+				"secret_key_wo_version",
 			},
+			ConflictsWith: []string{
+				"secret_key",
+				"secret_key_version",
+			},
+			Description: "Write-only secret key for the access key.",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if d.Id() == "" {
+					return false
+				}
+				if d.HasChange("secret_key_wo_version") {
+					return false
+				}
+				return true
+			},
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v := val.(string)
+				if v != "" {
+					if len(v) < 8 {
+						errs = append(errs, fmt.Errorf("%q must be at least 8 characters when specified", key))
+					}
+				}
+				return
+			},
+		},
 			"secret_key_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -327,6 +336,7 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Clear secret_key from state - it's write-only
 	_ = d.Set("secret_key", "")
+	_ = d.Set("secret_key_wo", "")
 
 	// Only set policy in state if it's not implied
 	if !info.ImpliedPolicy {


### PR DESCRIPTION
## Summary
The  field was causing perpetual configuration drift when used with , even when the values remained unchanged. This is different from  which already had a DiffSuppressFunc.

Additionally, clear  in the Read function for consistency with .

## Root Cause
The issue was that  lacked a , unlike  which has one. When using ephemeral random values (e.g., from ), Terraform would detect a diff on every plan because the new random value didn't match the old value in state.

## Changes
1. Add  to  field that suppresses diffs when  is not changed
2. Clear  in the Read function for consistency with how  is handled

## Related
- Fixes: https://github.com/aminueza/terraform-provider-minio/issues/941
- Reference: Original fix was in https://github.com/aminueza/terraform-provider-minio/pull/940 but was not properly merged/subsequently lost