### PR TITLE
docs: add examples for 3 resources/data-sources missing registry snippets

### DIFF
--- a/examples/data-sources/minio_prometheus_scrape_config/data-source.tf
+++ b/examples/data-sources/minio_prometheus_scrape_config/data-source.tf
@@ -1,0 +1,13 @@
+resource "minio_prometheus_bearer_token" "cluster" {
+  metric_type = "cluster"
+}
+
+data "minio_prometheus_scrape_config" "cluster" {
+  metric_type  = "cluster"
+  bearer_token = minio_prometheus_bearer_token.cluster.token
+}
+
+output "scrape_config_yaml" {
+  value     = data.minio_prometheus_scrape_config.cluster.scrape_config
+  sensitive = true
+}

--- a/examples/resources/minio_iam_user_group_membership/resource.tf
+++ b/examples/resources/minio_iam_user_group_membership/resource.tf
@@ -1,0 +1,20 @@
+resource "minio_iam_user" "alice" {
+  name = "alice"
+}
+
+resource "minio_iam_group" "dev" {
+  name = "developers"
+}
+
+resource "minio_iam_group" "ops" {
+  name = "operations"
+}
+
+resource "minio_iam_user_group_membership" "alice" {
+  user = minio_iam_user.alice.name
+
+  groups = [
+    minio_iam_group.dev.name,
+    minio_iam_group.ops.name,
+  ]
+}

--- a/examples/resources/minio_prometheus_bearer_token/resource.tf
+++ b/examples/resources/minio_prometheus_bearer_token/resource.tf
@@ -1,0 +1,13 @@
+resource "minio_prometheus_bearer_token" "cluster" {
+  metric_type = "cluster"
+  expires_in  = "8760h"
+}
+
+output "cluster_token" {
+  value     = minio_prometheus_bearer_token.cluster.token
+  sensitive = true
+}
+
+output "token_expiry" {
+  value = minio_prometheus_bearer_token.cluster.token_expiry
+}


### PR DESCRIPTION
## Summary

Three recently-added resources and data-sources were missing their `examples/` entries, which causes `tfplugindocs` to generate registry pages with no usage sample.

- `examples/resources/minio_iam_user_group_membership/resource.tf` — attaches one IAM user to multiple groups
- `examples/resources/minio_prometheus_bearer_token/resource.tf` — creates a JWT bearer token for a Prometheus metrics endpoint
- `examples/data-sources/minio_prometheus_scrape_config/data-source.tf` — generates a Prometheus scrape config YAML, paired with a bearer token

## Test plan

- [x] `go build ./minio/...` passes in this branch
- [x] Each snippet uses only the attributes defined in the corresponding schema