### PR TITLE
ci(docs): stop emitting [skip ci] on auto-generated docs commits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -96,7 +96,7 @@ jobs:
             # main is a protected branch — open a PR instead of pushing directly
             BRANCH="docs/auto-update-$(date +%Y%m%d%H%M%S)"
             git checkout -b "$BRANCH"
-            git commit -m "docs: auto-generate provider documentation [skip ci]"
+            git commit -m "docs: auto-generate provider documentation"
             git push origin "$BRANCH"
             gh pr create \
               --title "docs: auto-generate provider documentation" \
@@ -104,7 +104,7 @@ jobs:
               --head "$BRANCH" \
               --base main
           else
-            git commit -m "docs: auto-generate provider documentation [skip ci]"
+            git commit -m "docs: auto-generate provider documentation"
             git push
           fi
 


### PR DESCRIPTION
## Problem

The `Docs CI` workflow's `generate-docs` job pushes a follow-up commit to PR branches after `tfplugindocs` regenerates docs. That commit message ends with `[skip ci]`, which GitHub Actions honors by skipping **every** subsequent workflow (`go.yml` lint & test, `security.yml` gosec/Trivy, etc.) on the PR's new HEAD commit.

Observable effect: a PR that originally had failing lint/test/gosec checks shows up as green after the docs bot's auto-commit lands, because only a handful of always-on jobs (CodeQL, Analyze) ignore the marker. Reviewers see green, merge, and the lint/test regressions ship to main.

Spotted while triaging a batch of feature PRs ([#945](https://github.com/aminueza/terraform-provider-minio/pull/945)–[#949](https://github.com/aminueza/terraform-provider-minio/pull/949)) whose actual code-quality checks never re-ran on the fix commits.

## Fix

Drop `[skip ci]` from both auto-commit messages in `.github/workflows/docs.yml`:

- L107 — the PR-branch path (the immediate bug)
- L99 — the main-branch path that opens a separate docs PR (same issue: the docs PR would otherwise open with CI suppressed)

No loop risk: the workflow already short-circuits via `git diff --cached --quiet` when there is nothing new to commit, so re-running CI on the doc-update commit will simply observe up-to-date docs and exit.

## After this merges

The 5 feature PRs ([#945](https://github.com/aminueza/terraform-provider-minio/pull/945)–[#949](https://github.com/aminueza/terraform-provider-minio/pull/949)) need to be rebased so their docs-bot follow-up commits get rewritten without the marker, then their full CI matrix can actually run.