### PR TITLE
chore: drop noisy MutexKV debug log.Printf calls

### DIFF
--- a/minio/utils.go
+++ b/minio/utils.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"hash/crc32"
-	"log"
 	"math"
 	"strings"
 	"sync"
@@ -119,16 +118,12 @@ type MutexKV struct {
 // Locks the mutex for the given key. Caller is responsible for calling Unlock
 // for the same key
 func (m *MutexKV) Lock(key string) {
-	log.Printf("[DEBUG] Locking %q", key)
 	m.get(key).Lock()
-	log.Printf("[DEBUG] Locked %q", key)
 }
 
 // Unlock the mutex for the given key. Caller must have called Lock for the same key first
 func (m *MutexKV) Unlock(key string) {
-	log.Printf("[DEBUG] Unlocking %q", key)
 	m.get(key).Unlock()
-	log.Printf("[DEBUG] Unlocked %q", key)
 }
 
 // Returns a mutex for the given key, no guarantee of its lock status


### PR DESCRIPTION
## Summary

- Removes four `log.Printf("[DEBUG] Locking/Locked/Unlocking/Unlocked …")` calls from `MutexKV.Lock` and `MutexKV.Unlock` in `minio/utils.go`.
- Drops the now-unused stdlib `"log"` import.

## Why

These lines fire on every resource operation and spam `TF_LOG=DEBUG` output with no diagnostic value. The broader codebase was already migrated to `tflog` (#958/#959); these four lines were missed.

## Test plan

- [x] `go build ./minio/...` passes
- No behaviour change — callers are unaffected; only the log noise is gone.