### PR TITLE
fix(accesskey): resolve plan drift on sensitive access_key references

### DIFF
--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -92,7 +92,7 @@ The `policy` argument expects a JSON policy document. Use `jsonencode({...})` to
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `access_key` (String) The access key. If provided, must be between 8 and 20 characters.
+- `access_key` (String, Sensitive) The access key. If provided, must be between 8 and 20 characters.
 - `description` (String) Description for the access key (max 256 characters).
 - `policy` (String) Policy to attach to the access key (policy name or JSON document).
 - `secret_key` (String, Sensitive) The secret key. If provided, must be at least 8 characters. This is a write-only field and will not be stored in state.

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -93,13 +93,10 @@ func resourceMinioAccessKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				// Marked Sensitive so that sourcing the value from another
-				// sensitive value (e.g. random_password.foo.result) does
-				// not cause a sensitivity-mismatch diff on every plan,
-				// where state (untagged) is compared against config (tagged
-				// sensitive) and Terraform reports a perpetual change. An
-				// access key is half of a credential pair; redacting it in
-				// plan output is also a reasonable default.
+				// Sensitive so the marker matches when access_key is sourced
+				// from a sensitive expression (e.g. random_password.result);
+				// otherwise state (untagged) vs config (tagged) is reported
+				// as a diff on every plan even when the value is identical.
 				Sensitive:   true,
 				Description: "The access key. If provided, must be between 8 and 20 characters.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
@@ -342,10 +339,7 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 	_ = d.Set("access_key", accessKeyID)
 	_ = d.Set("description", info.Description)
 
-	// Clear write-only secret fields from state. Both secret_key and
-	// secret_key_wo are write-only and must not be persisted; clearing them
-	// here keeps the refreshed state aligned with that contract so plans
-	// don't drift on subsequent applies.
+	// Clear write-only secret fields from state.
 	_ = d.Set("secret_key", "")
 	_ = d.Set("secret_key_wo", "")
 

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -334,8 +334,12 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 	_ = d.Set("access_key", accessKeyID)
 	_ = d.Set("description", info.Description)
 
-	// Clear secret_key from state - it's write-only
+	// Clear write-only secret fields from state. Both secret_key and
+	// secret_key_wo are write-only and must not be persisted; clearing them
+	// here keeps the refreshed state aligned with that contract so plans
+	// don't drift on subsequent applies.
 	_ = d.Set("secret_key", "")
+	_ = d.Set("secret_key_wo", "")
 
 	// Only set policy in state if it's not implied
 	if !info.ImpliedPolicy {

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -90,9 +90,17 @@ func resourceMinioAccessKey() *schema.Resource {
 				},
 			},
 			"access_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Marked Sensitive so that sourcing the value from another
+				// sensitive value (e.g. random_password.foo.result) does
+				// not cause a sensitivity-mismatch diff on every plan,
+				// where state (untagged) is compared against config (tagged
+				// sensitive) and Terraform reports a perpetual change. An
+				// access key is half of a credential pair; redacting it in
+				// plan output is also a reasonable default.
+				Sensitive:   true,
 				Description: "The access key. If provided, must be between 8 and 20 characters.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -514,15 +514,18 @@ func TestAccMinioAccessKey_writeOnlySecretNoDrift(t *testing.T) {
 }
 
 // TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift reproduces
-// the user-reported scenario from issue #941 where secret_key_wo is sourced
-// from a random_password resource (rather than a literal HCL string) and
-// drift was observed on subsequent plans. The literal-string variant is
-// already covered by TestAccMinioAccessKey_writeOnlySecretNoDrift; this test
-// exercises the reference-through-the-plan-graph path that the reporter hit.
+// the user-reported scenario from issue #941 where both access_key and
+// secret_key_wo are sourced from random_password resources (rather than
+// literal HCL strings) and drift was observed on subsequent plans. The
+// literal-string variant is already covered by
+// TestAccMinioAccessKey_writeOnlySecretNoDrift; this test exercises the
+// reference-through-the-plan-graph path the reporter hit, which exposes
+// (1) a write-only state-clearing gap in Read, and (2) a sensitivity
+// marker mismatch on access_key when its value is sourced from a
+// sensitive expression like random_password.foo.result.
 func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "minio_accesskey.test"
-	accessKey := acctest.RandString(20)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -534,21 +537,22 @@ func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				Config: testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "secret_key", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "access_key"),
 					resource.TestCheckNoResourceAttr(resourceName, "secret_key_wo"),
 				),
 			},
 			{
-				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, 1),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
 				// Run plan-only twice in a row to catch drift that only
 				// appears after the first refresh-after-apply cycle.
-				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, 1),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -556,8 +560,13 @@ func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T
 	})
 }
 
-func testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey string, version int) string {
+func testAccMinioAccessKeyConfigWithRandomPasswordWO(rName string, version int) string {
 	return fmt.Sprintf(`
+resource "random_password" "access_key" {
+  length  = 16
+  special = false
+}
+
 resource "random_password" "secret" {
   length  = 40
   special = false
@@ -569,11 +578,11 @@ resource "minio_iam_user" "test" {
 
 resource "minio_accesskey" "test" {
   user                  = minio_iam_user.test.name
-  access_key            = %q
+  access_key            = random_password.access_key.result
   secret_key_wo         = random_password.secret.result
   secret_key_wo_version = %d
 }
-`, rName, accessKey, version)
+`, rName, version)
 }
 
 func testAccMinioAccessKeyConfigWithVersion(rName, accessKey, secretKey, version string) string {

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -513,6 +513,69 @@ func TestAccMinioAccessKey_writeOnlySecretNoDrift(t *testing.T) {
 	})
 }
 
+// TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift reproduces
+// the user-reported scenario from issue #941 where secret_key_wo is sourced
+// from a random_password resource (rather than a literal HCL string) and
+// drift was observed on subsequent plans. The literal-string variant is
+// already covered by TestAccMinioAccessKey_writeOnlySecretNoDrift; this test
+// exercises the reference-through-the-plan-graph path that the reporter hit.
+func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "minio_accesskey.test"
+	accessKey := acctest.RandString(20)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "secret_key", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_key_wo"),
+				),
+			},
+			{
+				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// Run plan-only twice in a row to catch drift that only
+				// appears after the first refresh-after-apply cycle.
+				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey, 1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, accessKey string, version int) string {
+	return fmt.Sprintf(`
+resource "random_password" "secret" {
+  length  = 40
+  special = false
+}
+
+resource "minio_iam_user" "test" {
+  name = %q
+}
+
+resource "minio_accesskey" "test" {
+  user                  = minio_iam_user.test.name
+  access_key            = %q
+  secret_key_wo         = random_password.secret.result
+  secret_key_wo_version = %d
+}
+`, rName, accessKey, version)
+}
+
 func testAccMinioAccessKeyConfigWithVersion(rName, accessKey, secretKey, version string) string {
 	return fmt.Sprintf(`
 resource "minio_iam_user" "test" {

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -513,16 +513,11 @@ func TestAccMinioAccessKey_writeOnlySecretNoDrift(t *testing.T) {
 	})
 }
 
-// TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift reproduces
-// the user-reported scenario from issue #941 where both access_key and
-// secret_key_wo are sourced from random_password resources (rather than
-// literal HCL strings) and drift was observed on subsequent plans. The
-// literal-string variant is already covered by
-// TestAccMinioAccessKey_writeOnlySecretNoDrift; this test exercises the
-// reference-through-the-plan-graph path the reporter hit, which exposes
-// (1) a write-only state-clearing gap in Read, and (2) a sensitivity
-// marker mismatch on access_key when its value is sourced from a
-// sensitive expression like random_password.foo.result.
+// TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift covers the
+// issue #941 scenario where access_key and secret_key_wo are sourced from
+// random_password rather than literal HCL strings. This is the reference
+// path that exposed the access_key sensitivity-marker flip and the
+// secret_key_wo state-clearing gap in Read.
 func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "minio_accesskey.test"
@@ -550,8 +545,8 @@ func TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift(t *testing.T
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				// Run plan-only twice in a row to catch drift that only
-				// appears after the first refresh-after-apply cycle.
+				// Second plan-only to catch drift that only surfaces after
+				// the first refresh-after-apply cycle.
 				Config:             testAccMinioAccessKeyConfigWithRandomPasswordWO(rName, 1),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,


### PR DESCRIPTION
## Summary

Two related fixes for the perpetual plan drift reported in #941 when `minio_accesskey` is used with values sourced from `random_password` (or any other sensitive expression). [Confirmed by @dennismdejong](https://github.com/aminueza/terraform-provider-minio/pull/944#issuecomment-4461979837) against a build of this branch using his original config, `tofu plan` now reports "No changes".

1. **`access_key` marked `Sensitive: true`**: the actual fix for the reported drift. The reporter's plan showed `~ access_key = (sensitive value)` because their config sets `access_key = random_password.name.result`, which the `hashicorp/random` provider marks sensitive. Our schema didn't, so state (untagged) vs config (tagged sensitive) was a marker mismatch that Terraform / OpenTofu treats as a change on every plan. Marking the schema field sensitive aligns the marker on both sides and stops the perpetual diff. It also redacts the value in plan output, which is a reasonable default for half of a credential pair.

2. **`secret_key_wo` cleared in Read**: defensive consistency with how `secret_key` is already cleared in Read. Mirrors the write-only contract explicitly so refreshed state never carries a write-only value.

## Why the `(write-only attribute)` line in the reported plan was a red herring

The reporter's first plan also showed:

```
~ secret_key_wo = (write-only attribute)
```

That line is Terraform / OpenTofu's standard display for any write-only field whenever its parent resource is in an update plan, it doesn't mean the WO field is what's drifting. Once the `access_key` sensitivity-flip is fixed, the resource is no longer in an update plan and the line disappears (visible in the reporter's "No changes" follow-up).

## Why `minio_iam_service_account` doesn't have this bug

Its `access_key` is `Computed: true` only, the user can't assign a sensitive expression to it, so the marker-flip path doesn't exist. The `Optional: true, Computed: true` on `minio_accesskey.access_key` is the structural reason this resource is uniquely affected.

## What's unchanged

- `DiffSuppressFunc` on `secret_key_wo` (from #940)
- `ValidateFunc` and description on `secret_key_wo`
- `Description` on `secret_key_wo_version`
- `CustomizeDiff` body
- Schema layout / field ordering

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test -run TestProvider_impl ./minio/...` (compile-check)
- [x] @dennismdejong confirmed drift is gone on his original config against a build of this branch
- [x] `TF_ACC=1 go test -v -run TestAccMinioAccessKey ./minio/...` against a live MinIO, covers the existing suite plus the new `TestAccMinioAccessKey_writeOnlySecretFromRandomPasswordNoDrift` (sources both `access_key` and `secret_key_wo` from `random_password` and runs two consecutive `PlanOnly` steps to assert zero drift)

The docs change in this PR (`docs/resources/accesskey.md`) is auto-generated by the existing docs workflow from the schema update; no manual doc edits.

Closes #941. Supersedes #942 and #943.