### PR TITLE
feat(batch_job): wire GetSupportedBatchJobTypes and add minio_batch_job_template

### DIFF
--- a/examples/data-sources/minio_batch_job_template/data-source.tf
+++ b/examples/data-sources/minio_batch_job_template/data-source.tf
@@ -1,0 +1,8 @@
+data "minio_batch_job_template" "replicate" {
+  job_type = "replicate"
+}
+
+resource "minio_batch_job" "migrate" {
+  job_type = "replicate"
+  job_yaml = data.minio_batch_job_template.replicate.yaml
+}

--- a/minio/data_source_minio_batch_job_template.go
+++ b/minio/data_source_minio_batch_job_template.go
@@ -1,0 +1,70 @@
+package minio
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/madmin-go/v3"
+)
+
+func dataSourceMinioBatchJobTemplate() *schema.Resource {
+	return &schema.Resource{
+		Description: "Returns a starter YAML template for a given MinIO batch job type. Calls `GenerateBatchJobV2` (EOS-only API) and falls back to the SDK's bundled static template when the server does not advertise the endpoint.",
+
+		ReadContext: dataSourceMinioBatchJobTemplateRead,
+
+		Schema: map[string]*schema.Schema{
+			"job_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Batch job type to generate a template for (e.g. `replicate`, `expire`, `keyrotate`).",
+			},
+			"yaml": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "YAML job-definition template.",
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Where the template came from: `server` (via `GenerateBatchJobV2`) or `sdk` (bundled fallback).",
+			},
+		},
+	}
+}
+
+func dataSourceMinioBatchJobTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	admin := meta.(*S3MinioClient).S3Admin
+
+	jobType := d.Get("job_type").(string)
+	opts := madmin.GenerateBatchJobOpts{Type: madmin.BatchJobType(jobType)}
+
+	log.Printf("[DEBUG] Generating batch job template for type: %s", jobType)
+
+	tmpl, apiUnavailable, err := admin.GenerateBatchJobV2(ctx, opts)
+	source := "server"
+	if err != nil {
+		return NewResourceError("generating batch job template", jobType, err)
+	}
+	if apiUnavailable {
+		log.Printf("[DEBUG] GenerateBatchJobV2 unavailable, falling back to SDK template for type: %s", jobType)
+		tmpl, err = admin.GenerateBatchJob(ctx, opts)
+		if err != nil {
+			return NewResourceError("generating batch job template (fallback)", jobType, err)
+		}
+		source = "sdk"
+	}
+
+	if err := d.Set("yaml", tmpl); err != nil {
+		return NewResourceError("setting yaml", jobType, err)
+	}
+	if err := d.Set("source", source); err != nil {
+		return NewResourceError("setting source", jobType, err)
+	}
+
+	d.SetId("batch_job_template:" + jobType)
+
+	return nil
+}

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -284,6 +284,7 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_s3_objects":                          dataSourceMinioS3Objects(),
 			"minio_pool_rebalance_status":               dataSourceMinioPoolRebalanceStatus(),
 			"minio_batch_jobs":                          dataSourceMinioBatchJobs(),
+			"minio_batch_job_template":                  dataSourceMinioBatchJobTemplate(),
 			"minio_pool_status":                         dataSourceMinioPoolStatus(),
 			"minio_bucket_metadata_export":              dataSourceMinioBucketMetadataExport(),
 

--- a/minio/resource_minio_batch_job.go
+++ b/minio/resource_minio_batch_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -27,11 +28,10 @@ func resourceMinioBatchJob() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"job_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"replicate", "expire", "keyrotate"}, false),
-				Description:  "Batch job type. One of `replicate`, `expire`, `keyrotate`.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Batch job type. The provider queries the server's supported types via `GetSupportedBatchJobTypes` at Create time and rejects values the server does not advertise. Typically one of `replicate`, `expire`, `keyrotate`.",
 			},
 			"job_yaml": {
 				Type:        schema.TypeString,
@@ -70,6 +70,10 @@ func minioCreateBatchJob(ctx context.Context, d *schema.ResourceData, meta inter
 	batchConfig := BatchJobConfig(d, meta)
 
 	log.Printf("[DEBUG] Creating batch job of type: %s", batchConfig.JobType)
+
+	if diags := validateBatchJobType(ctx, batchConfig.MinioAdmin, batchConfig.JobType); diags != nil {
+		return diags
+	}
 
 	result, err := batchConfig.MinioAdmin.StartBatchJob(ctx, batchConfig.JobYAML)
 	if err != nil {
@@ -150,6 +154,34 @@ func minioDeleteBatchJob(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId("")
 
 	return nil
+}
+
+func validateBatchJobType(ctx context.Context, admin *madmin.AdminClient, jobType string) diag.Diagnostics {
+	if jobType == "" {
+		return NewResourceError("validating job_type", jobType, fmt.Errorf("job_type must not be empty"))
+	}
+
+	supported, apiUnavailable, err := admin.GetSupportedBatchJobTypes(ctx)
+	if err != nil {
+		return NewResourceError("listing supported batch job types", jobType, err)
+	}
+
+	if apiUnavailable {
+		log.Printf("[DEBUG] GetSupportedBatchJobTypes unavailable on this MinIO version, accepting job_type %q without server-side validation", jobType)
+		return nil
+	}
+
+	for _, t := range supported {
+		if string(t) == jobType {
+			return nil
+		}
+	}
+
+	names := make([]string, len(supported))
+	for i, t := range supported {
+		names[i] = string(t)
+	}
+	return NewResourceError("validating job_type", jobType, fmt.Errorf("job_type %q is not supported by this MinIO server; supported types: %s", jobType, strings.Join(names, ", ")))
 }
 
 func waitForBatchJobStatus(ctx context.Context, config *S3MinioBatchJob, jobID string, targetStatus string, timeout time.Duration) diag.Diagnostics {

--- a/templates/data-sources/batch_job_template.md.tmpl
+++ b/templates/data-sources/batch_job_template.md.tmpl
@@ -1,0 +1,16 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile (printf "examples/data-sources/%s/data-source.tf" .Name) }}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
- Resolves #955.

## Summary

Closes out the two madmin-go SDK methods that were listed in #881's spec but not wired up by #945.

### `minio_batch_job` — server-driven `job_type` validation

Replaces the static `["replicate","expire","keyrotate"]` `ValidateFunc` with a Create-time call to `GetSupportedBatchJobTypes(ctx)`. Behavior:

- If the server advertises the endpoint and the configured `job_type` is in the list -> proceed.
- If it is not in the list -> fail with an error that quotes the server's actual supported set (so a user on a newer MinIO can discover `catalog`, and a user on a stripped-down build sees what is actually available).
- If the server returns `apiUnavailable` (older MinIO that pre-dates the endpoint) -> log and proceed with the user's value, preserving backwards compatibility.

### `minio_batch_job_template` data source

New data source wrapping `GenerateBatchJobV2(ctx, GenerateBatchJobOpts{Type: ...})`. Lets users pull a server-validated YAML skeleton instead of hand-writing one:

```hcl
data "minio_batch_job_template" "replicate" {
  job_type = "replicate"
}

resource "minio_batch_job" "migrate" {
  job_type = "replicate"
  job_yaml = data.minio_batch_job_template.replicate.yaml
}
```

`GenerateBatchJobV2` is documented as an EOS-only API; when the server returns `apiUnavailable`, the data source transparently falls back to `GenerateBatchJob` (the SDK's bundled static templates). A `source` computed attribute (`"server"` vs `"sdk"`) lets users see which path produced the YAML.

## Test plan

- [ ] `task test` (unit tests still pass)
- [ ] Manual acceptance: `TestAccBatchJob` against a real MinIO -> unchanged behavior for supported types
- [ ] Manual acceptance: apply with `job_type = "bogus"` -> error mentions the server's supported types instead of the static three
- [ ] Manual: `data.minio_batch_job_template.replicate.yaml` on a recent MinIO returns server template (`source = "server"`); on an older one falls back to SDK template (`source = "sdk"`)
- [ ] Docs regenerate cleanly after merge (`check-templates` already gated by template stub in this PR)