### PR TITLE
refactor(logging): plumb ctx through helpers, finish tflog migration

### DIFF
--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -1,6 +1,7 @@
 package minio
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -62,10 +63,10 @@ func BucketVersioningConfig(d *schema.ResourceData, meta interface{}) *S3MinioBu
 
 // BucketReplicationConfig creates configuration for managing MinIO bucket replication.
 // It sets up replication rules between buckets.
-func BucketReplicationConfig(d *schema.ResourceData, meta interface{}) (*S3MinioBucketReplication, diag.Diagnostics) {
+func BucketReplicationConfig(ctx context.Context, d *schema.ResourceData, meta interface{}) (*S3MinioBucketReplication, diag.Diagnostics) {
 	m := meta.(*S3MinioClient)
 
-	replicationRules, diags := getBucketReplicationConfig(d.Get("rule").([]interface{}), d)
+	replicationRules, diags := getBucketReplicationConfig(ctx, d.Get("rule").([]interface{}), d)
 	if diags.HasError() {
 		return nil, diags
 	}

--- a/minio/fuzz_test.go
+++ b/minio/fuzz_test.go
@@ -1,6 +1,7 @@
 package minio
 
 import (
+	"context"
 	"testing"
 )
 
@@ -42,7 +43,7 @@ func FuzzParseBandwidthLimit(f *testing.F) {
 			"bandwidth_limit": bandwidthStr,
 		}
 		// Must not panic regardless of input
-		_, _, _ = ParseBandwidthLimit(target)
+		_, _, _ = ParseBandwidthLimit(context.Background(), target)
 	})
 }
 

--- a/minio/import_minio_s3_buckets.go
+++ b/minio/import_minio_s3_buckets.go
@@ -35,18 +35,18 @@ func resourceMinioS3BucketImportState(
 		return []*schema.ResourceData{d}, nil
 	}
 
-	_ = d.Set("acl", policyToACLName(bucketConfig, pol))
+	_ = d.Set("acl", policyToACLName(ctx, bucketConfig, pol))
 
 	return []*schema.ResourceData{d}, nil
 }
 
-func policyToACLName(bucketConfig *S3MinioBucket, pol string) string {
+func policyToACLName(ctx context.Context, bucketConfig *S3MinioBucket, pol string) string {
 
 	defaultPolicies := map[string]string{
-		"public-read":       exportPolicyString(ReadOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public-write":      exportPolicyString(WriteOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public-read-write": exportPolicyString(ReadWritePolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public":            exportPolicyString(PublicPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-read":       exportPolicyString(ctx, ReadOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-write":      exportPolicyString(ctx, WriteOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-read-write": exportPolicyString(ctx, ReadWritePolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public":            exportPolicyString(ctx, PublicPolicy(bucketConfig), bucketConfig.MinioBucket),
 	}
 
 	for name, defaultPolicy := range defaultPolicies {

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"net"
 	"net/http"
 	"os"
@@ -24,9 +24,9 @@ const (
 
 // NewClient creates and configures both S3 and admin clients for MinIO
 // It handles the setup of credentials, SSL/TLS configuration, and custom transport options
-func (config *S3MinioConfig) NewClient() (interface{}, error) {
+func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error) {
 	// Set up custom transport with SSL/TLS configuration
-	tr, err := config.customTransport()
+	tr, err := config.customTransport(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure transport: %w", err)
 	}
@@ -64,7 +64,7 @@ func (config *S3MinioConfig) NewClient() (interface{}, error) {
 			return nil, fmt.Errorf("failed to assume role: %w", err)
 		}
 		minioCredentials = stsCreds
-		log.Printf("[DEBUG] Using STS AssumeRole credentials (role=%s, session=%s)", config.AssumeRoleARN, config.AssumeRoleSessionName)
+		tflog.Debug(ctx, "Using STS AssumeRole credentials", map[string]interface{}{"role": config.AssumeRoleARN, "session": config.AssumeRoleSessionName})
 	}
 
 	if config.WebIdentityToken != "" || config.WebIdentityTokenFile != "" {
@@ -94,7 +94,7 @@ func (config *S3MinioConfig) NewClient() (interface{}, error) {
 			return nil, fmt.Errorf("failed to assume role with web identity: %w", err)
 		}
 		minioCredentials = wiCreds
-		log.Printf("[DEBUG] Using STS WebIdentity credentials")
+		tflog.Debug(ctx, "Using STS WebIdentity credentials")
 	}
 
 	// Initialize S3 client
@@ -142,7 +142,7 @@ func detectEdition(admin *madmin.AdminClient, s3CompatMode bool) string {
 	defer cancel()
 	info, err := admin.ServerInfo(ctx)
 	if err != nil {
-		log.Printf("[DEBUG] server edition probe failed: %v", err)
+		tflog.Debug(ctx, "server edition probe failed", map[string]interface{}{"err": err.Error()})
 		return ""
 	}
 	for _, srv := range info.Servers {
@@ -165,7 +165,7 @@ func isValidCertificate(certBytes []byte) bool {
 
 // customTransport creates and configures an HTTP transport with SSL/TLS settings
 // It handles CA certificates, client certificates, and verification settings
-func (config *S3MinioConfig) customTransport() (*http.Transport, error) {
+func (config *S3MinioConfig) customTransport(ctx context.Context) (*http.Transport, error) {
 	timeout := time.Duration(config.RequestTimeoutSeconds) * time.Second
 
 	// If SSL is disabled, return default transport with timeout settings
@@ -221,7 +221,7 @@ func (config *S3MinioConfig) customTransport() (*http.Transport, error) {
 	tr.TLSHandshakeTimeout = timeout
 	tr.ResponseHeaderTimeout = timeout
 
-	log.Printf("[DEBUG] MinIO SSL client transport configured successfully")
+	tflog.Debug(ctx, "MinIO SSL client transport configured successfully")
 	return tr, nil
 }
 

--- a/minio/new_client_test.go
+++ b/minio/new_client_test.go
@@ -1,6 +1,7 @@
 package minio
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -10,7 +11,7 @@ func TestCustomTransport_DefaultTimeout(t *testing.T) {
 		RequestTimeoutSeconds: 30,
 	}
 
-	tr, err := config.customTransport()
+	tr, err := config.customTransport(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -25,7 +26,7 @@ func TestCustomTransport_CustomTimeout(t *testing.T) {
 		RequestTimeoutSeconds: 60,
 	}
 
-	tr, err := config.customTransport()
+	tr, err := config.customTransport(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -40,7 +41,7 @@ func TestCustomTransport_ZeroTimeout(t *testing.T) {
 		RequestTimeoutSeconds: 0,
 	}
 
-	tr, err := config.customTransport()
+	tr, err := config.customTransport(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -57,7 +58,7 @@ func TestCustomTransport_SSLWithTimeout(t *testing.T) {
 		RequestTimeoutSeconds: 45,
 	}
 
-	tr, err := config.customTransport()
+	tr, err := config.customTransport(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -81,7 +82,7 @@ func TestNewClient_PropagatesRetryConfig(t *testing.T) {
 		RetryDelayMs:          2000,
 	}
 
-	client, err := config.NewClient()
+	client, err := config.NewClient(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -408,7 +408,7 @@ func validateAPIVersion(v interface{}, k string) (ws []string, errors []error) {
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	minioConfig := NewConfig(d)
-	client, err := minioConfig.NewClient()
+	client, err := minioConfig.NewClient(ctx)
 	if err != nil {
 		return nil, NewResourceError("Failed to create MinIO client", "client_creation", err)
 	}

--- a/minio/resource_minio_bucket_metadata_import.go
+++ b/minio/resource_minio_bucket_metadata_import.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"io"
-	"log"
 	"strings"
 	"time"
 
@@ -190,10 +189,10 @@ func minioReadBucketMetadataImport(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func minioDeleteBucketMetadataImport(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func minioDeleteBucketMetadataImport(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	bucket := d.Get("bucket").(string)
 
-	log.Printf("[DEBUG] Removing bucket metadata import from state for bucket: %s", bucket)
+	tflog.Debug(ctx, "Removing bucket metadata import from state", map[string]interface{}{"bucket": bucket})
 
 	d.SetId("")
 

--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"regexp"
 	"strings"
 
@@ -88,7 +87,7 @@ func minioUpdateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 	if d.HasChange(iamGroupConfig.MinioIAMName) {
 		_, nn := d.GetChange(iamGroupConfig.MinioIAMName)
 
-		log.Println("[DEBUG] Update IAM Group:", iamGroupConfig.MinioIAMName)
+		tflog.Debug(ctx, "Updating IAM group", map[string]interface{}{"name": iamGroupConfig.MinioIAMName})
 
 		groupAddRemove := madmin.GroupAddRemove{
 			Group:    iamGroupConfig.MinioIAMName,
@@ -203,7 +202,7 @@ func minioStatusGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	iamGroupConfig := IAMGroupConfig(d, meta)
 
-	log.Println("[DEBUG] Disabling IAM Group request:", iamGroupConfig.MinioIAMName)
+	tflog.Debug(ctx, "Disabling IAM group", map[string]interface{}{"name": iamGroupConfig.MinioIAMName})
 
 	if iamGroupConfig.MinioDisableGroup {
 		minioGroupStatus = madmin.GroupDisabled
@@ -222,7 +221,7 @@ func minioStatusGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 func deleteMinioGroup(ctx context.Context, iamGroupConfig *S3MinioIAMGroupConfig, members []string) error {
 
-	log.Println("[DEBUG] deleting IAM Group request:", iamGroupConfig.MinioIAMName)
+	tflog.Debug(ctx, "Deleting IAM group", map[string]interface{}{"name": iamGroupConfig.MinioIAMName})
 	groupAddRemove := madmin.GroupAddRemove{
 		Group:    iamGroupConfig.MinioIAMName,
 		Members:  members,

--- a/minio/resource_minio_iam_import.go
+++ b/minio/resource_minio_iam_import.go
@@ -9,12 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"io"
-	"log"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v3"
+	"io"
 )
 
 func resourceMinioIAMImport() *schema.Resource {
@@ -124,10 +122,10 @@ func resourceMinioIAMImportRead(_ context.Context, d *schema.ResourceData, _ int
 	return nil
 }
 
-func resourceMinioIAMImportDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Deleting IAM import (no-op): %s", d.Id())
+func resourceMinioIAMImportDelete(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, "Deleting IAM import (no-op)", map[string]interface{}{"id": d.Id()})
 	d.SetId("")
-	log.Printf("[DEBUG] Deleted IAM import")
+	tflog.Debug(ctx, "Deleted IAM import")
 	return nil
 }
 

--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"regexp"
 	"strings"
 
@@ -127,7 +126,7 @@ func minioReadPolicy(ctx context.Context, d *schema.ResourceData, meta interface
 func minioUpdatePolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamPolicyConfig := IAMPolicyConfig(d, meta)
 
-	log.Println("[DEBUG] Update IAM Policy:", d.Id())
+	tflog.Debug(ctx, "Updating IAM policy", map[string]interface{}{"id": d.Id()})
 
 	err := iamPolicyConfig.MinioAdmin.AddCannedPolicy(ctx, d.Id(), []byte(iamPolicyConfig.MinioIAMPolicy))
 	if err != nil {

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"regexp"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -268,7 +267,7 @@ func validateMinioIamUserName(v interface{}, k string) (ws []string, errors []er
 }
 
 func deleteMinioIamUser(ctx context.Context, iamUserConfig *S3MinioIAMUserConfig) error {
-	log.Println("[DEBUG] Deleting IAM User request:", iamUserConfig.MinioIAMName)
+	tflog.Debug(ctx, "Deleting IAM user", map[string]interface{}{"name": iamUserConfig.MinioIAMName})
 	err := iamUserConfig.MinioAdmin.RemoveUser(ctx, iamUserConfig.MinioIAMName)
 	if err != nil {
 		return err

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -477,7 +476,7 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 			}
 			return nil
 		}
-		log.Println(NewResourceErrorStr("reading lifecycle configuration failed", d.Id(), err))
+		tflog.Error(ctx, NewResourceErrorStr("reading lifecycle configuration failed", d.Id(), err))
 		d.SetId("")
 		return nil
 	}

--- a/minio/resource_minio_notify_common.go
+++ b/minio/resource_minio_notify_common.go
@@ -3,9 +3,9 @@ package minio
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -26,7 +26,7 @@ func notifyCreate(nrc notifyResourceConfig) schema.CreateContextFunc {
 		admin := meta.(*S3MinioClient).S3Admin
 		name := d.Get("name").(string)
 
-		log.Printf("[DEBUG] Creating %s: %s", nrc.subsystem, name)
+		tflog.Debug(ctx, "Creating notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 
 		cfgData := nrc.buildCfg(d, meta)
 		configString := fmt.Sprintf("%s %s", notifyConfigKey(nrc.subsystem, name), cfgData)
@@ -38,7 +38,7 @@ func notifyCreate(nrc notifyResourceConfig) schema.CreateContextFunc {
 		d.SetId(name)
 		_ = d.Set("restart_required", restart)
 
-		log.Printf("[DEBUG] Created %s: %s (restart_required=%v)", nrc.subsystem, name, restart)
+		tflog.Debug(ctx, "Created notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name, "restart_required": restart})
 
 		return notifyRead(nrc)(ctx, d, meta)
 	}
@@ -49,16 +49,16 @@ func notifyRead(nrc notifyResourceConfig) schema.ReadContextFunc {
 		admin := meta.(*S3MinioClient).S3Admin
 		name := d.Id()
 
-		log.Printf("[DEBUG] Reading %s: %s", nrc.subsystem, name)
+		tflog.Debug(ctx, "Reading notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 
 		configKey := notifyConfigKey(nrc.subsystem, name)
 		configData, err := admin.GetConfigKV(ctx, configKey)
 		if err != nil {
-			return handleNotifyReadError(err, nrc.subsystem, name, d)
+			return handleNotifyReadError(ctx, err, nrc.subsystem, name, d)
 		}
 
 		configStr := strings.TrimSpace(string(configData))
-		log.Printf("[DEBUG] Raw config data for %s %s: %s", nrc.subsystem, name, configStr)
+		tflog.Debug(ctx, "Raw notification target config", map[string]interface{}{"subsystem": nrc.subsystem, "name": name, "raw": configStr})
 
 		var valueStr string
 		for _, line := range strings.Split(configStr, "\n") {
@@ -94,7 +94,7 @@ func notifyUpdate(nrc notifyResourceConfig) schema.UpdateContextFunc {
 		admin := meta.(*S3MinioClient).S3Admin
 		name := d.Get("name").(string)
 
-		log.Printf("[DEBUG] Updating %s: %s", nrc.subsystem, name)
+		tflog.Debug(ctx, "Updating notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 
 		cfgData := nrc.buildCfg(d, meta)
 		configString := fmt.Sprintf("%s %s", notifyConfigKey(nrc.subsystem, name), cfgData)
@@ -105,7 +105,7 @@ func notifyUpdate(nrc notifyResourceConfig) schema.UpdateContextFunc {
 
 		_ = d.Set("restart_required", restart)
 
-		log.Printf("[DEBUG] Updated %s: %s (restart_required=%v)", nrc.subsystem, name, restart)
+		tflog.Debug(ctx, "Updated notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name, "restart_required": restart})
 
 		return notifyRead(nrc)(ctx, d, meta)
 	}
@@ -116,7 +116,7 @@ func notifyDelete(nrc notifyResourceConfig) schema.DeleteContextFunc {
 		admin := meta.(*S3MinioClient).S3Admin
 		name := d.Id()
 
-		log.Printf("[DEBUG] Deleting %s: %s", nrc.subsystem, name)
+		tflog.Debug(ctx, "Deleting notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 
 		configKey := notifyConfigKey(nrc.subsystem, name)
 		_, err := admin.DelConfigKV(ctx, configKey)
@@ -124,7 +124,7 @@ func notifyDelete(nrc notifyResourceConfig) schema.DeleteContextFunc {
 			errMsg := strings.ToLower(err.Error())
 			if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "does not exist") ||
 				strings.Contains(errMsg, "there is no target") {
-				log.Printf("[WARN] %s %s already removed", nrc.subsystem, name)
+				tflog.Warn(ctx, "Notification target already removed", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 				d.SetId("")
 				return nil
 			}
@@ -132,21 +132,21 @@ func notifyDelete(nrc notifyResourceConfig) schema.DeleteContextFunc {
 		}
 
 		d.SetId("")
-		log.Printf("[DEBUG] Deleted %s: %s", nrc.subsystem, name)
+		tflog.Debug(ctx, "Deleted notification target", map[string]interface{}{"subsystem": nrc.subsystem, "name": name})
 
 		return nil
 	}
 }
 
-func handleNotifyReadError(err error, subsystem, name string, d *schema.ResourceData) diag.Diagnostics {
+func handleNotifyReadError(ctx context.Context, err error, subsystem, name string, d *schema.ResourceData) diag.Diagnostics {
 	errMsg := strings.ToLower(err.Error())
 	if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "does not exist") {
-		log.Printf("[WARN] %s %s no longer exists, removing from state", subsystem, name)
+		tflog.Warn(ctx, "Notification target no longer exists, removing from state", map[string]interface{}{"subsystem": subsystem, "name": name})
 		d.SetId("")
 		return nil
 	}
 	if strings.Contains(errMsg, "there is no target") {
-		log.Printf("[WARN] %s %s not yet active (server restart may be required)", subsystem, name)
+		tflog.Warn(ctx, "Notification target not yet active (server restart may be required)", map[string]interface{}{"subsystem": subsystem, "name": name})
 		_ = d.Set("name", name)
 		return nil
 	}

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -586,10 +585,10 @@ func minioSetBucketACL(ctx context.Context, bucketConfig *S3MinioBucket) diag.Di
 	}
 
 	defaultPolicies := map[string]string{
-		"public-write":      exportPolicyString(WriteOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public-read":       exportPolicyString(ReadOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public-read-write": exportPolicyString(ReadWritePolicy(bucketConfig), bucketConfig.MinioBucket),
-		"public":            exportPolicyString(PublicPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-write":      exportPolicyString(ctx, WriteOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-read":       exportPolicyString(ctx, ReadOnlyPolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public-read-write": exportPolicyString(ctx, ReadWritePolicy(bucketConfig), bucketConfig.MinioBucket),
+		"public":            exportPolicyString(ctx, PublicPolicy(bucketConfig), bucketConfig.MinioBucket),
 	}
 
 	policyString, policyExists := defaultPolicies[bucketConfig.MinioACL]
@@ -637,10 +636,10 @@ func removeBucketPolicy(ctx context.Context, bucketConfig *S3MinioBucket) diag.D
 	return nil
 }
 
-func exportPolicyString(policyStruct BucketPolicy, bucketName string) string {
+func exportPolicyString(ctx context.Context, policyStruct BucketPolicy, bucketName string) string {
 	policyJSON, err := json.Marshal(policyStruct)
 	if err != nil {
-		log.Printf("%s", NewResourceErrorStr("unable to parse bucket policy", bucketName, err))
+		tflog.Error(ctx, NewResourceErrorStr("unable to parse bucket policy", bucketName, err))
 		return NewResourceError("unable to parse bucket policy", bucketName, err)[0].Summary
 	}
 	return string(policyJSON)

--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"math"
 	"net/url"
 	"path"
@@ -275,7 +274,7 @@ func resourceMinioBucketReplication() *schema.Resource {
 }
 
 func minioPutBucketReplication(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	bucketReplicationConfig, diags := BucketReplicationConfig(d, meta)
+	bucketReplicationConfig, diags := BucketReplicationConfig(ctx, d, meta)
 	replicationConfig := bucketReplicationConfig.ReplicationRules
 
 	if replicationConfig == nil || diags.HasError() {
@@ -284,7 +283,7 @@ func minioPutBucketReplication(ctx context.Context, d *schema.ResourceData, meta
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put replication configuration: %v", bucketReplicationConfig.MinioBucket, replicationConfig))
 
-	cfg, err := convertBucketReplicationConfig(bucketReplicationConfig, replicationConfig)
+	cfg, err := convertBucketReplicationConfig(ctx, bucketReplicationConfig, replicationConfig)
 
 	if err != nil {
 		return NewResourceError(fmt.Sprintf("error generating bucket replication configuration for %q", bucketReplicationConfig.MinioBucket), d.Id(), err)
@@ -325,7 +324,7 @@ func minioPutBucketReplication(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	bucketReplicationConfig, diags := BucketReplicationConfig(d, meta)
+	bucketReplicationConfig, diags := BucketReplicationConfig(ctx, d, meta)
 
 	if diags.HasError() {
 		return diags
@@ -506,7 +505,7 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 }
 
 func minioDeleteBucketReplication(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	bucketReplicationConfig, diags := BucketReplicationConfig(d, meta)
+	bucketReplicationConfig, diags := BucketReplicationConfig(ctx, d, meta)
 
 	if len(bucketReplicationConfig.ReplicationRules) == 0 && !diags.HasError() {
 		tflog.Debug(ctx, fmt.Sprintf("Removing bucket replication for unversioned bucket (%s) from state", d.Id()))
@@ -550,29 +549,27 @@ func toEnableFlag(b bool) string {
 	return "disable"
 }
 
-func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplication, c []S3MinioBucketReplicationRule) (rcfg replication.Config, err error) {
+func convertBucketReplicationConfig(ctx context.Context, bucketReplicationConfig *S3MinioBucketReplication, c []S3MinioBucketReplicationRule) (rcfg replication.Config, err error) {
 	client := bucketReplicationConfig.MinioClient
 	admclient := bucketReplicationConfig.MinioAdmin
 
-	ctx := context.Background()
-
 	rcfg, err = client.GetBucketReplication(ctx, bucketReplicationConfig.MinioBucket)
 	if err != nil {
-		log.Printf("[WARN] Unable to fetch bucket replication config for %q: %v", bucketReplicationConfig.MinioBucket, err)
+		tflog.Warn(ctx, fmt.Sprintf("Unable to fetch bucket replication config for %q: %v", bucketReplicationConfig.MinioBucket, err))
 		return
 	}
 
 	usedARNs := make([]string, len(c))
 	existingRemoteTargets, err := admclient.ListRemoteTargets(ctx, bucketReplicationConfig.MinioBucket, "")
 	if err != nil {
-		log.Printf("[WARN] Unable to fetch existing remote target config for %q: %v", bucketReplicationConfig.MinioBucket, err)
+		tflog.Warn(ctx, fmt.Sprintf("Unable to fetch existing remote target config for %q: %v", bucketReplicationConfig.MinioBucket, err))
 		return
 	}
 
 	for i, rule := range c {
 		err = s3utils.CheckValidBucketName(rule.Target.Bucket)
 		if err != nil {
-			log.Printf("[WARN] Invalid bucket name for %q: %v", rule.Target.Bucket, err)
+			tflog.Warn(ctx, fmt.Sprintf("Invalid bucket name for %q: %v", rule.Target.Bucket, err))
 			return
 		}
 
@@ -580,7 +577,7 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 		if rule.Target.Path != "" {
 			tgtBucket = path.Clean("./" + rule.Target.Path + "/" + tgtBucket)
 		}
-		log.Printf("[DEBUG] Full path to target bucket is %s", tgtBucket)
+		tflog.Debug(ctx, fmt.Sprintf("Full path to target bucket is %s", tgtBucket))
 
 		creds := &madmin.Credentials{AccessKey: rule.Target.AccessKey, SecretKey: rule.Target.SecretKey}
 		bktTarget := &madmin.BucketTarget{
@@ -598,7 +595,7 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 			HealthCheckDuration: rule.Target.HealthCheckPeriod,
 		}
 		targets, _ := admclient.ListRemoteTargets(ctx, bucketReplicationConfig.MinioBucket, string(madmin.ReplicationService))
-		log.Printf("[DEBUG] Existing remote targets %q: %v", bucketReplicationConfig.MinioBucket, targets)
+		tflog.Debug(ctx, fmt.Sprintf("Existing remote targets %q: %v", bucketReplicationConfig.MinioBucket, targets))
 		var arn string
 
 		var existingRemoteTarget *madmin.BucketTarget
@@ -615,18 +612,16 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 
 		if existingRemoteTarget == nil || existingRemoteTarget.ReplicationSync != bktTarget.ReplicationSync {
 			if existingRemoteTarget != nil {
-				log.Printf("[DEBUG] Synchronous mode change detected (current: %t, new: %t). Re-creating remote target for bucket %q", existingRemoteTarget.ReplicationSync, bktTarget.ReplicationSync, bucketReplicationConfig.MinioBucket)
+				tflog.Debug(ctx, fmt.Sprintf("Synchronous mode change detected (current: %t, new: %t). Re-creating remote target for bucket %q", existingRemoteTarget.ReplicationSync, bktTarget.ReplicationSync, bucketReplicationConfig.MinioBucket))
 			} else {
-				log.Printf("[DEBUG] Adding new remote target for bucket %q: %s", bucketReplicationConfig.MinioBucket, formatBucketTargetForLog(bktTarget))
+				tflog.Debug(ctx, fmt.Sprintf("Adding new remote target for bucket %q: %s", bucketReplicationConfig.MinioBucket, formatBucketTargetForLog(bktTarget)))
 			}
 			arn, err = admclient.SetRemoteTarget(ctx, bucketReplicationConfig.MinioBucket, bktTarget)
 			if err != nil {
-				log.Printf("[WARN] Unable to configure remote target for bucket %q and targetBucket=%q at endpoint=%q: %v",
-					bucketReplicationConfig.MinioBucket,
+				tflog.Warn(ctx, fmt.Sprintf("Unable to configure remote target for bucket %q and targetBucket=%q at endpoint=%q: %v", bucketReplicationConfig.MinioBucket,
 					bktTarget.TargetBucket,
 					bktTarget.Endpoint,
-					err,
-				)
+					err))
 				return
 			}
 		} else {
@@ -656,15 +651,13 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 				existingRemoteTarget.Path = bktTarget.Path
 				remoteTargetUpdate = append(remoteTargetUpdate, madmin.PathUpdateType)
 			}
-			log.Printf("[DEBUG] Editing remote target for bucket %q: %s", bucketReplicationConfig.MinioBucket, formatBucketTargetForLog(bktTarget))
+			tflog.Debug(ctx, fmt.Sprintf("Editing remote target for bucket %q: %s", bucketReplicationConfig.MinioBucket, formatBucketTargetForLog(bktTarget)))
 			arn, err = admclient.UpdateRemoteTarget(ctx, existingRemoteTarget, remoteTargetUpdate...)
 			if err != nil {
-				log.Printf("[WARN] Unable to update remote target for bucket %q and targetBucket=%q at endpoint=%q: %v",
-					bucketReplicationConfig.MinioBucket,
+				tflog.Warn(ctx, fmt.Sprintf("Unable to update remote target for bucket %q and targetBucket=%q at endpoint=%q: %v", bucketReplicationConfig.MinioBucket,
 					bktTarget.TargetBucket,
 					bktTarget.Endpoint,
-					err,
-				)
+					err))
 				return
 			}
 		}
@@ -698,11 +691,11 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 			rule.Id = xid.New().String()
 			opts.ID = rule.Id
 			opts.Op = replication.AddOption
-			log.Printf("[DEBUG] Adding replication option for rule#%d: %v", i, opts)
+			tflog.Debug(ctx, fmt.Sprintf("Adding replication option for rule#%d: %v", i, opts))
 			err = rcfg.AddRule(opts)
 		} else {
 			opts.Op = replication.SetOption
-			log.Printf("[DEBUG] Editing replication option for rule#%d: %v", i, opts)
+			tflog.Debug(ctx, fmt.Sprintf("Editing replication option for rule#%d: %v", i, opts))
 			err = rcfg.EditRule(opts)
 		}
 
@@ -725,7 +718,7 @@ func convertBucketReplicationConfig(bucketReplicationConfig *S3MinioBucketReplic
 	return
 }
 
-func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result []S3MinioBucketReplicationRule, errs diag.Diagnostics) {
+func getBucketReplicationConfig(ctx context.Context, v []interface{}, d *schema.ResourceData) (result []S3MinioBucketReplicationRule, errs diag.Diagnostics) {
 	if len(v) == 0 || v[0] == nil {
 		return
 	}
@@ -738,26 +731,26 @@ func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result
 			errs = append(errs, diag.Errorf("Unable to extra the rule %d", i)...)
 			continue
 		}
-		log.Printf("[DEBUG] rule[%d] contains %v", i, tfMap)
+		tflog.Debug(ctx, fmt.Sprintf("rule[%d] contains %v", i, tfMap))
 
 		result[i].Arn, _ = tfMap["arn"].(string)
 		result[i].Id, _ = tfMap["id"].(string)
 
 		if result[i].Enabled, ok = tfMap["enabled"].(bool); !ok {
-			log.Printf("[DEBUG] rule[%d].enabled omitted. Defaulting to true", i)
+			tflog.Debug(ctx, fmt.Sprintf("rule[%d].enabled omitted. Defaulting to true", i))
 			result[i].Enabled = true
 		}
 
 		if result[i].Priority, ok = tfMap["priority"].(int); !ok || result[i].Priority == 0 {
 			// Since priorities are always positive, we use a negative value to indicate they were automatically generated
 			result[i].Priority = -len(v) + i
-			log.Printf("[DEBUG] rule[%d].priority omitted. Defaulting to index (%d)", i, -result[i].Priority)
+			tflog.Debug(ctx, fmt.Sprintf("rule[%d].priority omitted. Defaulting to index (%d)", i, -result[i].Priority))
 		}
 
 		result[i].Prefix, _ = tfMap["prefix"].(string)
 
 		if tags, ok := tfMap["tags"].(map[string]interface{}); ok {
-			log.Printf("[DEBUG] rule[%d].tags map contains: %v", i, tags)
+			tflog.Debug(ctx, fmt.Sprintf("rule[%d].tags map contains: %v", i, tags))
 			tagMap := map[string]string{}
 			for k, val := range tags {
 				var valOk bool
@@ -771,7 +764,7 @@ func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result
 			errs = append(errs, diag.Errorf("unable to extarct rule[%d].tags of type %s", i, reflect.TypeOf(tfMap["tags"]))...)
 		}
 
-		log.Printf("[DEBUG] rule[%d].tags are: %v", i, result[i].Tags)
+		tflog.Debug(ctx, fmt.Sprintf("rule[%d].tags are: %v", i, result[i].Tags))
 
 		result[i].DeleteReplication, ok = tfMap["delete_replication"].(bool)
 		result[i].DeleteReplication = result[i].DeleteReplication && ok
@@ -865,7 +858,7 @@ func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result
 
 		var bandwidth uint64
 		var err error
-		bandwidth, ok, parseDiags := ParseBandwidthLimit(target)
+		bandwidth, ok, parseDiags := ParseBandwidthLimit(ctx, target)
 		if len(parseDiags) > 0 {
 			errs = append(errs, diag.Errorf("rule[%d].target.bandwidth_limit is invalid. Make sure to use k, m, g as prefix only", i)...)
 		}
@@ -873,7 +866,7 @@ func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result
 		if ok {
 			var bwLimit int64
 			if bandwidth > uint64(math.MaxInt64) {
-				log.Printf("[WARN] Configured bandwidth limit (%d) exceeds maximum supported value (%d), clamping.", bandwidth, int64(math.MaxInt64))
+				tflog.Warn(ctx, fmt.Sprintf("Configured bandwidth limit (%d) exceeds maximum supported value (%d), clamping.", bandwidth, int64(math.MaxInt64)))
 				bwLimit = math.MaxInt64 // Clamp to max int64 if overflow would occur
 			} else {
 				bwLimit = int64(bandwidth)
@@ -885,7 +878,7 @@ func getBucketReplicationConfig(v []interface{}, d *schema.ResourceData) (result
 		if healthcheckDuration, ok = target["health_check_period"].(string); ok {
 			result[i].Target.HealthCheckPeriod, err = time.ParseDuration(healthcheckDuration)
 			if err != nil {
-				log.Printf("[WARN] invalid healthcheck value %q: %v", result[i].Target.HealthCheckPeriod, err)
+				tflog.Warn(ctx, fmt.Sprintf("invalid healthcheck value %q: %v", result[i].Target.HealthCheckPeriod, err))
 				errs = append(errs, diag.Errorf("rule[%d].target.health_check_period is invalid. Make sure to use a valid golang time duration notation", i)...)
 			}
 		}

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -996,7 +996,7 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 				"bandwidth_limt": "200M",
 			}
 
-			bandwidth, ok, _ := ParseBandwidthLimit(target)
+			bandwidth, ok, _ := ParseBandwidthLimit(context.Background(), target)
 			if !ok {
 				t.Fatalf("Expected bandwidth to be parsed successfully")
 			}
@@ -1013,7 +1013,7 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 				"bandwidth_limit": "300M",
 			}
 
-			bandwidth, ok, _ := ParseBandwidthLimit(target)
+			bandwidth, ok, _ := ParseBandwidthLimit(context.Background(), target)
 			if !ok {
 				t.Fatalf("Expected bandwidth to be parsed successfully")
 			}
@@ -1031,7 +1031,7 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 				"bandwidth_limit": "300M",
 			}
 
-			bandwidth, ok, _ := ParseBandwidthLimit(target)
+			bandwidth, ok, _ := ParseBandwidthLimit(context.Background(), target)
 			if !ok {
 				t.Fatalf("Expected bandwidth to be parsed successfully")
 			}
@@ -1052,7 +1052,7 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 				"bandwidth_limit": "400M",
 			}
 
-			bandwidth, ok, _ := ParseBandwidthLimit(target)
+			bandwidth, ok, _ := ParseBandwidthLimit(context.Background(), target)
 			if !ok {
 				t.Fatalf("Expected bandwidth to be parsed successfully")
 			}

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 	"strings"
 	"time"
 
@@ -367,7 +366,7 @@ func minioDeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func deleteMinioServiceAccount(ctx context.Context, serviceAccountConfig *S3MinioServiceAccountConfig) (err error) {
-	log.Println("[DEBUG] Deleting service account request:", serviceAccountConfig.MinioAccessKey)
+	tflog.Debug(ctx, "Deleting service account", map[string]interface{}{"access_key": serviceAccountConfig.MinioAccessKey})
 	err = serviceAccountConfig.MinioAdmin.DeleteServiceAccount(ctx, serviceAccountConfig.MinioAccessKey)
 	if err == nil {
 		return

--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -539,7 +539,7 @@ func testAccCheckMinioServiceAccountCanLogIn(n string) resource.TestCheckFunc {
 			S3UserSecret:   rs.Primary.Attributes["secret_key"],
 			S3SSL:          map[string]bool{"true": true, "false": false}[os.Getenv("MINIO_ENABLE_HTTPS")],
 		}
-		client, err := cfg.NewClient()
+		client, err := cfg.NewClient(context.Background())
 		if err != nil {
 			return err
 		}

--- a/minio/utils.go
+++ b/minio/utils.go
@@ -1,9 +1,11 @@
 package minio
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"hash/crc32"
 	"log"
 	"math"
@@ -225,7 +227,7 @@ func SafeInt64ToInt64(val int64) int64 {
 // ParseBandwidthLimit extracts and parses the bandwidth limit from a target map.
 // It handles both the legacy attribute "bandwidth_limt" and the new attribute "bandwidth_limit".
 // Returns the parsed bandwidth value, a boolean indicating success, and any diagnostic errors.
-func ParseBandwidthLimit(target map[string]any) (uint64, bool, diag.Diagnostics) {
+func ParseBandwidthLimit(ctx context.Context, target map[string]any) (uint64, bool, diag.Diagnostics) {
 	var ok bool
 	var bandwidthStr string
 	var legacyLimitValue string
@@ -251,14 +253,14 @@ func ParseBandwidthLimit(target map[string]any) (uint64, bool, diag.Diagnostics)
 
 	bandwidth, err := humanize.ParseBytes(bandwidthStr)
 	if err != nil {
-		log.Printf("[WARN] invalid bandwidth value %q: %v", bandwidthStr, err)
+		tflog.Warn(ctx, "invalid bandwidth value", map[string]interface{}{"value": bandwidthStr, "err": err.Error()})
 		errs = append(errs, diag.Errorf("bandwidth_limit is invalid. Make sure to use k, m, g as prefix only")...)
 		return 0, false, errs
 	}
 
 	// Check if bandwidth exceeds maximum int64 value
 	if bandwidth > uint64(math.MaxInt64) {
-		log.Printf("[WARN] Configured bandwidth limit (%s) exceeds maximum supported value (%s)", humanize.Bytes(bandwidth), humanize.Bytes(uint64(math.MaxInt64)))
+		tflog.Warn(ctx, "Configured bandwidth limit exceeds maximum supported value, clamping", map[string]interface{}{"configured": humanize.Bytes(bandwidth), "max": humanize.Bytes(uint64(math.MaxInt64))})
 	}
 
 	return bandwidth, true, nil


### PR DESCRIPTION
## Summary
Follow-up to #958. Migrates the remaining 45 \`log.Printf\` / \`log.Println\` sites that were intentionally skipped because they sat in ctx-less helpers. Only **6** \`log.Printf\` calls remain — all in \`MutexKV.Lock\`/\`Unlock\` in \`utils.go\` — and I left them intentionally (plumbing \`ctx\` into a generic mutex would invade every caller for what is purely developer-tracing output).

## Changes by file group

| File / group | Sites | What I did |
|---|---|---|
| \`resource_minio_notify_common.go\` | 10 | The closures (\`notifyCreate\`/\`Read\`/\`Update\`/\`Delete\`) already had \`ctx\`. The earlier migrator only matched top-level \`func\` decls and missed closures. Also threaded \`ctx\` into \`handleNotifyReadError\`. |
| \`resource_minio_s3_bucket_replication.go\` | 19 | Added \`ctx\` to \`convertBucketReplicationConfig\`, \`getBucketReplicationConfig\`, and \`BucketReplicationConfig\`. Dropped the redundant \`ctx := context.Background()\` inside \`convertBucketReplicationConfig\` now that ctx flows from the caller. |
| \`new_client.go\` | 4 | Added \`ctx\` to \`NewClient\` and \`customTransport\`; threaded from \`providerConfigure\` (which already has \`ctx\`). |
| \`utils.go\` (\`ParseBandwidthLimit\`) | 2 | Added \`ctx\`; updated the one production caller plus the fuzz and replication tests. |
| \`resource_minio_s3_bucket.go\` (\`exportPolicyString\`) | 1 | Added \`ctx\`; updated 8 call sites including \`policyToACLName\` (single caller is the importer, which has \`ctx\`). |
| iam_group / iam_user / iam_policy / service_account / iam_import / bucket_metadata_import / ilm_policy | 9 | \`log.Println(...)\` sites — converted one-by-one. Earlier migrator only handled \`log.Printf\`. |

## Why not the MutexKV calls
\`utils.go\` \`MutexKV.Lock\` / \`Unlock\` log a debug line for every acquire/release. \`tflog\` requires \`ctx\`, but \`MutexKV\` is a synchronous helper passed to dozens of callers and adding \`ctx\` to its API surface would force every site to thread one through purely for these debug logs. Cost-benefit doesn't justify it.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] Unit + schema tests pass
- [x] Local \`staticcheck ./...\` produces zero new findings