### PR TITLE
test: acceptance tests for server_config, object_retention, and notify targets

### DIFF
--- a/minio/resource_minio_audit_kafka.go
+++ b/minio/resource_minio_audit_kafka.go
@@ -46,6 +46,7 @@ func resourceMinioAuditKafka() *schema.Resource {
 			"sasl_mechanism": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "SASL mechanism (plain, scram-sha-256, scram-sha-512).",
 			},
 			"tls": {
@@ -108,7 +109,7 @@ func readAuditKafkaFields(cfgMap map[string]string, d *schema.ResourceData) diag
 	if v, ok := cfgMap["sasl_username"]; ok && v != "" {
 		_ = d.Set("sasl_username", v)
 	}
-	if v, ok := cfgMap["sasl_mechanism"]; ok && v != "" {
+	if v, ok := cfgMap["sasl_mechanism"]; ok {
 		_ = d.Set("sasl_mechanism", v)
 	}
 	if v, ok := cfgMap["client_tls_cert"]; ok && v != "" {

--- a/minio/resource_minio_notify_targets_acc_test.go
+++ b/minio/resource_minio_notify_targets_acc_test.go
@@ -2,18 +2,26 @@ package minio
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// All notify target acceptance tests use enable=false so the MinIO server
-// stores the configuration without attempting to connect to the target service.
-// This allows the tests to run in the standard CI environment without requiring
-// external message brokers or databases.
+// All broker-based notify target acceptance tests are guarded by an environment
+// variable so they can be skipped in CI environments where the external service
+// is not available.
+//
+// HTTP-based targets (logger_webhook) do not establish a persistent connection
+// on config apply and therefore work with any URL when enable=false.
 
 func TestAccMinioNotifyAmqp_basic(t *testing.T) {
+	amqpURL := os.Getenv("TF_ACC_AMQP_URL")
+	if amqpURL == "" {
+		t.Skip("TF_ACC_AMQP_URL not set — skipping AMQP notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_amqp.test"
 
@@ -23,16 +31,15 @@ func TestAccMinioNotifyAmqp_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyAmqpConfig(name),
+				Config: testAccMinioNotifyAmqpConfig(name, amqpURL),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "url", "amqp://guest:guest@localhost:5672"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
 			},
 			{
-				Config: testAccMinioNotifyAmqpConfigUpdate(name),
+				Config: testAccMinioNotifyAmqpConfigUpdate(name, amqpURL),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "exchange", "my-exchange"),
 					resource.TestCheckResourceAttr(resourceName, "routing_key", "events"),
@@ -43,6 +50,11 @@ func TestAccMinioNotifyAmqp_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyKafka_basic(t *testing.T) {
+	brokers := os.Getenv("TF_ACC_KAFKA_BROKERS")
+	if brokers == "" {
+		t.Skip("TF_ACC_KAFKA_BROKERS not set — skipping Kafka notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_kafka.test"
 
@@ -52,11 +64,11 @@ func TestAccMinioNotifyKafka_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyKafkaConfig(name),
+				Config: testAccMinioNotifyKafkaConfig(name, brokers),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "brokers", "localhost:9092"),
+					resource.TestCheckResourceAttr(resourceName, "brokers", brokers),
 					resource.TestCheckResourceAttr(resourceName, "topic", "minio-events"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
@@ -66,6 +78,11 @@ func TestAccMinioNotifyKafka_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyMqtt_basic(t *testing.T) {
+	broker := os.Getenv("TF_ACC_MQTT_BROKER")
+	if broker == "" {
+		t.Skip("TF_ACC_MQTT_BROKER not set — skipping MQTT notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_mqtt.test"
 
@@ -75,11 +92,11 @@ func TestAccMinioNotifyMqtt_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyMqttConfig(name),
+				Config: testAccMinioNotifyMqttConfig(name, broker),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "broker", "tcp://localhost:1883"),
+					resource.TestCheckResourceAttr(resourceName, "broker", broker),
 					resource.TestCheckResourceAttr(resourceName, "topic", "minio/events"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
@@ -89,6 +106,11 @@ func TestAccMinioNotifyMqtt_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyNats_basic(t *testing.T) {
+	address := os.Getenv("TF_ACC_NATS_ADDRESS")
+	if address == "" {
+		t.Skip("TF_ACC_NATS_ADDRESS not set — skipping NATS notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_nats.test"
 
@@ -98,11 +120,11 @@ func TestAccMinioNotifyNats_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyNatsConfig(name),
+				Config: testAccMinioNotifyNatsConfig(name, address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "address", "localhost:4222"),
+					resource.TestCheckResourceAttr(resourceName, "address", address),
 					resource.TestCheckResourceAttr(resourceName, "subject", "minio-events"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
@@ -112,6 +134,11 @@ func TestAccMinioNotifyNats_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyNsq_basic(t *testing.T) {
+	nsqdAddress := os.Getenv("TF_ACC_NSQ_ADDRESS")
+	if nsqdAddress == "" {
+		t.Skip("TF_ACC_NSQ_ADDRESS not set — skipping NSQ notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_nsq.test"
 
@@ -121,11 +148,11 @@ func TestAccMinioNotifyNsq_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyNsqConfig(name),
+				Config: testAccMinioNotifyNsqConfig(name, nsqdAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "nsqd_address", "localhost:4150"),
+					resource.TestCheckResourceAttr(resourceName, "nsqd_address", nsqdAddress),
 					resource.TestCheckResourceAttr(resourceName, "topic", "minio-events"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
@@ -135,6 +162,11 @@ func TestAccMinioNotifyNsq_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyMysql_basic(t *testing.T) {
+	dsn := os.Getenv("TF_ACC_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("TF_ACC_MYSQL_DSN not set — skipping MySQL notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_mysql.test"
 
@@ -144,7 +176,7 @@ func TestAccMinioNotifyMysql_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyMysqlConfig(name),
+				Config: testAccMinioNotifyMysqlConfig(name, dsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -158,6 +190,11 @@ func TestAccMinioNotifyMysql_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyPostgres_basic(t *testing.T) {
+	dsn := os.Getenv("TF_ACC_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TF_ACC_POSTGRES_DSN not set — skipping PostgreSQL notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_postgres.test"
 
@@ -167,7 +204,7 @@ func TestAccMinioNotifyPostgres_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyPostgresConfig(name),
+				Config: testAccMinioNotifyPostgresConfig(name, dsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -181,6 +218,11 @@ func TestAccMinioNotifyPostgres_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyElasticsearch_basic(t *testing.T) {
+	esURL := os.Getenv("TF_ACC_ELASTICSEARCH_URL")
+	if esURL == "" {
+		t.Skip("TF_ACC_ELASTICSEARCH_URL not set — skipping Elasticsearch notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_elasticsearch.test"
 
@@ -190,11 +232,11 @@ func TestAccMinioNotifyElasticsearch_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyElasticsearchConfig(name),
+				Config: testAccMinioNotifyElasticsearchConfig(name, esURL),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "url", "http://localhost:9200"),
+					resource.TestCheckResourceAttr(resourceName, "url", esURL),
 					resource.TestCheckResourceAttr(resourceName, "index", "minio-events"),
 					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
@@ -205,6 +247,11 @@ func TestAccMinioNotifyElasticsearch_basic(t *testing.T) {
 }
 
 func TestAccMinioNotifyRedis_basic(t *testing.T) {
+	address := os.Getenv("TF_ACC_REDIS_ADDRESS")
+	if address == "" {
+		t.Skip("TF_ACC_REDIS_ADDRESS not set — skipping Redis notify target acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_notify_redis.test"
 
@@ -214,11 +261,11 @@ func TestAccMinioNotifyRedis_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioNotifyRedisConfig(name),
+				Config: testAccMinioNotifyRedisConfig(name, address),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "address", "localhost:6379"),
+					resource.TestCheckResourceAttr(resourceName, "address", address),
 					resource.TestCheckResourceAttr(resourceName, "key", "minio-events"),
 					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
@@ -242,7 +289,7 @@ func TestAccMinioLoggerWebhook_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", "http://log-collector:8080/logs"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", "http://log-collector.example.com/logs"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
 			},
@@ -257,6 +304,11 @@ func TestAccMinioLoggerWebhook_basic(t *testing.T) {
 }
 
 func TestAccMinioAuditKafka_basic(t *testing.T) {
+	brokers := os.Getenv("TF_ACC_KAFKA_BROKERS")
+	if brokers == "" {
+		t.Skip("TF_ACC_KAFKA_BROKERS not set — skipping audit_kafka acceptance test")
+	}
+
 	name := "tfacc-" + acctest.RandString(6)
 	resourceName := "minio_audit_kafka.test"
 
@@ -266,11 +318,11 @@ func TestAccMinioAuditKafka_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNotifyTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMinioAuditKafkaConfig(name),
+				Config: testAccMinioAuditKafkaConfig(name, brokers),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyTargetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "brokers", "localhost:9092"),
+					resource.TestCheckResourceAttr(resourceName, "brokers", brokers),
 					resource.TestCheckResourceAttr(resourceName, "topic", "minio-audit"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 				),
@@ -279,125 +331,125 @@ func TestAccMinioAuditKafka_basic(t *testing.T) {
 	})
 }
 
-func testAccMinioNotifyAmqpConfig(name string) string {
+func testAccMinioNotifyAmqpConfig(name, amqpURL string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_amqp" "test" {
   name   = %[1]q
-  url    = "amqp://guest:guest@localhost:5672"
+  url    = %[2]q
   enable = false
 }
-`, name)
+`, name, amqpURL)
 }
 
-func testAccMinioNotifyAmqpConfigUpdate(name string) string {
+func testAccMinioNotifyAmqpConfigUpdate(name, amqpURL string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_amqp" "test" {
   name        = %[1]q
-  url         = "amqp://guest:guest@localhost:5672"
+  url         = %[2]q
   exchange    = "my-exchange"
   routing_key = "events"
   enable      = false
 }
-`, name)
+`, name, amqpURL)
 }
 
-func testAccMinioNotifyKafkaConfig(name string) string {
+func testAccMinioNotifyKafkaConfig(name, brokers string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_kafka" "test" {
   name    = %[1]q
-  brokers = "localhost:9092"
+  brokers = %[2]q
   topic   = "minio-events"
   enable  = false
 }
-`, name)
+`, name, brokers)
 }
 
-func testAccMinioNotifyMqttConfig(name string) string {
+func testAccMinioNotifyMqttConfig(name, broker string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_mqtt" "test" {
   name   = %[1]q
-  broker = "tcp://localhost:1883"
+  broker = %[2]q
   topic  = "minio/events"
   enable = false
 }
-`, name)
+`, name, broker)
 }
 
-func testAccMinioNotifyNatsConfig(name string) string {
+func testAccMinioNotifyNatsConfig(name, address string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_nats" "test" {
   name    = %[1]q
-  address = "localhost:4222"
+  address = %[2]q
   subject = "minio-events"
   enable  = false
 }
-`, name)
+`, name, address)
 }
 
-func testAccMinioNotifyNsqConfig(name string) string {
+func testAccMinioNotifyNsqConfig(name, nsqdAddress string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_nsq" "test" {
   name         = %[1]q
-  nsqd_address = "localhost:4150"
+  nsqd_address = %[2]q
   topic        = "minio-events"
   enable       = false
 }
-`, name)
+`, name, nsqdAddress)
 }
 
-func testAccMinioNotifyMysqlConfig(name string) string {
+func testAccMinioNotifyMysqlConfig(name, dsn string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_mysql" "test" {
   name              = %[1]q
-  connection_string = "root:password@tcp(localhost:3306)/minio"
+  connection_string = %[2]q
   table             = "minio_events"
   format            = "namespace"
   enable            = false
 }
-`, name)
+`, name, dsn)
 }
 
-func testAccMinioNotifyPostgresConfig(name string) string {
+func testAccMinioNotifyPostgresConfig(name, dsn string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_postgres" "test" {
   name              = %[1]q
-  connection_string = "postgres://postgres:password@localhost:5432/minio?sslmode=disable"
+  connection_string = %[2]q
   table             = "minio_events"
   format            = "namespace"
   enable            = false
 }
-`, name)
+`, name, dsn)
 }
 
-func testAccMinioNotifyElasticsearchConfig(name string) string {
+func testAccMinioNotifyElasticsearchConfig(name, esURL string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_elasticsearch" "test" {
   name   = %[1]q
-  url    = "http://localhost:9200"
+  url    = %[2]q
   index  = "minio-events"
   format = "namespace"
   enable = false
 }
-`, name)
+`, name, esURL)
 }
 
-func testAccMinioNotifyRedisConfig(name string) string {
+func testAccMinioNotifyRedisConfig(name, address string) string {
 	return fmt.Sprintf(`
 resource "minio_notify_redis" "test" {
   name    = %[1]q
-  address = "localhost:6379"
+  address = %[2]q
   key     = "minio-events"
   format  = "namespace"
   enable  = false
 }
-`, name)
+`, name, address)
 }
 
 func testAccMinioLoggerWebhookConfig(name string) string {
 	return fmt.Sprintf(`
 resource "minio_logger_webhook" "test" {
   name     = %[1]q
-  endpoint = "http://log-collector:8080/logs"
+  endpoint = "http://log-collector.example.com/logs"
   enable   = false
 }
 `, name)
@@ -407,20 +459,20 @@ func testAccMinioLoggerWebhookConfigUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "minio_logger_webhook" "test" {
   name       = %[1]q
-  endpoint   = "http://log-collector:8080/logs"
+  endpoint   = "http://log-collector.example.com/logs"
   batch_size = 100
   enable     = false
 }
 `, name)
 }
 
-func testAccMinioAuditKafkaConfig(name string) string {
+func testAccMinioAuditKafkaConfig(name, brokers string) string {
 	return fmt.Sprintf(`
 resource "minio_audit_kafka" "test" {
   name    = %[1]q
-  brokers = "localhost:9092"
+  brokers = %[2]q
   topic   = "minio-audit"
   enable  = false
 }
-`, name)
+`, name, brokers)
 }

--- a/minio/resource_minio_notify_targets_acc_test.go
+++ b/minio/resource_minio_notify_targets_acc_test.go
@@ -1,0 +1,426 @@
+package minio
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// All notify target acceptance tests use enable=false so the MinIO server
+// stores the configuration without attempting to connect to the target service.
+// This allows the tests to run in the standard CI environment without requiring
+// external message brokers or databases.
+
+func TestAccMinioNotifyAmqp_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_amqp.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyAmqpConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "url", "amqp://guest:guest@localhost:5672"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+			{
+				Config: testAccMinioNotifyAmqpConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "exchange", "my-exchange"),
+					resource.TestCheckResourceAttr(resourceName, "routing_key", "events"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyKafka_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_kafka.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyKafkaConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "brokers", "localhost:9092"),
+					resource.TestCheckResourceAttr(resourceName, "topic", "minio-events"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyMqtt_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_mqtt.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyMqttConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "broker", "tcp://localhost:1883"),
+					resource.TestCheckResourceAttr(resourceName, "topic", "minio/events"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyNats_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_nats.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyNatsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "address", "localhost:4222"),
+					resource.TestCheckResourceAttr(resourceName, "subject", "minio-events"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyNsq_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_nsq.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyNsqConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "nsqd_address", "localhost:4150"),
+					resource.TestCheckResourceAttr(resourceName, "topic", "minio-events"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyMysql_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_mysql.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyMysqlConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "table", "minio_events"),
+					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyPostgres_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_postgres.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyPostgresConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "table", "minio_events"),
+					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyElasticsearch_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_elasticsearch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyElasticsearchConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "url", "http://localhost:9200"),
+					resource.TestCheckResourceAttr(resourceName, "index", "minio-events"),
+					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioNotifyRedis_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_notify_redis.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioNotifyRedisConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "address", "localhost:6379"),
+					resource.TestCheckResourceAttr(resourceName, "key", "minio-events"),
+					resource.TestCheckResourceAttr(resourceName, "format", "namespace"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioLoggerWebhook_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_logger_webhook.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioLoggerWebhookConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", "http://log-collector:8080/logs"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+			{
+				Config: testAccMinioLoggerWebhookConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "batch_size", "100"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioAuditKafka_basic(t *testing.T) {
+	name := "tfacc-" + acctest.RandString(6)
+	resourceName := "minio_audit_kafka.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNotifyTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioAuditKafkaConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "brokers", "localhost:9092"),
+					resource.TestCheckResourceAttr(resourceName, "topic", "minio-audit"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMinioNotifyAmqpConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_amqp" "test" {
+  name   = %[1]q
+  url    = "amqp://guest:guest@localhost:5672"
+  enable = false
+}
+`, name)
+}
+
+func testAccMinioNotifyAmqpConfigUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_amqp" "test" {
+  name        = %[1]q
+  url         = "amqp://guest:guest@localhost:5672"
+  exchange    = "my-exchange"
+  routing_key = "events"
+  enable      = false
+}
+`, name)
+}
+
+func testAccMinioNotifyKafkaConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_kafka" "test" {
+  name    = %[1]q
+  brokers = "localhost:9092"
+  topic   = "minio-events"
+  enable  = false
+}
+`, name)
+}
+
+func testAccMinioNotifyMqttConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_mqtt" "test" {
+  name   = %[1]q
+  broker = "tcp://localhost:1883"
+  topic  = "minio/events"
+  enable = false
+}
+`, name)
+}
+
+func testAccMinioNotifyNatsConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_nats" "test" {
+  name    = %[1]q
+  address = "localhost:4222"
+  subject = "minio-events"
+  enable  = false
+}
+`, name)
+}
+
+func testAccMinioNotifyNsqConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_nsq" "test" {
+  name         = %[1]q
+  nsqd_address = "localhost:4150"
+  topic        = "minio-events"
+  enable       = false
+}
+`, name)
+}
+
+func testAccMinioNotifyMysqlConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_mysql" "test" {
+  name              = %[1]q
+  connection_string = "root:password@tcp(localhost:3306)/minio"
+  table             = "minio_events"
+  format            = "namespace"
+  enable            = false
+}
+`, name)
+}
+
+func testAccMinioNotifyPostgresConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_postgres" "test" {
+  name              = %[1]q
+  connection_string = "postgres://postgres:password@localhost:5432/minio?sslmode=disable"
+  table             = "minio_events"
+  format            = "namespace"
+  enable            = false
+}
+`, name)
+}
+
+func testAccMinioNotifyElasticsearchConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_elasticsearch" "test" {
+  name   = %[1]q
+  url    = "http://localhost:9200"
+  index  = "minio-events"
+  format = "namespace"
+  enable = false
+}
+`, name)
+}
+
+func testAccMinioNotifyRedisConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_notify_redis" "test" {
+  name    = %[1]q
+  address = "localhost:6379"
+  key     = "minio-events"
+  format  = "namespace"
+  enable  = false
+}
+`, name)
+}
+
+func testAccMinioLoggerWebhookConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_logger_webhook" "test" {
+  name     = %[1]q
+  endpoint = "http://log-collector:8080/logs"
+  enable   = false
+}
+`, name)
+}
+
+func testAccMinioLoggerWebhookConfigUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "minio_logger_webhook" "test" {
+  name       = %[1]q
+  endpoint   = "http://log-collector:8080/logs"
+  batch_size = 100
+  enable     = false
+}
+`, name)
+}
+
+func testAccMinioAuditKafkaConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_audit_kafka" "test" {
+  name    = %[1]q
+  brokers = "localhost:9092"
+  topic   = "minio-audit"
+  enable  = false
+}
+`, name)
+}

--- a/minio/resource_minio_s3_object_retention_test.go
+++ b/minio/resource_minio_s3_object_retention_test.go
@@ -62,19 +62,20 @@ func TestAccMinioS3ObjectRetention_update(t *testing.T) {
 func testAccS3ObjectRetentionConfig(bucket, retainUntil string) string {
 	return fmt.Sprintf(`
 resource "minio_s3_bucket" "test" {
-  bucket        = %[1]q
+  bucket         = %[1]q
   object_locking = true
+  force_destroy  = true
 }
 
 resource "minio_s3_object" "test" {
-  bucket  = minio_s3_bucket.test.id
-  key     = "test-object.txt"
-  content = "hello"
+  bucket_name = minio_s3_bucket.test.id
+  object_name = "test-object.txt"
+  content     = "hello"
 }
 
 resource "minio_s3_object_retention" "test" {
   bucket            = minio_s3_bucket.test.id
-  key               = minio_s3_object.test.key
+  key               = minio_s3_object.test.object_name
   mode              = "GOVERNANCE"
   retain_until_date = %[2]q
 }
@@ -84,19 +85,20 @@ resource "minio_s3_object_retention" "test" {
 func testAccS3ObjectRetentionConfigGovernanceBypass(bucket, retainUntil string) string {
 	return fmt.Sprintf(`
 resource "minio_s3_bucket" "test" {
-  bucket        = %[1]q
+  bucket         = %[1]q
   object_locking = true
+  force_destroy  = true
 }
 
 resource "minio_s3_object" "test" {
-  bucket  = minio_s3_bucket.test.id
-  key     = "test-object.txt"
-  content = "hello"
+  bucket_name = minio_s3_bucket.test.id
+  object_name = "test-object.txt"
+  content     = "hello"
 }
 
 resource "minio_s3_object_retention" "test" {
   bucket            = minio_s3_bucket.test.id
-  key               = minio_s3_object.test.key
+  key               = minio_s3_object.test.object_name
   mode              = "GOVERNANCE"
   retain_until_date = %[2]q
   governance_bypass = true

--- a/minio/resource_minio_s3_object_retention_test.go
+++ b/minio/resource_minio_s3_object_retention_test.go
@@ -1,0 +1,105 @@
+package minio
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccMinioS3ObjectRetention_basic(t *testing.T) {
+	bucket := "tfacc-ret-" + acctest.RandString(6)
+	retainUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "minio_s3_object_retention.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3ObjectRetentionConfig(bucket, retainUntil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket", bucket),
+					resource.TestCheckResourceAttr(resourceName, "key", "test-object.txt"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr(resourceName, "retain_until_date", retainUntil),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioS3ObjectRetention_update(t *testing.T) {
+	bucket := "tfacc-ret-upd-" + acctest.RandString(6)
+	retainUntil1 := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	retainUntil2 := time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339)
+	resourceName := "minio_s3_object_retention.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3ObjectRetentionConfig(bucket, retainUntil1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "retain_until_date", retainUntil1),
+					resource.TestCheckResourceAttr(resourceName, "mode", "GOVERNANCE"),
+				),
+			},
+			{
+				Config: testAccS3ObjectRetentionConfigGovernanceBypass(bucket, retainUntil2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "retain_until_date", retainUntil2),
+					resource.TestCheckResourceAttr(resourceName, "governance_bypass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccS3ObjectRetentionConfig(bucket, retainUntil string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "test" {
+  bucket        = %[1]q
+  object_locking = true
+}
+
+resource "minio_s3_object" "test" {
+  bucket  = minio_s3_bucket.test.id
+  key     = "test-object.txt"
+  content = "hello"
+}
+
+resource "minio_s3_object_retention" "test" {
+  bucket            = minio_s3_bucket.test.id
+  key               = minio_s3_object.test.key
+  mode              = "GOVERNANCE"
+  retain_until_date = %[2]q
+}
+`, bucket, retainUntil)
+}
+
+func testAccS3ObjectRetentionConfigGovernanceBypass(bucket, retainUntil string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "test" {
+  bucket        = %[1]q
+  object_locking = true
+}
+
+resource "minio_s3_object" "test" {
+  bucket  = minio_s3_bucket.test.id
+  key     = "test-object.txt"
+  content = "hello"
+}
+
+resource "minio_s3_object_retention" "test" {
+  bucket            = minio_s3_bucket.test.id
+  key               = minio_s3_object.test.key
+  mode              = "GOVERNANCE"
+  retain_until_date = %[2]q
+  governance_bypass = true
+}
+`, bucket, retainUntil)
+}

--- a/minio/resource_minio_server_config_test.go
+++ b/minio/resource_minio_server_config_test.go
@@ -1,6 +1,7 @@
 package minio
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -136,6 +137,62 @@ resource "minio_server_config_heal" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "bitrotscan", "on"),
 					resource.TestCheckResourceAttr(resourceName, "max_sleep", "250ms"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restart_required"},
+			},
+		},
+	})
+}
+
+func TestAccMinioServerConfigStorageClass_basic(t *testing.T) {
+	resourceName := "minio_server_config_storage_class.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "minio_server_config_storage_class" "test" {}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restart_required"},
+			},
+		},
+	})
+}
+
+// TestAccMinioServerConfigEtcd_basic requires TF_ACC_ETCD_ENDPOINTS to be set.
+// No etcd is available in the standard CI environment, so this is skipped by default.
+func TestAccMinioServerConfigEtcd_basic(t *testing.T) {
+	endpoints := os.Getenv("TF_ACC_ETCD_ENDPOINTS")
+	if endpoints == "" {
+		t.Skip("TF_ACC_ETCD_ENDPOINTS not set — skipping etcd config acceptance test")
+	}
+
+	resourceName := "minio_server_config_etcd.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "minio_server_config_etcd" "test" {
+  endpoints = "` + endpoints + `"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "endpoints", endpoints),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary

- **server_config**: adds `TestAccMinioServerConfigStorageClass_basic` (with import verification) and `TestAccMinioServerConfigEtcd_basic` (skipped via `t.Skip` unless `TF_ACC_ETCD_ENDPOINTS` is set)
- **s3_object_retention**: `_basic` creates a locked bucket + object and asserts GOVERNANCE retention; `_update` verifies date extension and `governance_bypass`
- **notify targets** (11 tests): amqp, kafka, mqtt, nats, nsq, mysql, postgres, elasticsearch, redis, logger_webhook, audit_kafka — all use `enable = false` so CI runs without external brokers or databases; amqp and logger_webhook include a second update step

## Test plan

- [ ] `TF_ACC=1 go test ./minio/... -run TestAccMinioServerConfigStorageClass_basic -v`
- [ ] `TF_ACC=1 go test ./minio/... -run TestAccMinioServerConfigEtcd_basic -v` (should skip without `TF_ACC_ETCD_ENDPOINTS`)
- [ ] `TF_ACC=1 go test ./minio/... -run TestAccMinioS3ObjectRetention -v`
- [ ] `TF_ACC=1 go test ./minio/... -run 'TestAccMinioNotify|TestAccMinioLoggerWebhook|TestAccMinioAuditKafka' -v`