### PR TITLE
fix: treat NoSuchBucket as success in bucket delete path

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -444,6 +444,10 @@ func minioDeleteBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if err := bucketConfig.MinioClient.RemoveBucket(ctx, bucketName); err != nil {
+		if isNoSuchBucketError(err) {
+			tflog.Warn(ctx, fmt.Sprintf("Bucket %q already absent — skipping delete", bucketName))
+			return nil
+		}
 		tflog.Error(ctx, NewResourceErrorStr("unable to remove bucket", bucketName, err))
 		return NewResourceError("unable to remove bucket", bucketName, err)
 	}
@@ -766,6 +770,9 @@ func bucketHasObjects(ctx context.Context, client *minio.Client, bucketName stri
 		return false, nil
 	}
 	if obj.Err != nil {
+		if isNoSuchBucketError(obj.Err) {
+			return false, nil
+		}
 		return false, NewResourceError("error listing bucket objects", bucketName, obj.Err)
 	}
 	return true, nil

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -1433,6 +1433,25 @@ func TestIsNoSuchBucketError(t *testing.T) {
 	}
 }
 
+func TestBucketHasObjects_NoSuchBucket(t *testing.T) {
+	// bucketHasObjects must return (false, nil) when the bucket no longer exists,
+	// so that minioDeleteBucket treats an already-deleted bucket as a no-op rather
+	// than a fatal error. This is the condition that caused "disappears" acceptance
+	// tests to fail with "[FATAL] error listing bucket objects: NoSuchBucket".
+	//
+	// We cannot call bucketHasObjects directly without a real client, but we can
+	// verify that isNoSuchBucketError (the guard we added) correctly classifies
+	// the error returned by minio-go's ListObjects channel for a missing bucket.
+	noSuchBucket := minio.ErrorResponse{
+		Code:       "NoSuchBucket",
+		Message:    "The specified bucket does not exist",
+		StatusCode: http.StatusNotFound,
+	}
+	if !isNoSuchBucketError(noSuchBucket) {
+		t.Fatal("isNoSuchBucketError should return true for NoSuchBucket ErrorResponse")
+	}
+}
+
 func TestAccMinioS3Bucket_withPolicyAndVersioning(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 


### PR DESCRIPTION
## Problem

Two acceptance tests were failing with a fatal error during post-test cleanup:

```
Error: [FATAL] error listing bucket objects (bucket-name): The specified bucket does not exist
Code: NoSuchBucket
```

Affected tests:
- `TestAccS3BucketPolicy_disappears`
- `TestAccMinioS3BucketNotification_disappearsBucket`

Both are "disappears" tests — they delete the bucket externally in a `PreConfig` step, then let the Terraform framework run the standard destroy sequence. The destroy fails because:

1. `minioDeleteBucket` calls `bucketHasObjects` first (to decide whether to empty the bucket)
2. `bucketHasObjects` calls `ListObjects`, which returns `NoSuchBucket` via the error channel
3. The code was treating this as a fatal error instead of "nothing to list"

## Fix

Two guard clauses, both using the existing `isNoSuchBucketError` helper:

1. **`bucketHasObjects`** — `NoSuchBucket` from `ListObjects` → `(false, nil)` (bucket has no objects because it doesn't exist)
2. **`minioDeleteBucket`** — `NoSuchBucket` from `RemoveBucket` → log + `nil` (already gone, nothing to do)

This follows the standard Terraform delete pattern: if the resource is already absent, treat the delete as a no-op.

## Test plan
- [x] `TestBucketHasObjects_NoSuchBucket` — unit test confirming the guard condition
- [x] `TestIsNoSuchBucketError` — existing tests still pass
- [x] `go build ./...` clean
- [ ] `TestAccS3BucketPolicy_disappears` passes (requires running acceptance tests)
- [ ] `TestAccMinioS3BucketNotification_disappearsBucket` passes (requires running acceptance tests)