### PR TITLE
fix(accesskey): clear secret_key_wo in Read for consistency

### DIFF
--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -177,8 +177,11 @@ func resourceMinioAccessKey() *schema.Resource {
 				Description: "Version identifier for the secret key. Change this value to trigger a secret key rotation. Can be a hash, version number, timestamp, or any string that changes when the secret changes.",
 			},
 			"secret_key_wo_version": {
-				Type:         schema.TypeInt,
-				Optional:     true,
+				Type:     schema.TypeInt,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 				ValidateFunc: validation.IntAtLeast(1),
 				RequiredWith: []string{
 					"secret_key_wo",
@@ -336,6 +339,7 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Clear secret_key from state - it's write-only
 	_ = d.Set("secret_key", "")
+	_ = d.Set("secret_key_wo", "")
 
 	// Only set policy in state if it's not implied
 	if !info.ImpliedPolicy {

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -136,36 +136,23 @@ func resourceMinioAccessKey() *schema.Resource {
 				},
 			},
 			"secret_key_wo": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				WriteOnly: true,
-				Sensitive: true,
-				RequiredWith: []string{
-					"secret_key_wo_version",
-				},
-				ConflictsWith: []string{
-					"secret_key",
-					"secret_key_version",
-				},
-				Description: "Write-only secret key for the access key.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				Sensitive:     true,
+				RequiredWith:  []string{"secret_key_wo_version"},
+				ConflictsWith: []string{"secret_key", "secret_key_version"},
+				Description:   "Write-only secret key for the access key.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if d.Id() == "" {
-						return false
-					}
-					if d.HasChange("secret_key_wo_version") {
-						return false
-					}
-					return true
+					return !d.HasChange("secret_key_wo_version")
 				},
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if v != "" {
-						if len(v) < 8 {
-							errs = append(errs, fmt.Errorf("%q must be at least 8 characters when specified", key))
-						}
-					}
-					return
-				},
+			},
+			"secret_key_wo_version": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ValidateFunc:  validation.IntAtLeast(1),
+				RequiredWith:  []string{"secret_key_wo"},
+				ConflictsWith: []string{"secret_key", "secret_key_version"},
 			},
 			"secret_key_version": {
 				Type:     schema.TypeString,
@@ -175,22 +162,6 @@ func resourceMinioAccessKey() *schema.Resource {
 					"secret_key_wo_version",
 				},
 				Description: "Version identifier for the secret key. Change this value to trigger a secret key rotation. Can be a hash, version number, timestamp, or any string that changes when the secret changes.",
-			},
-			"secret_key_wo_version": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
-				ValidateFunc: validation.IntAtLeast(1),
-				RequiredWith: []string{
-					"secret_key_wo",
-				},
-				ConflictsWith: []string{
-					"secret_key",
-					"secret_key_version",
-				},
-				Description: "Version identifier for secret_key_wo. Increment this integer to trigger rotation when using secret_key_wo.",
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -339,7 +310,6 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Clear secret_key from state - it's write-only
 	_ = d.Set("secret_key", "")
-	_ = d.Set("secret_key_wo", "")
 
 	// Only set policy in state if it's not implied
 	if !info.ImpliedPolicy {


### PR DESCRIPTION
## Summary\nThe DiffSuppressFunc was added in PR #940 to prevent configuration drift for , but the field should also be cleared in the Read function for consistency with how  is handled.\n\n## Changes\n- Clear  in the Read function after reading the access key\n\n## Related\n- Builds on #940 which added the DiffSuppressFunc\n- Fixes #941 (original issue about configuration drift)