### PR TITLE
chore: align go directive with toolchain (1.26.3)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,8 @@ jobs:
         id: gosec
         uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
         continue-on-error: true
+        env:
+          GOTOOLCHAIN: auto
         with:
           args: -fmt sarif -out gosec.sarif -exclude-dir=vendor -tests=false -exclude=G101 ./
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,8 @@ jobs:
         id: gosec
         uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
         continue-on-error: true
+        env:
+          GOTOOLCHAIN: auto
         with:
           args: "-fmt sarif -out gosec.sarif -exclude-dir=vendor -tests=false -exclude=G101 ./..."
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       retries: 6
       start_period: 10s
   test:
-    image: golang:1.25.10
+    image: golang:1.26.3
     volumes:
       - .:/app
       - go-modules:/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/aminueza/terraform-provider-minio/v3
 
-go 1.25.10
-
-toolchain go1.26.3
+go 1.26.3
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -390,7 +390,7 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 			"metadata_sync":               rule.SourceSelectionCriteria.ReplicaModifications.Status == replication.Enabled,
 		}
 
-		tflog.Debug(ctx, fmt.Sprintf("Rule data for rule#%d is: %q", ruleIdx, rule))
+		tflog.Debug(ctx, fmt.Sprintf("Rule data for rule#%d is: %+v", ruleIdx, rule))
 
 		if len(rule.Filter.And.Tags) != 0 || rule.Filter.And.Prefix != "" {
 			tags := map[string]string{}


### PR DESCRIPTION
## Summary

`go.mod` had `go 1.25.10` as the minimum version directive alongside a separate `toolchain go1.26.3` line added in #973. This consolidates them: setting `go 1.26.3` directly makes the minimum and toolchain requirement the same, which is the canonical form when you're pinning to a specific patch.

The separate `toolchain` line is only needed when the `go` directive is lower than the toolchain you want to use — since we actually require 1.26.3 for the CVE fixes, the `go` line should just say so.

No functional change; `govulncheck ./...` still reports zero vulnerabilities.