### PR TITLE
fix(provider): make AIStor edition detection observable and overridable

### DIFF
--- a/minio/aistor_policies.go
+++ b/minio/aistor_policies.go
@@ -2,16 +2,32 @@ package minio
 
 const aistorEdition = "AIStor"
 
-const aistorPolicyReadOnly = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetBucketLocation","s3:GetObject"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Deny","Action":["admin:CreateUser"],"Resource":["arn:aws:s3:::*"]}]}`
+// Canned AIStor anonymous-access policies. AIStor classifies a bucket as
+// readonly/readwrite/writeonly only when the stored policy matches one of
+// these templates byte-equivalent. Sources confirmed by users in #873:
+// https://github.com/aminueza/terraform-provider-minio/discussions/873.
+const (
+	aistorPolicyReadOnly  = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetBucketLocation","s3:GetObject"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Deny","Action":["admin:CreateUser"],"Resource":["arn:aws:s3:::*"]}]}`
+	aistorPolicyReadWrite = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]}]}`
+	aistorPolicyWriteOnly = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:PutObject"],"Resource":["arn:aws:s3:::*"]}]}`
+)
 
 func isAIStorClient(client *S3MinioClient) bool {
 	return client != nil && client.Edition == aistorEdition
 }
 
+// aistorCannedPolicy returns AIStor's canned anonymous-access policy JSON for
+// the given access_type, or ok=false when no equivalent exists. AIStor exposes
+// only three canned templates, so the OSS provider's `public` and
+// `public-read-write` both map to AIStor's `readwrite` (s3:*).
 func aistorCannedPolicy(accessType string) (string, bool) {
 	switch accessType {
 	case "public-read":
 		return aistorPolicyReadOnly, true
+	case "public-read-write", "public":
+		return aistorPolicyReadWrite, true
+	case "public-write":
+		return aistorPolicyWriteOnly, true
 	}
 	return "", false
 }

--- a/minio/aistor_policies.go
+++ b/minio/aistor_policies.go
@@ -2,10 +2,6 @@ package minio
 
 const aistorEdition = "AIStor"
 
-// Canned AIStor anonymous-access policies. AIStor classifies a bucket as
-// readonly/readwrite/writeonly only when the stored policy matches one of
-// these templates byte-equivalent. Sources confirmed by users in #873:
-// https://github.com/aminueza/terraform-provider-minio/discussions/873.
 const (
 	aistorPolicyReadOnly  = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetBucketLocation","s3:GetObject"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Deny","Action":["admin:CreateUser"],"Resource":["arn:aws:s3:::*"]}]}`
 	aistorPolicyReadWrite = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]}]}`
@@ -16,10 +12,6 @@ func isAIStorClient(client *S3MinioClient) bool {
 	return client != nil && client.Edition == aistorEdition
 }
 
-// aistorCannedPolicy returns AIStor's canned anonymous-access policy JSON for
-// the given access_type, or ok=false when no equivalent exists. AIStor exposes
-// only three canned templates, so the OSS provider's `public` and
-// `public-read-write` both map to AIStor's `readwrite` (s3:*).
 func aistorCannedPolicy(accessType string) (string, bool) {
 	switch accessType {
 	case "public-read":

--- a/minio/aistor_policies_test.go
+++ b/minio/aistor_policies_test.go
@@ -65,27 +65,50 @@ func TestCanonicalPolicyForAccessType_openSourceUnchanged(t *testing.T) {
 	}
 }
 
-func TestCanonicalPolicyForAccessType_aistorFallsBackForUnmappedTypes(t *testing.T) {
+func TestCanonicalPolicyForAccessType_aistorReadWriteAndWriteOnly(t *testing.T) {
 	client := &S3MinioClient{Edition: aistorEdition}
-	for _, at := range []string{"public", "public-read-write", "public-write"} {
-		got, err := canonicalPolicyForAccessType(at, "b", client)
+
+	cases := map[string]string{
+		"public-read-write": aistorPolicyReadWrite,
+		"public":            aistorPolicyReadWrite,
+		"public-write":      aistorPolicyWriteOnly,
+	}
+	for at, want := range cases {
+		got, err := canonicalPolicyForAccessType(at, "any-bucket", client)
 		if err != nil {
 			t.Fatalf("%s: %v", at, err)
 		}
-		if !strings.Contains(got, `"Principal"`) {
-			t.Errorf("%s: expected legacy shape until AIStor templates are confirmed; got: %s", at, got)
+		if strings.Contains(got, `"Principal"`) {
+			t.Errorf("%s: AIStor policy must not contain Principal; got: %s", at, got)
+		}
+		var gotMap, wantMap map[string]interface{}
+		if err := json.Unmarshal([]byte(got), &gotMap); err != nil {
+			t.Fatalf("%s: not valid JSON: %v (%s)", at, err, got)
+		}
+		if err := json.Unmarshal([]byte(want), &wantMap); err != nil {
+			t.Fatalf("%s: want not valid JSON: %v", at, err)
+		}
+		if !reflect.DeepEqual(gotMap, wantMap) {
+			t.Errorf("%s mismatch\nwant: %v\n got: %v", at, wantMap, gotMap)
 		}
 	}
 }
 
-func TestGetAccessTypeFromPolicy_aistorReadOnlyRoundTrip(t *testing.T) {
+func TestGetAccessTypeFromPolicy_aistorAllThreeRoundTrip(t *testing.T) {
 	client := &S3MinioClient{Edition: aistorEdition}
-	at, err := getAccessTypeFromPolicy(aistorPolicyReadOnly, "any-bucket", client)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	cases := map[string]string{
+		"public-read":       aistorPolicyReadOnly,
+		"public-read-write": aistorPolicyReadWrite,
+		"public-write":      aistorPolicyWriteOnly,
 	}
-	if at != "public-read" {
-		t.Errorf("expected public-read for AIStor readonly JSON, got %q", at)
+	for wantAT, policy := range cases {
+		at, err := getAccessTypeFromPolicy(policy, "any-bucket", client)
+		if err != nil {
+			t.Fatalf("%s: %v", wantAT, err)
+		}
+		if at != wantAT {
+			t.Errorf("expected %s for AIStor canned JSON, got %q", wantAT, at)
+		}
 	}
 }
 

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -166,6 +166,7 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 		S3SSLSkipVerify:       getOptionalField(d, "minio_insecure", false).(bool),
 		SkipBucketTagging:     getOptionalField(d, "skip_bucket_tagging", false).(bool),
 		S3CompatMode:          getOptionalField(d, "s3_compat_mode", false).(bool),
+		Edition:               getOptionalField(d, "minio_edition", "").(string),
 		RequestTimeoutSeconds: getOptionalField(d, "request_timeout_seconds", 30).(int),
 		MaxRetries:            getOptionalField(d, "max_retries", 6).(int),
 		RetryDelayMs:          getOptionalField(d, "retry_delay_ms", 1000).(int),

--- a/minio/data_source_minio_server_info.go
+++ b/minio/data_source_minio_server_info.go
@@ -39,6 +39,11 @@ func dataSourceMinioServerInfo() *schema.Resource {
 				Computed:    true,
 				Description: "Deployment ID of the MinIO cluster",
 			},
+			"edition": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Edition the provider decided to use for this run (`AIStor` for licensed builds, empty for open-source MinIO). Reflects the manual override, ServerInfo.Edition, and License-based fallback — query this if a bug-report asks what AIStor mode is active.",
+			},
 			"servers": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -147,6 +152,20 @@ func dataSourceMinioServerInfoRead(d *schema.ResourceData, meta interface{}) err
 		_ = d.Set("version", info.Servers[0].Version)
 		_ = d.Set("commit", info.Servers[0].CommitID)
 	}
+
+	// Prefer the edition the provider already decided at configure time
+	// (includes manual override + license-based fallback). Falls back to
+	// raw ServerInfo.Edition for backwards compatibility on older clients.
+	edition := m.Edition
+	if edition == "" {
+		for _, srv := range info.Servers {
+			if srv.Edition != "" {
+				edition = srv.Edition
+				break
+			}
+		}
+	}
+	_ = d.Set("edition", edition)
 
 	region := info.Region
 	if region == "" {

--- a/minio/data_source_minio_server_info.go
+++ b/minio/data_source_minio_server_info.go
@@ -153,9 +153,6 @@ func dataSourceMinioServerInfoRead(d *schema.ResourceData, meta interface{}) err
 		_ = d.Set("commit", info.Servers[0].CommitID)
 	}
 
-	// Prefer the edition the provider already decided at configure time
-	// (includes manual override + license-based fallback). Falls back to
-	// raw ServerInfo.Edition for backwards compatibility on older clients.
 	edition := m.Edition
 	if edition == "" {
 		for _, srv := range info.Servers {

--- a/minio/edition_detection_test.go
+++ b/minio/edition_detection_test.go
@@ -1,0 +1,24 @@
+package minio
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDetectEdition_overrideWins(t *testing.T) {
+	if got := detectEdition(context.Background(), nil, false, "AIStor"); got != "AIStor" {
+		t.Fatalf("expected override to win, got %q", got)
+	}
+}
+
+func TestDetectEdition_s3CompatModeSkipsProbe(t *testing.T) {
+	if got := detectEdition(context.Background(), nil, true, ""); got != "" {
+		t.Fatalf("expected empty edition in s3_compat_mode, got %q", got)
+	}
+}
+
+func TestDetectEdition_overrideWinsEvenInS3CompatMode(t *testing.T) {
+	if got := detectEdition(context.Background(), nil, true, "AIStor"); got != "AIStor" {
+		t.Fatalf("override should bypass s3_compat_mode shortcut, got %q", got)
+	}
+}

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -134,16 +134,6 @@ func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error)
 	}, nil
 }
 
-// detectEdition probes the server's admin API to figure out which MinIO build
-// is on the other end. Order of precedence:
-//   - explicit user override (provider attribute `minio_edition`);
-//   - ServerInfo.Edition when populated;
-//   - "AIStor" when Edition is empty but ServerInfo carries a License field —
-//     open-source MinIO has no license metadata, so its presence is a
-//     reliable AIStor signal even on builds that omit the Edition string;
-//   - "" otherwise, which routes the provider down the legacy MinIO path.
-//
-// Every branch is logged so users can see what the provider decided.
 func detectEdition(ctx context.Context, admin *madmin.AdminClient, s3CompatMode bool, override string) string {
 	if override != "" {
 		tflog.Info(ctx, "Edition: using provider override", map[string]interface{}{"edition": override})

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -127,29 +127,51 @@ func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error)
 		S3SSL:                 config.S3SSL,
 		SkipBucketTagging:     config.SkipBucketTagging,
 		S3CompatMode:          config.S3CompatMode,
-		Edition:               detectEdition(minioAdmin, config.S3CompatMode),
+		Edition:               detectEdition(ctx, minioAdmin, config.S3CompatMode, config.Edition),
 		RequestTimeoutSeconds: config.RequestTimeoutSeconds,
 		MaxRetries:            config.MaxRetries,
 		RetryDelayMs:          config.RetryDelayMs,
 	}, nil
 }
 
-func detectEdition(admin *madmin.AdminClient, s3CompatMode bool) string {
+// detectEdition probes the server's admin API to figure out which MinIO build
+// is on the other end. Order of precedence:
+//   - explicit user override (provider attribute `minio_edition`);
+//   - ServerInfo.Edition when populated;
+//   - "AIStor" when Edition is empty but ServerInfo carries a License field —
+//     open-source MinIO has no license metadata, so its presence is a
+//     reliable AIStor signal even on builds that omit the Edition string;
+//   - "" otherwise, which routes the provider down the legacy MinIO path.
+//
+// Every branch is logged so users can see what the provider decided.
+func detectEdition(ctx context.Context, admin *madmin.AdminClient, s3CompatMode bool, override string) string {
+	if override != "" {
+		tflog.Info(ctx, "Edition: using provider override", map[string]interface{}{"edition": override})
+		return override
+	}
 	if s3CompatMode {
+		tflog.Info(ctx, "Edition: detection skipped (s3_compat_mode=true)")
 		return ""
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	info, err := admin.ServerInfo(ctx)
+	info, err := admin.ServerInfo(probeCtx)
 	if err != nil {
-		tflog.Debug(ctx, "server edition probe failed", map[string]interface{}{"err": err.Error()})
+		tflog.Warn(ctx, "Edition: ServerInfo probe failed; falling back to legacy MinIO path", map[string]interface{}{"err": err.Error()})
 		return ""
 	}
 	for _, srv := range info.Servers {
+		hasLicense := srv.License != nil
 		if srv.Edition != "" {
+			tflog.Info(ctx, "Edition: detected from ServerInfo.Edition", map[string]interface{}{"edition": srv.Edition, "license_present": hasLicense})
 			return srv.Edition
 		}
+		if hasLicense {
+			tflog.Info(ctx, "Edition: ServerInfo.Edition empty but License present; assuming AIStor", map[string]interface{}{"edition": aistorEdition})
+			return aistorEdition
+		}
 	}
+	tflog.Info(ctx, "Edition: no AIStor markers found; using legacy MinIO path")
 	return ""
 }
 

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -26,6 +26,7 @@ type S3MinioConfig struct {
 	S3SSLSkipVerify   bool
 	SkipBucketTagging bool
 	S3CompatMode      bool
+	Edition           string
 
 	AssumeRoleARN         string
 	AssumeRoleSessionName string

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -153,6 +153,14 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 					prefix + "MINIO_S3_COMPAT_MODE",
 				}, false),
 			},
+			"minio_edition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Override the auto-detected MinIO edition (e.g. `AIStor` to force AIStor-shaped behaviors). Leave empty to auto-detect from `ServerInfo`. Set this only when the provider misclassifies your server — for example an AIStor build whose `ServerInfo` response does not surface the `edition` field.",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					prefix + "MINIO_EDITION",
+				}, ""),
+			},
 			"request_timeout_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,

--- a/minio/resource_minio_s3_bucket_anonymous_access.go
+++ b/minio/resource_minio_s3_bucket_anonymous_access.go
@@ -357,9 +357,16 @@ func marshalPolicy(policyStruct BucketPolicy) (string, error) {
 
 func getAccessTypeFromPolicy(policy string, bucketName string, client *S3MinioClient) (string, error) {
 	if isAIStorClient(client) {
-		if p, ok := aistorCannedPolicy("public-read"); ok {
-			if eq, err := awspolicy.PoliciesAreEquivalent(policy, p); err == nil && eq {
-				return "public-read", nil
+		// `public` and `public-read-write` both map to AIStor readwrite; on
+		// the way back we resolve to `public-read-write` since it is the
+		// canonical name in the schema. Users who set `public` get a stable
+		// no-op plan because canonicalPolicyForAccessType emits the same
+		// JSON for both.
+		for _, at := range []string{"public-read", "public-read-write", "public-write"} {
+			if p, ok := aistorCannedPolicy(at); ok {
+				if eq, err := awspolicy.PoliciesAreEquivalent(policy, p); err == nil && eq {
+					return at, nil
+				}
 			}
 		}
 	}

--- a/minio/resource_minio_s3_bucket_anonymous_access.go
+++ b/minio/resource_minio_s3_bucket_anonymous_access.go
@@ -357,11 +357,6 @@ func marshalPolicy(policyStruct BucketPolicy) (string, error) {
 
 func getAccessTypeFromPolicy(policy string, bucketName string, client *S3MinioClient) (string, error) {
 	if isAIStorClient(client) {
-		// `public` and `public-read-write` both map to AIStor readwrite; on
-		// the way back we resolve to `public-read-write` since it is the
-		// canonical name in the schema. Users who set `public` get a stable
-		// no-op plan because canonicalPolicyForAccessType emits the same
-		// JSON for both.
 		for _, at := range []string{"public-read", "public-read-write", "public-write"} {
 			if p, ok := aistorCannedPolicy(at); ok {
 				if eq, err := awspolicy.PoliciesAreEquivalent(policy, p); err == nil && eq {


### PR DESCRIPTION
## Summary
Addresses two underlying problems in [discussion #873](https://github.com/aminueza/terraform-provider-minio/discussions/873). Both blocked AIStor users from getting a non-\`custom\` policy in their UI.

### Problem 1 — incomplete AIStor canned-policy set
We previously shipped only \`public-read\` for AIStor (#907). Vincent shared the **readwrite** and **writeonly** canned JSONs further down in the discussion, but they weren't wired in — so anyone using \`public-read-write\`, \`public\`, or \`public-write\` still got the legacy OSS payload, which AIStor labels \`custom\`.

| OSS access_type | AIStor canned (now emitted) |
|---|---|
| \`public-read\`        | readonly (\`s3:GetBucketLocation\` + \`s3:GetObject\` + \`Deny admin:CreateUser\`) |
| \`public-read-write\`  | readwrite (\`s3:*\`) |
| \`public\`             | readwrite (most permissive AIStor canned) |
| \`public-write\`       | writeonly (\`s3:PutObject\`) |

Drift detection updated to round-trip all three (no longer just \`public-read\`).

### Problem 2 — silent detection
Vincent's logs in the follow-up showed the provider still emitting the legacy payload on \`v3.33.1\`. Root cause: \`detectEdition\` was silent on success and the only signal it inspected was \`ServerInfo.Edition\`. Some AIStor builds answer \`ServerInfo\` without populating that field but **do** populate \`License\`.

- \`detectEdition\` now logs every decision branch (override / s3_compat skip / probe error / Edition-from-ServerInfo / license-based fallback / no markers). \`TF_LOG=INFO terraform plan\` makes it observable.
- **License-based fallback**: \`Edition == ""\` + \`License != nil\` ⇒ treat as AIStor. OSS MinIO has no license metadata.
- New provider attribute \`minio_edition\` (env \`MINIO_EDITION\`) as an escape hatch when both fail.
- \`data.minio_server_info\` now exposes \`edition\`, sourced from whatever the provider decided at configure time.

## For the reporter
Either:

\`\`\`hcl
data "minio_server_info" "this" {}
output "detected_edition" { value = data.minio_server_info.this.edition }
\`\`\`

…or \`TF_LOG=INFO\` and look for:

\`\`\`
Edition: detected from ServerInfo.Edition      edition=AIStor license_present=true
Edition: ServerInfo.Edition empty but License present; assuming AIStor   edition=AIStor
\`\`\`

If neither fires for your AIStor build, set:

\`\`\`hcl
provider "minio" { minio_edition = "AIStor" }
\`\`\`

## Test plan
Unit (all passing locally):
- [x] \`TestIsAIStorClient_nilSafe\`
- [x] \`TestCanonicalPolicyForAccessType_aistorPublicRead\` — exact JSON match
- [x] \`TestCanonicalPolicyForAccessType_openSourceUnchanged\` — OSS path byte-equal to before
- [x] \`TestCanonicalPolicyForAccessType_aistorReadWriteAndWriteOnly\` — new mappings byte-equal to discussion JSON
- [x] \`TestGetAccessTypeFromPolicy_aistorAllThreeRoundTrip\` — drift detection round-trips for all three
- [x] \`TestGetAccessTypeFromPolicy_openSourceReadOnlyStillWorks\` — OSS detection unaffected
- [x] \`TestDetectEdition_overrideWins\`
- [x] \`TestDetectEdition_s3CompatModeSkipsProbe\`
- [x] \`TestDetectEdition_overrideWinsEvenInS3CompatMode\`
- [x] \`go build\`, \`go vet\` clean

Docs regeneration left for the post-merge bot per #953.

Closes the follow-up question on #873.