### PR TITLE
Add Claude Code skill for the MinIO provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ variable "minio_password" {
 }
 ```
 
+## Claude Code Skill
+
+This repository ships a [Claude Code](https://docs.claude.com/en/docs/claude-code) skill in [`skills/terraform-minio`](./skills/terraform-minio) that turns natural-language requests (e.g. *"give this app a read-only key for the backups bucket"*) into correct `aminueza/minio` HCL and drives Terraform through a safe **plan → confirm → apply** workflow.
+
+It knows every resource and data source, the exact argument names, and the provider's auth options (STS, OIDC, mTLS, `s3_compat_mode`). Read operations (`terraform plan`, `mc ls`) run freely, while mutating operations (`apply`, `destroy`, `import`) are gated behind a reviewed plan and explicit confirmation.
+
+**Install it:**
+
+```sh
+# Global (available in every project):
+cp -R skills/terraform-minio ~/.claude/skills/
+
+# Or per-project (auto-loaded when you open a repo in Claude Code):
+mkdir -p .claude/skills && cp -R skills/terraform-minio .claude/skills/
+```
+
+Then just ask Claude Code to create or change MinIO buckets, users, policies, or service accounts — it picks up the skill automatically.
+
 ## Testing
 
 The project uses Docker Compose to run acceptance tests against multiple MinIO instances. Docker is required.

--- a/skills/terraform-minio/SKILL.md
+++ b/skills/terraform-minio/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: terraform-minio
+description: >-
+  Author, plan, and safely apply Terraform for MinIO and S3-compatible object
+  storage using the aminueza/minio provider. Use this skill whenever the user
+  works with the MinIO Terraform provider, writes or reviews any minio_* resource
+  or data source (minio_s3_bucket, minio_iam_user, minio_iam_policy,
+  minio_iam_service_account, minio_ilm_policy, minio_s3_bucket_replication,
+  minio_s3_bucket_versioning, ...), references the provider source aminueza/minio,
+  or wants to create or change buckets, IAM users, groups, policies, service
+  accounts, lifecycle rules, versioning, replication, encryption, or
+  notifications in MinIO through Terraform. Also use it to translate
+  natural-language requests like "give this app a read-only key for the backups
+  bucket" into correct MinIO HCL, to debug minio provider plan/apply errors, to
+  import existing MinIO resources into Terraform state, and to operate a MinIO
+  endpoint with terraform (and the mc client) using a safe plan-then-confirm
+  workflow.
+---
+
+# terraform-minio
+
+An assistant for managing **MinIO** (and S3-compatible) object storage with the
+[`aminueza/minio`](https://registry.terraform.io/providers/aminueza/minio/latest)
+Terraform provider. It turns natural-language intent ("create a read-only user
+for the `backups` bucket", "enable versioning + a 30-day expiry on `logs`") into
+**correct HCL**, then drives Terraform through a **safe plan → confirm → apply**
+loop — the same safe-by-default philosophy as `kubectl-ai`, adapted to Terraform.
+
+The provider is large (65 resources, 54 data sources). This file covers the
+operating model and the high-frequency surface. For the full inventory and exact
+schemas, read the files under `references/` (pointers are given throughout).
+
+## Operating principles
+
+These exist because object-storage mistakes are expensive and often
+irreversible (a wrong policy exposes a bucket publicly; `force_destroy` deletes
+data; a leaked service-account key is a breach). Internalize the *why*, don't
+just follow the steps.
+
+1. **Act, don't narrate.** When `terraform` / `mc` are available, *run* the
+   read-only and `plan` steps yourself and show the user the results — don't
+   just print commands for them to copy. The user wants the outcome, not a
+   tutorial. (Stop and hand control back before any mutating step — see the
+   safety gate.)
+2. **Safe by default.** Read-only operations run freely. Anything that mutates
+   real infrastructure or state is **gated behind a reviewed plan and explicit
+   user confirmation**. See [the safety gate](#the-safety-gate-read-vs-write).
+3. **Plan before apply, always.** `terraform apply` without first showing the
+   user a `terraform plan` is never acceptable. The plan *is* the
+   confirmation summary. Use `-auto-approve` **only** after the user has seen a
+   plan and said yes.
+4. **Never invent values.** Don't guess bucket names, regions, ARNs, user names,
+   or policy JSON. Inspect what exists first (read the `.tf` files,
+   `terraform show`, `mc admin info`, the relevant data sources), then ask the
+   user for anything still missing. Assumed defaults on object storage are how
+   buckets end up public or data ends up in the wrong region.
+5. **Secrets never go in HCL or state in plaintext.** Use variables + env vars
+   for credentials; mark generated secrets sensitive; never echo a secret key.
+   Prefer write-only secret arguments (`secret_wo`, Terraform ≥ 1.11) so secrets
+   don't persist in state. See [Credentials & secrets](#credentials--secrets).
+6. **Terraform owns managed resources — `mc` is for inspection.** Changing a
+   managed resource with `mc` (or the console) causes drift and confusing
+   diffs. Use `mc` to *look* (and to act on things Terraform doesn't manage),
+   use Terraform to *change* what's in state.
+
+## The working loop
+
+1. **Understand intent.** Restate the goal in MinIO terms (which buckets,
+   users, policies, permissions). Resolve ambiguity now, not after `apply`.
+2. **Gather context.** Read existing `*.tf`, check the provider block and
+   endpoint, and inspect live state where useful:
+   - `terraform show` / `terraform state list` — what Terraform manages.
+   - `mc admin info <alias>`, `mc ls <alias>`, `mc admin user list <alias>` —
+     what actually exists on the server.
+   - data sources (`minio_s3_buckets`, `minio_iam_users`, `minio_server_info`)
+     when you want this inside the config.
+3. **Author / modify HCL.** Use exact argument names (see the cheat-sheet and
+   `references/resources.md`). Pin the provider. Keep secrets in variables.
+4. **Validate + plan.** `terraform fmt`, `terraform validate`, then
+   `terraform plan` (with `-input=false`). Read the diff yourself.
+5. **Present the plan & confirm.** Summarize what will be created / changed /
+   **destroyed** in plain language, call out anything dangerous (public access,
+   `force_destroy`, deletions), and ask for explicit confirmation.
+6. **Apply.** Only after confirmation. Then **verify** (`mc ls`, `mc stat`,
+   re-run `plan` to show it's clean).
+
+## The safety gate (read vs write)
+
+Classify every command before running it. **Read-only → run freely. Mutating →
+stop, show the plan/intent, get explicit confirmation.**
+
+**Terraform — read-only (run freely):**
+`init`, `validate`, `fmt`, `plan`, `show`, `output`, `state list`,
+`state show`, `providers`, `providers schema`, `version`, `graph`.
+(`init` only downloads providers/modules into the working dir — safe.)
+
+**Terraform — mutating (require a reviewed plan + explicit confirmation):**
+`apply`, `destroy`, `apply -destroy`, `import`, `state rm`, `state mv`,
+`state push`, `state replace-provider`, `taint`, `untaint`,
+`workspace delete`. Never pass `-auto-approve` unless the user approved a plan.
+
+**mc — read-only (run freely):**
+`mc ls`, `mc stat`, `mc du`, `mc tree`, `mc find`, `mc cat`, `mc alias list`,
+`mc version`, `mc admin info`, `mc admin user list`, `mc admin group list`,
+`mc admin policy list`/`info`, `mc admin config get`, `mc anonymous get`,
+`mc ilm rule ls`, `mc replicate ls`.
+
+**mc — mutating (require explicit confirmation):**
+`mc mb`, `mc rb`, `mc rm`, `mc mv`, `mc cp`/`mc mirror` (to a target),
+`mc anonymous set`, `mc admin user add`/`remove`/`enable`/`disable`,
+`mc admin policy create`/`attach`/`detach`, `mc admin group add`/`rm`,
+`mc admin config set`, `mc admin service restart`/`stop`,
+`mc ilm rule add`/`rm`, `mc replicate add`/`rm`.
+
+The single escape hatch is the user explicitly saying "go ahead / apply / skip
+the confirmations". Honor it for that operation; don't make it the default.
+
+## Provider setup essentials
+
+The provider **source is `aminueza/minio`** (not `aminueza/terraform-provider-minio`).
+`minio_server` is a bare `host:port` (no scheme); TLS is toggled by `minio_ssl`,
+not by an `https://` prefix.
+
+```hcl
+terraform {
+  required_providers {
+    minio = {
+      source  = "aminueza/minio"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "minio" {
+  minio_server   = "localhost:9000"     # host:port, no scheme; env: MINIO_ENDPOINT
+  minio_region   = "us-east-1"          # signing region (matters for S3-compat)
+  minio_user     = var.minio_user       # access key;  env: MINIO_USER
+  minio_password = var.minio_password   # secret key;  env: MINIO_PASSWORD (sensitive)
+  minio_ssl      = false                # env: MINIO_ENABLE_HTTPS
+}
+```
+
+- Canonical credential args are `minio_user` / `minio_password`. The older
+  `minio_access_key` / `minio_secret_key` are **deprecated** and *conflict* if
+  both pairs are set.
+- Common extras: `minio_session_token`, `minio_insecure`, `minio_cacert_file`,
+  `minio_api_version` (`v4`/`v2`), `s3_compat_mode` (for non-MinIO S3 backends
+  like R2 / B2 / Spaces / Hetzner), plus `assume_role` and
+  `assume_role_with_web_identity` blocks for STS / OIDC.
+- Every provider arg has a `MINIO_*` env var. **Full reference, env-var table,
+  STS/OIDC/mTLS, and S3-compat caveats: read `references/auth-and-config.md`.**
+
+### Credentials & secrets
+
+- Put credentials in **variables fed by env vars** (`TF_VAR_minio_user`, …) or
+  the provider's own `MINIO_*` env vars — never hardcode them in committed HCL.
+- Resources that **generate** secrets (`minio_iam_service_account`,
+  `minio_accesskey`, `minio_iam_user` with a server-generated secret) expose
+  `secret_key` as a **sensitive** computed attribute that lands in state. Treat
+  state as secret, and when the provider/Terraform supports it use the
+  **write-only** `secret_wo` argument (Terraform ≥ 1.11) so the value never
+  persists in state.
+- Never print a secret value back to the user in plaintext; reference where it
+  lives (an output, the service account resource) instead.
+
+## High-frequency resource cheat-sheet
+
+Exact argument names for the resources people use most. **Get these right** —
+wrong arg names are the #1 failure. Full schemas for these and every other
+resource: `references/resources.md`. Copy-pasteable end-to-end recipes:
+`references/recipes.md`.
+
+| Resource | Key arguments (exact) | Notes / gotchas |
+|---|---|---|
+| `minio_s3_bucket` | `bucket` (or `bucket_prefix`), `acl`, `force_destroy`, `object_locking` | `acl` defaults to private; `force_destroy=true` deletes a non-empty bucket. |
+| `minio_s3_bucket_policy` | `bucket`, `policy` (JSON) | Full custom bucket policy. |
+| `minio_s3_bucket_versioning` | `bucket`, `versioning_configuration { status }` | `status = "Enabled"`. |
+| `minio_s3_object` | `bucket_name`, `object_name`, `content`/`content_base64`/`source` | **Not** `bucket`/`key`. |
+| `minio_iam_user` | `name`, `force_destroy`, `disable_user`, `secret`/`secret_wo`, `tags` | `secret_wo` (write-only) keeps the secret out of state (TF ≥ 1.11). |
+| `minio_iam_group` | `name`, `force_destroy`, `disable_group` | |
+| `minio_iam_group_membership` | `name`, `group`, `users` (set) | Authoritative membership for a group. |
+| `minio_iam_policy` | `name` (or `name_prefix`), `policy` (JSON) | Managed policy; reference its `.id`. |
+| `minio_iam_user_policy_attachment` | `user_name`, `policy_name` | **Not** `user`/`policy`. Import id: `user-name/policy-name`. |
+| `minio_iam_group_policy_attachment` | `group_name`, `policy_name` | Attach a managed policy to a group. |
+| `minio_iam_service_account` | `target_user` | Exports **sensitive** `access_key` / `secret_key`. App credentials. |
+
+> Easily-confused pairs (which to use when) are spelled out in
+> `references/resources.md` → *Clarifications*: the three group-membership
+> resources, `s3_bucket_lifecycle` vs `ilm_policy`,
+> `s3_bucket_anonymous_access` vs `s3_bucket_policy`, `service_account` vs
+> `accesskey`, inline vs managed policy.
+
+## The IAM permissions pattern
+
+Don't hand-write policy JSON when you can build it with the
+**`minio_iam_policy_document`** data source (AWS-IAM-style) and feed its `.json`
+into a `minio_iam_policy`, then attach it. This is the canonical, least-error
+path for "user/app X can do Y on bucket Z":
+
+```hcl
+data "minio_iam_policy_document" "backups_ro" {
+  statement {
+    sid       = "ReadBackups"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = ["arn:aws:s3:::backups", "arn:aws:s3:::backups/*"]
+  }
+}
+
+resource "minio_iam_policy" "backups_ro" {
+  name   = "backups-read-only"
+  policy = data.minio_iam_policy_document.backups_ro.json
+}
+
+resource "minio_iam_user" "app" {
+  name = "backups-reader"
+}
+
+resource "minio_iam_user_policy_attachment" "app_backups_ro" {
+  user_name   = minio_iam_user.app.id   # note: user_name / policy_name
+  policy_name = minio_iam_policy.backups_ro.id
+}
+```
+
+Note the bucket needs **two** resource ARNs: the bucket itself (for
+`ListBucket`) and `bucket/*` (for object actions). For machine credentials an
+app actually authenticates with, prefer a `minio_iam_service_account` (it emits
+an access/secret key pair) over embedding the user's own secret.
+
+## When a resource isn't covered here
+
+The provider evolves and is bigger than this file. To get an exact, current
+schema rather than guessing:
+
+- **Authoritative & offline:** `terraform providers schema -json | jq '.provider_schemas[].resource_schemas["minio_<name>"]'` after `terraform init`.
+- **Docs:** `https://registry.terraform.io/providers/aminueza/minio/latest/docs/resources/<name>` (and `.../data-sources/<name>`). The URL uses the name **without** the `minio_` prefix.
+- **Full inventory in this skill:** `references/resources.md` and
+  `references/data-sources.md`.
+
+## Reference map
+
+Read the file that matches the task — don't load everything up front.
+
+- `references/resources.md` — every resource grouped by area, one-line purpose
+  each, exact schemas for the common ones, and the *Clarifications* section for
+  confusing pairs. **Read when** writing/reviewing any resource beyond the
+  cheat-sheet, or when unsure of an argument name.
+- `references/data-sources.md` — every data source (singular/plural pairs,
+  cluster-info sources). **Read when** querying existing MinIO state from HCL or
+  building policy documents.
+- `references/recipes.md` — copy-pasteable end-to-end configs (private bucket +
+  versioning + lifecycle, public/anonymous bucket, read-only user, app service
+  account, group + policy, replication, OIDC/LDAP attach, **importing existing
+  resources**). **Read when** the user wants a complete working setup.
+- `references/auth-and-config.md` — full provider configuration: every argument
+  + env var, `assume_role`, web-identity/OIDC, mTLS, `s3_compat_mode`,
+  timeouts/retries, edition. **Read when** setting up the provider, using STS,
+  or targeting a non-MinIO S3 backend.
+
+## Troubleshooting quick hits
+
+- **`Error: Provider configuration ... AccessDenied` / signature errors** →
+  wrong `minio_region` (S3-compat backends reject mismatched signing regions),
+  or wrong credentials, or `minio_ssl` mismatch with the endpoint scheme.
+- **`409` / "bucket already exists" on create** → the bucket exists out-of-band;
+  `terraform import` it instead of recreating. Every resource is importable —
+  per-resource import syntax is in `references/resources.md`.
+- **Plan shows a forced replacement of a user/key you didn't change** → likely a
+  `secret`/`update_secret` interaction; see the `secret` vs `secret_wo`
+  clarification in `references/resources.md`.
+- **Feature silently does nothing on a non-MinIO backend** → with
+  `s3_compat_mode = true` the provider skips unsupported features
+  (notifications, object-lock, CORS, lifecycle) on backends like R2/B2/Spaces.
+- **Drift / unexpected diffs** → something changed the resource via `mc` or the
+  console. Reconcile with `terraform apply` or `terraform import`, and stop
+  managing it both ways.

--- a/skills/terraform-minio/references/auth-and-config.md
+++ b/skills/terraform-minio/references/auth-and-config.md
@@ -1,0 +1,121 @@
+# MinIO provider — authentication & configuration
+
+Full provider configuration for `aminueza/minio`. The provider **source is
+`aminueza/minio`**. `minio_server` is a bare `host:port` (no scheme); TLS is
+controlled by `minio_ssl`, not by an `https://` prefix.
+
+## All provider arguments
+
+| Argument | Req? | Default | Env var | Notes |
+|---|---|---|---|---|
+| `minio_server` | **yes** | — | `MINIO_ENDPOINT` | `host:port`. |
+| `minio_user` | no | — | `MINIO_USER` | access key. Conflicts with `minio_access_key`. |
+| `minio_password` | no | — | `MINIO_PASSWORD` | secret key (sensitive). Conflicts with `minio_secret_key`. |
+| `minio_access_key` | no | — | `MINIO_ACCESS_KEY` | **deprecated** → use `minio_user`. |
+| `minio_secret_key` | no | — | `MINIO_SECRET_KEY` | **deprecated** → use `minio_password`. |
+| `minio_session_token` | no | `""` | `MINIO_SESSION_TOKEN` | temporary STS credentials. |
+| `minio_region` | no | `us-east-1` | — | signing region; **must match** S3-compat backends. |
+| `minio_api_version` | no | `v4` | — | only `v2` or `v4`. |
+| `minio_ssl` | no | `false` | `MINIO_ENABLE_HTTPS` | enable TLS. |
+| `minio_insecure` | no | `false` | `MINIO_INSECURE` | skip TLS cert verification. |
+| `minio_cacert_file` | no | — | `MINIO_CACERT_FILE` | CA cert path. |
+| `minio_cert_file` | no | — | `MINIO_CERT_FILE` | client cert (mTLS). |
+| `minio_key_file` | no | — | `MINIO_KEY_FILE` | client key (mTLS, sensitive). |
+| `minio_debug` | no | `false` | `MINIO_DEBUG` | request debug logging. |
+| `skip_bucket_tagging` | no | `false` | `MINIO_SKIP_BUCKET_TAGGING` | legacy-compat flag. |
+| `s3_compat_mode` | no | `false` | `MINIO_S3_COMPAT_MODE` | for non-MinIO S3 backends (see below). |
+| `minio_edition` | no | auto-detect | `MINIO_EDITION` | force e.g. `AIStor`. |
+| `request_timeout_seconds` | no | `30` | `MINIO_REQUEST_TIMEOUT_SECONDS` | per-request timeout. |
+| `max_retries` | no | `6` | `MINIO_MAX_RETRIES` | retry attempts. |
+| `retry_delay_ms` | no | `1000` | `MINIO_RETRY_DELAY_MS` | backoff base. |
+| `assume_role` | no | — | (sub-args) | STS AssumeRole block (max 1). |
+| `assume_role_with_web_identity` | no | — | (sub-args) | OIDC web-identity block (max 1). |
+
+**Auth precedence:** explicit provider arguments override environment variables.
+Canonical credential pair is `minio_user` / `minio_password`; do not also set the
+deprecated `minio_access_key` / `minio_secret_key` (they conflict).
+
+## STS: `assume_role`
+
+```hcl
+provider "minio" {
+  minio_server = "minio.example.com:9000"
+  minio_ssl    = true
+  assume_role {
+    role_arn         = "arn:aws:iam::000000000000:role/my-role"  # env MINIO_ASSUME_ROLE_ARN
+    session_name     = "terraform"                                # default "terraform"
+    duration_seconds = 3600                                       # default 3600
+    policy           = jsonencode({ ... })                        # optional inline session policy
+    external_id      = "..."                                      # optional
+  }
+}
+```
+
+## OIDC: `assume_role_with_web_identity`
+
+For CI (GitHub Actions, GitLab CI) or Kubernetes service-account tokens:
+```hcl
+provider "minio" {
+  minio_server = "minio.example.com:9000"
+  minio_ssl    = true
+  assume_role_with_web_identity {
+    web_identity_token_file = "/var/run/secrets/token"  # env MINIO_WEB_IDENTITY_TOKEN_FILE
+    # web_identity_token    = var.oidc_token            # env MINIO_WEB_IDENTITY_TOKEN
+    duration_seconds        = 3600
+  }
+}
+```
+
+## mTLS
+
+```hcl
+provider "minio" {
+  minio_server      = "minio.example.com:9000"
+  minio_ssl         = true
+  minio_cacert_file = "/etc/minio/ca.crt"
+  minio_cert_file   = "/etc/minio/client.crt"
+  minio_key_file    = "/etc/minio/client.key"
+}
+```
+Use `minio_insecure = true` only for self-signed certs in non-production.
+
+## S3-compatible (non-MinIO) backends
+
+Set `s3_compat_mode = true` for Cloudflare R2, Backblaze B2, DigitalOcean Spaces,
+Hetzner Object Storage, Versity Gateway, etc.
+```hcl
+provider "minio" {
+  minio_server   = "<account>.r2.cloudflarestorage.com"
+  minio_region   = "auto"          # set to the backend's actual region — mismatches fail signing
+  minio_user     = var.access_key
+  minio_password = var.secret_key
+  minio_ssl      = true
+  s3_compat_mode = true
+}
+```
+**Caveats:**
+- In compat mode the provider **silently skips** features the backend doesn't
+  support — bucket notifications, object lock, CORS, lifecycle. Don't expect
+  those `minio_*` resources to take effect.
+- MinIO-specific features (IAM users/groups/policies, service accounts, server
+  config, site replication, notify targets, audit) require a **real MinIO
+  server** and won't work against generic S3.
+- Region is the most common failure: many gateways reject a mismatched signing
+  region with an opaque `AccessDenied`/signature error.
+
+## Secrets handling (summary)
+
+- Source credentials from env vars (`MINIO_*`) or `TF_VAR_*`-fed variables;
+  never commit them in HCL.
+- Generated secrets (`minio_iam_service_account.secret_key`,
+  `minio_iam_user.secret`) are sensitive and persist in **state** — protect state.
+- Prefer write-only secret args (`secret_wo`, `secret_key_wo`) where available
+  (Terraform ≥ 1.11) so values never enter state, or `minio_accesskey` whose
+  `secret_key` is write-only by design.
+- Never print a secret value back to the user; point them to the output/resource.
+
+## Licensing note
+
+The provider is **AGPL-3.0** (from v2.0.0). If that matters for the user's
+distribution model, flag it — it only affects the provider binary's license, not
+the data or buckets it manages.

--- a/skills/terraform-minio/references/data-sources.md
+++ b/skills/terraform-minio/references/data-sources.md
@@ -1,0 +1,131 @@
+# MinIO provider — data sources reference
+
+Data sources read existing MinIO state into your config (or build policy JSON).
+Argument names verified against `aminueza/minio` generated docs. For a source not
+detailed here, run `terraform providers schema -json` or see
+`https://registry.terraform.io/providers/aminueza/minio/latest/docs/data-sources/<name>`.
+
+## Full inventory
+
+### IAM
+- `minio_iam_policy_document` — build AWS-IAM-style policy JSON (`.json` output).
+- `minio_iam_policy` — read a managed policy.
+- `minio_iam_user` / `minio_iam_users` — read one user / list users.
+- `minio_iam_group` / `minio_iam_groups` — read one group / list groups.
+- `minio_iam_user_policies` — policies attached to a user.
+- `minio_iam_service_accounts` — list service accounts.
+- `minio_iam_export` — export IAM entities.
+
+### S3 bucket & object
+- `minio_s3_bucket` / `minio_s3_buckets` — read one bucket / list buckets.
+- `minio_s3_object` / `minio_s3_objects` — read one object / list objects.
+- `minio_s3_bucket_policy` — bucket policy JSON.
+- `minio_s3_bucket_tags` — bucket tags.
+- `minio_s3_bucket_versioning` — versioning state.
+- `minio_s3_bucket_encryption` — SSE config.
+- `minio_s3_bucket_notification_config` — notification config.
+- `minio_s3_bucket_cors_config` — CORS config.
+- `minio_s3_bucket_retention` — default retention.
+- `minio_s3_bucket_quota` — quota.
+- `minio_s3_bucket_object_lock_configuration` — object-lock config.
+- `minio_s3_bucket_replication` — replication rules.
+- `minio_s3_bucket_replication_status` / `minio_s3_bucket_replication_metrics` — replication health/metrics.
+- `minio_s3_bucket_anonymous_access` — current anonymous access.
+
+### ILM / KMS
+- `minio_ilm_policy` — lifecycle config.
+- `minio_ilm_tiers` / `minio_ilm_tier_stats` — remote tiers and their stats.
+- `minio_kms_status` / `minio_kms_metrics` — KMS health/metrics.
+
+### Server / cluster info (no required args — great for inspection)
+- `minio_server_info` — version, edition, deployment id, per-server drives.
+- `minio_account_info` — account/usage info.
+- `minio_storage_info` — total/used/available space, disk counts/states.
+- `minio_data_usage` — data usage stats.
+- `minio_health_status` — healthy/live/ready/quorum booleans.
+- `minio_config_history` — config change history.
+- `minio_license_info` — license info.
+- `minio_prometheus_scrape_config` — Prometheus scrape config.
+- `minio_pool_status` / `minio_pool_rebalance_status` — pool state / rebalance progress.
+- `minio_bucket_metadata_export` — export bucket metadata.
+
+### Batch
+- `minio_batch_jobs` — list batch jobs.
+- `minio_batch_job_template` — generate a batch job template.
+
+### Notification targets
+- `minio_notify_webhook`, `minio_notify_amqp`, `minio_notify_kafka`,
+  `minio_notify_mqtt`, `minio_notify_nats`, `minio_notify_nsq`,
+  `minio_notify_mysql`, `minio_notify_postgres`,
+  `minio_notify_elasticsearch`, `minio_notify_redis`.
+
+---
+
+## Exact schemas (common)
+
+### `minio_iam_policy_document` — the policy JSON builder
+Use this instead of hand-writing policy JSON, then feed `.json` into a
+`minio_iam_policy` / `minio_iam_group_policy` / service-account `policy`.
+```hcl
+data "minio_iam_policy_document" "this" {
+  version       = "2012-10-17"   # optional
+  policy_id     = "..."          # optional
+  source_json   = "..."          # optional base doc to extend  (NOTE: singular, not source_policy)
+  override_json = "..."          # optional overrides           (NOTE: singular)
+
+  statement {                    # repeatable
+    sid           = "ReadBucket"
+    effect        = "Allow"      # Allow | Deny
+    actions       = ["s3:GetObject", "s3:ListBucket"]
+    resources     = ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
+    not_resources = []           # optional
+    principal     = "*"          # optional (singular String)
+    not_principal = ""           # optional
+    condition {                  # optional, repeatable (a Set)
+      test     = "StringLike"    # REQUIRED
+      variable = "s3:prefix"     # REQUIRED
+      values   = ["home/"]       # REQUIRED
+    }
+  }
+}
+# Exported: json
+```
+Gotchas: it's `resources`/`not_resources` (plural lists) and `principal`/`not_principal`
+(singular strings); merge args are `source_json` / `override_json` (singular), **not**
+`source_policy`/`override_policy_documents`.
+
+### `minio_s3_bucket` / `minio_s3_buckets`
+```hcl
+data "minio_s3_bucket" "one" {
+  bucket = "my-bucket"           # REQUIRED
+}
+# exports: object_lock_enabled (bool), policy (string), region (string), versioning_enabled (bool)
+
+data "minio_s3_buckets" "all" {
+  name_prefix = "app-"           # optional
+}
+# exports: buckets = [{ name, creation_date }]
+```
+
+### `minio_iam_user` / `minio_iam_users`
+```hcl
+data "minio_iam_user" "one" {
+  name = "alice"                 # REQUIRED
+}
+# exports: status, member_of_groups ([]string), policy_names ([]string), tags (map)
+
+data "minio_iam_users" "list" {
+  name_prefix = "svc-"           # optional
+  status      = "enabled"        # optional: enabled | disabled | all
+}
+# exports: users = [{ name, status, member_of_groups, policy_names }]
+```
+
+### Inspection sources (no args)
+```hcl
+data "minio_server_info"   "srv" {}  # version, commit, deployment_id, region, edition, servers[].drives[...]
+data "minio_health_status" "h"   {}  # healthy, live, ready, read_quorum, write_quorum, safe_for_maintenance
+data "minio_storage_info"  "s"   {}  # total_space, used_space, available_space, disk_count, online/offline_disks, disks[...]
+```
+Use these to confirm the cluster is healthy and to read region/edition before
+authoring config that depends on them.

--- a/skills/terraform-minio/references/recipes.md
+++ b/skills/terraform-minio/references/recipes.md
@@ -1,0 +1,287 @@
+# MinIO provider — recipes
+
+Copy-pasteable, end-to-end configs using verified argument names. Adjust names,
+regions, and ARNs to the user's reality — **never apply with these placeholders**.
+Always `terraform plan` and confirm before `apply`.
+
+## Contents
+- [0. Provider bootstrap](#0-provider-bootstrap)
+- [1. Private bucket + versioning + lifecycle](#1-private-bucket--versioning--lifecycle)
+- [2. Public (anonymous-read) bucket](#2-public-anonymous-read-bucket)
+- [3. Read-only user for a bucket](#3-read-only-user-for-a-bucket)
+- [4. App credentials via service account](#4-app-credentials-via-service-account)
+- [5. Group + managed policy + membership](#5-group--managed-policy--membership)
+- [6. Bucket replication](#6-bucket-replication)
+- [7. Server-side encryption](#7-server-side-encryption)
+- [8. Import existing resources](#8-import-existing-resources)
+
+---
+
+## 0. Provider bootstrap
+
+```hcl
+# versions.tf
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    minio = {
+      source  = "aminueza/minio"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+# variables.tf
+variable "minio_server" {
+  type = string
+}
+variable "minio_user" {
+  type      = string
+  sensitive = true
+}
+variable "minio_password" {
+  type      = string
+  sensitive = true
+}
+
+# provider.tf
+provider "minio" {
+  minio_server   = var.minio_server   # host:port, no scheme
+  minio_region   = "us-east-1"
+  minio_user     = var.minio_user
+  minio_password = var.minio_password
+  minio_ssl      = true
+}
+```
+Feed credentials from the environment, never commit them:
+```bash
+export TF_VAR_minio_server="minio.example.com:9000"
+export TF_VAR_minio_user="$MINIO_ROOT_USER"
+export TF_VAR_minio_password="$MINIO_ROOT_PASSWORD"
+# (or skip the vars entirely and let the provider read MINIO_ENDPOINT / MINIO_USER / MINIO_PASSWORD)
+```
+
+## 1. Private bucket + versioning + lifecycle
+
+A private bucket that keeps versions and expires objects after 30 days (and old
+versions after 7).
+```hcl
+resource "minio_s3_bucket" "logs" {
+  bucket = "app-logs"
+  acl    = "private"
+}
+
+resource "minio_s3_bucket_versioning" "logs" {
+  bucket = minio_s3_bucket.logs.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "minio_s3_bucket_lifecycle" "logs" {
+  bucket = minio_s3_bucket.logs.bucket
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+    expiration { days = 30 }
+    noncurrent_version_expiration { noncurrent_days = 7 }
+  }
+}
+```
+
+## 2. Public (anonymous-read) bucket
+
+Exposes every object to the world — confirm the user really wants this.
+```hcl
+resource "minio_s3_bucket" "assets" {
+  bucket = "public-assets"
+}
+
+resource "minio_s3_bucket_anonymous_access" "assets" {
+  bucket      = minio_s3_bucket.assets.bucket
+  access_type = "public-read"   # readable by anyone; objects are still uploaded privately by you
+}
+```
+Use `minio_s3_bucket_policy` instead if you need custom/conditional public rules.
+Don't put both on one bucket.
+
+## 3. Read-only user for a bucket
+
+The canonical permissions pattern: build the policy with a data source, create a
+managed policy, attach it to a user. Note the bucket needs **two** ARNs
+(`bucket` for `ListBucket`, `bucket/*` for object reads).
+```hcl
+data "minio_iam_policy_document" "reports_ro" {
+  statement {
+    sid       = "ListBucket"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::reports"]
+  }
+  statement {
+    sid       = "ReadObjects"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::reports/*"]
+  }
+}
+
+resource "minio_iam_policy" "reports_ro" {
+  name   = "reports-read-only"
+  policy = data.minio_iam_policy_document.reports_ro.json
+}
+
+resource "minio_iam_user" "auditor" {
+  name = "auditor"
+}
+
+resource "minio_iam_user_policy_attachment" "auditor_ro" {
+  user_name   = minio_iam_user.auditor.id   # user_name / policy_name (not user/policy)
+  policy_name = minio_iam_policy.reports_ro.id
+}
+```
+
+## 4. App credentials via service account
+
+When an application needs an access/secret key pair, prefer a service account
+over the user's own secret. A service account **cannot exceed its parent user's
+permissions**, so the user must hold the permissions (here via an attached
+policy); the SA inherits them.
+```hcl
+data "minio_iam_policy_document" "uploader" {
+  statement {
+    sid       = "ListMediaPrefix"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::media"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["uploads/*"]
+    }
+  }
+  statement {
+    sid       = "ReadWriteUploads"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["arn:aws:s3:::media/uploads/*"]
+  }
+}
+
+resource "minio_iam_policy" "uploader" {
+  name   = "media-uploader"
+  policy = data.minio_iam_policy_document.uploader.json
+}
+
+resource "minio_iam_user" "app" {
+  name = "media-app"
+}
+
+resource "minio_iam_user_policy_attachment" "app" {
+  user_name   = minio_iam_user.app.id
+  policy_name = minio_iam_policy.uploader.id
+}
+
+resource "minio_iam_service_account" "app" {
+  target_user = minio_iam_user.app.name
+  # optionally narrow further with: policy = data.minio_iam_policy_document.<even_tighter>.json
+}
+
+output "app_access_key" {
+  value = minio_iam_service_account.app.access_key
+}
+output "app_secret_key" {
+  value     = minio_iam_service_account.app.secret_key
+  sensitive = true   # read it with: terraform output -raw app_secret_key
+}
+```
+If the secret must never touch state, use `minio_accesskey` with a write-only
+secret from a secret store instead (see `resources.md`).
+
+## 5. Group + managed policy + membership
+
+```hcl
+resource "minio_iam_group" "devs" {
+  name = "developers"
+}
+
+resource "minio_iam_policy" "dev" {
+  name   = "dev-access"
+  policy = data.minio_iam_policy_document.dev.json
+}
+
+resource "minio_iam_group_policy_attachment" "dev" {
+  group_name  = minio_iam_group.devs.id   # group_name / policy_name
+  policy_name = minio_iam_policy.dev.id
+}
+
+resource "minio_iam_group_membership" "devs" {
+  name  = "developers-members"
+  group = minio_iam_group.devs.name
+  users = [minio_iam_user.alice.name, minio_iam_user.bob.name]
+}
+```
+
+## 6. Bucket replication
+
+Source bucket must be versioned; the target bucket must already exist and be
+versioned on the destination server. Target credentials are sensitive.
+```hcl
+resource "minio_s3_bucket" "src" {
+  bucket = "data-primary"
+}
+
+resource "minio_s3_bucket_versioning" "src" {
+  bucket = minio_s3_bucket.src.bucket
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "minio_s3_bucket_replication" "src" {
+  bucket = minio_s3_bucket.src.bucket
+  rule {
+    enabled  = true
+    priority = 1
+    target {
+      bucket     = "data-dr"
+      host       = "minio-dr.example.com:9000"
+      access_key = var.dr_access_key
+      secret_key = var.dr_secret_key   # sensitive
+      secure     = true
+    }
+  }
+}
+```
+
+## 7. Server-side encryption
+
+SSE-S3 (`AES256`) needs no external key:
+```hcl
+resource "minio_s3_bucket_server_side_encryption" "secure" {
+  bucket          = minio_s3_bucket.secure.bucket
+  encryption_type = "AES256"
+}
+```
+For SSE-KMS, set `encryption_type = "aws:kms"` and `kms_key_id = "<existing-key>"`.
+The key must already exist on the server (create/lookup via `minio_kms_key` or
+`mc admin kms key`). MinIO KMS must be configured (KES) for this to work.
+
+## 8. Import existing resources
+
+Prefer the reviewable `import {}` block (Terraform ≥ 1.5) so the import shows up
+in a plan before it touches state:
+```hcl
+import {
+  to = minio_s3_bucket.legacy
+  id = "legacy-bucket"
+}
+
+resource "minio_s3_bucket" "legacy" {
+  bucket = "legacy-bucket"
+}
+```
+Then `terraform plan` (optionally `-generate-config-out=generated.tf` to scaffold
+the resource block). Or the CLI form for one-offs:
+```bash
+terraform import minio_iam_user.alice alice
+terraform import minio_iam_user_policy_attachment.x alice/reports-read-only   # user/policy
+terraform import minio_s3_object.f my-bucket/path/file.txt                    # bucket/object
+```
+Import IDs for every resource are tabulated in `resources.md` → *Import syntax*.
+After importing, run `terraform plan` and reconcile any diff (some resources, e.g.
+objects and lifecycle, only read partial state on import).

--- a/skills/terraform-minio/references/resources.md
+++ b/skills/terraform-minio/references/resources.md
@@ -1,0 +1,449 @@
+# MinIO provider — resources reference
+
+Exact schemas and the full inventory for `aminueza/minio`. Argument names are
+verified against the provider's generated docs. When in doubt about a resource
+not detailed here, run `terraform providers schema -json` or check
+`https://registry.terraform.io/providers/aminueza/minio/latest/docs/resources/<name>`
+(URL omits the `minio_` prefix).
+
+## Contents
+
+- [Full inventory](#full-inventory) — every resource, grouped, one line each
+- [Exact schemas: S3 bucket & object](#exact-schemas-s3-bucket--object)
+- [Exact schemas: IAM](#exact-schemas-iam)
+- [Clarifications](#clarifications) — which of several similar resources to use
+- [Import syntax](#import-syntax)
+
+---
+
+## Full inventory
+
+### S3 bucket & object
+- `minio_s3_bucket` — create/manage a bucket (name, acl, force_destroy, object lock).
+- `minio_s3_bucket_policy` — full bucket policy from raw JSON.
+- `minio_s3_bucket_anonymous_access` — canned/anonymous public access for a bucket.
+- `minio_s3_bucket_versioning` — versioning configuration.
+- `minio_s3_bucket_replication` — bucket-to-bucket replication rules.
+- `minio_s3_bucket_retention` — default object-lock retention mode/period.
+- `minio_s3_bucket_object_lock_configuration` — object-lock configuration.
+- `minio_s3_bucket_notification` — event notifications (queue/topic/lambda targets).
+- `minio_s3_bucket_server_side_encryption` — bucket default SSE (AES256 / aws:kms).
+- `minio_s3_bucket_cors` — CORS rules.
+- `minio_s3_bucket_quota` — bucket size quota.
+- `minio_s3_bucket_lifecycle` — lifecycle (ILM) rules, AWS-parity block schema. **Preferred.**
+- `minio_s3_bucket_tags` — bucket tags.
+- `minio_s3_object` — upload/manage an object.
+- `minio_s3_object_tags` — object tags.
+- `minio_s3_object_legal_hold` — object legal hold.
+- `minio_s3_object_retention` — per-object retention.
+- `minio_s3_incomplete_upload_cleanup` — abort/clean incomplete multipart uploads.
+
+### IAM
+- `minio_iam_user` — IAM user.
+- `minio_iam_group` — IAM group.
+- `minio_iam_group_membership` — group-centric authoritative membership set.
+- `minio_iam_user_group_membership` — user-centric authoritative group set.
+- `minio_iam_group_user_attachment` — single user↔group edge (non-authoritative).
+- `minio_iam_service_account` — service account; emits access/secret key pair.
+- `minio_iam_policy` — managed (named) policy.
+- `minio_iam_group_policy` — inline policy embedded on a group.
+- `minio_iam_user_policy_attachment` — attach a managed policy to a user.
+- `minio_iam_group_policy_attachment` — attach a managed policy to a group.
+- `minio_iam_import` — bulk import of IAM entities.
+
+### LDAP / external IdP
+- `minio_iam_ldap_user_policy_attachment` — attach policy to an LDAP user DN.
+- `minio_iam_ldap_group_policy_attachment` — attach policy to an LDAP group DN.
+- `minio_iam_idp_openid` — OpenID Connect IdP configuration.
+- `minio_iam_idp_ldap` — LDAP IdP configuration.
+
+### ILM / KMS / access keys
+- `minio_ilm_policy` — **legacy** lifecycle (string durations); see clarification vs `minio_s3_bucket_lifecycle`.
+- `minio_ilm_tier` — remote transition tier (e.g. to another S3/cloud).
+- `minio_kms_key` — KMS key.
+- `minio_accesskey` — access key for a user (write-only secret; not exported).
+
+### Server configuration
+- `minio_config` — generic server config key/value.
+- `minio_config_restore` — restore server config from a backup.
+- `minio_server_config_api` — typed server config: API subsystem.
+- `minio_server_config_region` — typed server config: region/bucket lookup.
+- `minio_server_config_scanner` — typed server config: object scanner.
+- `minio_server_config_heal` — typed server config: auto-heal.
+- `minio_server_config_storage_class` — typed server config: storage classes.
+- `minio_server_config_etcd` — typed server config: etcd.
+- `minio_audit_webhook` / `minio_audit_kafka` — audit log targets.
+- `minio_logger_webhook` — logger webhook target.
+- `minio_site_replication` — multi-site (active-active) replication setup.
+- `minio_prometheus_bearer_token` — Prometheus scrape bearer token.
+
+### Notification targets (server-side event destinations)
+- `minio_notify_webhook`, `minio_notify_amqp`, `minio_notify_kafka`,
+  `minio_notify_mqtt`, `minio_notify_nats`, `minio_notify_nsq`,
+  `minio_notify_mysql`, `minio_notify_postgres`,
+  `minio_notify_elasticsearch`, `minio_notify_redis`.
+
+### Pool / batch / service
+- `minio_pool_rebalance` — trigger a pool rebalance.
+- `minio_pool_decommission` — decommission a pool.
+- `minio_batch_job` — server-side batch job (replicate/expire/keyrotate).
+- `minio_bucket_metadata_import` — import bucket metadata.
+- `minio_service_action` — restart/stop service action.
+
+---
+
+## Exact schemas: S3 bucket & object
+
+### `minio_s3_bucket`
+All args optional. Use **either** `bucket` or `bucket_prefix` (prefix is create-only).
+```hcl
+resource "minio_s3_bucket" "this" {
+  bucket         = "my-bucket"      # OR bucket_prefix; exact name
+  acl            = "private"        # default "private"
+  force_destroy  = false            # true deletes all objects (incl. locked) on destroy
+  object_locking = false            # enable object lock at creation (immutable later)
+  quota          = 1073741824       # bytes (optional)
+  tags           = { Env = "prod" }
+}
+```
+- `acl` canned values: `private` (default), `public`, `public-read`, `public-read-write`, `public-write`.
+- Exported: `arn`, `bucket_domain_name`, `id`.
+
+### `minio_s3_bucket_policy`
+```hcl
+resource "minio_s3_bucket_policy" "this" {
+  bucket = "my-bucket"            # REQUIRED
+  policy = jsonencode({ ... })    # REQUIRED — full policy JSON
+}
+```
+
+### `minio_s3_bucket_anonymous_access`
+```hcl
+resource "minio_s3_bucket_anonymous_access" "this" {
+  bucket      = "my-bucket"       # REQUIRED
+  access_type = "public-read"     # public | public-read | public-read-write | public-write
+  # policy    = jsonencode({...}) # optional custom JSON; wins over access_type if both set
+}
+```
+Do **not** also put a `minio_s3_bucket_policy` on the same bucket — they write the same underlying policy.
+
+### `minio_s3_bucket_versioning`
+```hcl
+resource "minio_s3_bucket_versioning" "this" {
+  bucket = "my-bucket"            # REQUIRED
+  versioning_configuration {      # REQUIRED (max 1)
+    status            = "Enabled" # Enabled | Suspended
+    exclude_folders   = false
+    excluded_prefixes = ["tmp/"]
+  }
+}
+```
+
+### `minio_s3_bucket_lifecycle` (preferred lifecycle resource)
+Integer `days`; block-form `filter`/`expiration`/`transition`.
+```hcl
+resource "minio_s3_bucket_lifecycle" "this" {
+  bucket = "my-bucket"            # REQUIRED
+  rule {                          # REQUIRED (≥1)
+    id     = "expire-logs"        # REQUIRED (≤255 chars)
+    status = "Enabled"            # Enabled | Disabled (default Enabled)
+
+    filter {                                   # optional (max 1)
+      prefix                   = "logs/"       # cannot combine with top-level `tag`
+      object_size_greater_than = 10485760
+      object_size_less_than    = 104857600
+      tag { key = "k" value = "v" }            # single tag (max 1)
+      and {                                    # composite AND (max 1)
+        prefix                   = "reports/"
+        tags                     = { retain = "long" }
+        object_size_greater_than = 1024
+      }
+    }
+    expiration {                               # optional (max 1)
+      days                         = 30        # int; mutually exclusive with `date`
+      # date                       = "2025-12-31"
+      expired_object_delete_marker = false
+    }
+    transition {                               # optional (max 1)
+      storage_class = "GLACIER"                # REQUIRED in block
+      days          = 60                       # int; OR `date`
+    }
+    noncurrent_version_expiration {            # needs versioning
+      noncurrent_days           = 180          # REQUIRED int
+      newer_noncurrent_versions = 3
+    }
+    noncurrent_version_transition {            # needs versioning
+      noncurrent_days = 90                      # REQUIRED int
+      storage_class   = "GLACIER"               # REQUIRED
+    }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7                 # REQUIRED int; can't combine with tag filters
+    }
+  }
+}
+```
+
+### `minio_ilm_policy` (legacy)
+String durations (`"90d"`); scalar `filter`/`expiration`. Same underlying config as
+`minio_s3_bucket_lifecycle` — never use both on one bucket.
+```hcl
+resource "minio_ilm_policy" "this" {
+  bucket = "my-bucket"            # REQUIRED
+  rule {                          # REQUIRED (≥1)
+    id         = "rule1"          # REQUIRED
+    status     = "Enabled"
+    expiration = "90d"            # STRING: "5d" | "1970-01-01" | "DeleteMarker"
+    filter     = "documents/"     # STRING prefix
+    tags       = { env = "test" }
+    transition {
+      storage_class = "GLACIER"   # REQUIRED
+      days          = "30d"       # STRING "Nd"; OR date "YYYY-MM-DD"
+    }
+    noncurrent_expiration {
+      days           = "365d"     # REQUIRED STRING
+      newer_versions = 5
+    }
+  }
+}
+```
+
+### `minio_s3_bucket_replication`
+Source bucket must be versioned. `target.secret_key` is sensitive.
+```hcl
+resource "minio_s3_bucket_replication" "this" {
+  bucket         = "source-bucket"  # REQUIRED (versioned)
+  resync_version = 0                # bump to resync existing objects
+  rule {
+    enabled                     = true
+    delete_replication          = true
+    delete_marker_replication   = true
+    existing_object_replication = true
+    metadata_sync               = true   # must be true for two-way
+    prefix                      = "data/"
+    priority                    = 1
+    target {                            # REQUIRED (max 1)
+      bucket          = "target-bucket" # REQUIRED
+      host            = "minio-b:9000"  # REQUIRED reachable host
+      access_key      = "..."           # REQUIRED
+      secret_key      = "..."           # sensitive (optional so it can be imported)
+      secure          = true
+      bandwidth_limit = "100M"          # min 100MB
+      region          = "us-east-1"
+      path_style      = "auto"
+      synchronous     = false           # NOTE: misspelled `syncronous` alias is deprecated
+    }
+  }
+}
+```
+Avoid deprecated aliases `bandwidth_limt`, `syncronous`. Exported: `last_resync_id`, per-rule `rule.arn`/`rule.id`.
+
+### `minio_s3_bucket_server_side_encryption`
+```hcl
+resource "minio_s3_bucket_server_side_encryption" "this" {
+  bucket          = "my-bucket"   # REQUIRED
+  encryption_type = "aws:kms"     # REQUIRED: "AES256" (SSE-S3) | "aws:kms" (SSE-KMS)
+  kms_key_id      = "my-kms-key"  # REQUIRED when encryption_type = "aws:kms"
+}
+```
+
+### `minio_s3_object`
+Note the names: `bucket_name` / `object_name` (not `bucket`/`key`).
+```hcl
+resource "minio_s3_object" "this" {
+  bucket_name  = "my-bucket"      # REQUIRED
+  object_name  = "path/text.txt"  # REQUIRED
+  content      = "hello"          # use ONE of content / content_base64 / source
+  # content_base64 = "..."
+  # source         = "./file.txt"
+  content_type = "text/plain"
+  acl          = "private"        # private | public-read | public-read-write | authenticated-read
+  # also: cache_control, content_encoding, content_disposition, expires, storage_class, metadata
+}
+```
+
+---
+
+## Exact schemas: IAM
+
+### `minio_iam_user`
+```hcl
+resource "minio_iam_user" "this" {
+  name          = "test-user"     # REQUIRED
+  secret        = var.user_secret # sensitive; stored in state
+  update_secret = false           # set true to rotate `secret`
+  disable_user  = false
+  force_destroy = false           # delete even if it has non-TF-managed access keys
+  tags          = { team = "data" }
+  # secret_wo         = var.user_secret  # write-only (NOT stored in state); Terraform ≥ 1.11
+  # secret_wo_version = 1                # bump to rotate when using secret_wo
+}
+```
+Exported: `status`, `id`.
+
+### `minio_iam_group`
+```hcl
+resource "minio_iam_group" "this" {
+  name          = "developers"    # REQUIRED
+  disable_group = false
+  force_destroy = false
+}
+```
+Exported: `group_name`.
+
+### `minio_iam_group_membership` (group-centric, authoritative)
+```hcl
+resource "minio_iam_group_membership" "this" {
+  name  = "dev-membership"        # REQUIRED — name of THIS resource
+  group = "developers"            # REQUIRED — target group
+  users = ["alice", "bob"]        # REQUIRED — Set of String
+}
+```
+
+### `minio_iam_user_group_membership` (user-centric, authoritative)
+```hcl
+resource "minio_iam_user_group_membership" "this" {
+  user   = "alice"                     # REQUIRED
+  groups = ["developers", "admins"]    # REQUIRED — user ends up in EXACTLY these
+}
+```
+
+### `minio_iam_group_user_attachment` (single edge, non-authoritative)
+```hcl
+resource "minio_iam_group_user_attachment" "this" {
+  group_name = "developers"       # REQUIRED
+  user_name  = "alice"            # REQUIRED
+}
+```
+
+### `minio_iam_policy` (managed)
+```hcl
+resource "minio_iam_policy" "this" {
+  policy      = data.minio_iam_policy_document.this.json  # REQUIRED (JSON string)
+  name        = "my-policy"        # conflicts with name_prefix
+  # name_prefix = "my-policy-"
+}
+```
+
+### `minio_iam_group_policy` (inline on a group)
+```hcl
+resource "minio_iam_group_policy" "this" {
+  group  = "developers"            # REQUIRED
+  policy = jsonencode({ ... })     # REQUIRED
+  name   = "inline-rule"           # random if omitted; conflicts with name_prefix
+}
+```
+
+### `minio_iam_user_policy_attachment`
+Names: `user_name` / `policy_name`.
+```hcl
+resource "minio_iam_user_policy_attachment" "this" {
+  user_name   = minio_iam_user.this.id
+  policy_name = minio_iam_policy.this.id
+}
+```
+
+### `minio_iam_group_policy_attachment`
+Names: `group_name` / `policy_name`.
+```hcl
+resource "minio_iam_group_policy_attachment" "this" {
+  group_name  = minio_iam_group.this.id
+  policy_name = minio_iam_policy.this.id
+}
+```
+
+### `minio_iam_service_account`
+Mints credentials; **exports** the secret (sensitive) so other resources can use it.
+```hcl
+resource "minio_iam_service_account" "this" {
+  target_user  = minio_iam_user.this.name   # REQUIRED — owning user
+  name         = "svc"                       # optional, ≤32 bytes, can't be cleared once set
+  description  = "CI uploader"               # optional, ≤256 bytes
+  policy       = data.minio_iam_policy_document.scoped.json  # optional — restricts the SA
+  disable_user = false                       # disable the SA (there is NO `status` input)
+  expiration   = "2026-12-31T00:00:00Z"      # optional RFC3339 (now+15min .. now+365d)
+  update_secret = false                      # rotate the secret key
+  # secret_key_wo         = "..."            # write-only; Terraform ≥ 1.11
+  # secret_key_wo_version = 1
+}
+# Exported (SENSITIVE): access_key, secret_key; plus status.
+```
+
+### `minio_accesskey`
+Like a service account but the secret is **write-only and never exported**.
+```hcl
+resource "minio_accesskey" "this" {
+  user               = minio_iam_user.this.name  # REQUIRED
+  access_key         = "MYAPPKEY12345"            # optional, 8-20 chars; auto-generated if omitted
+  secret_key         = var.app_secret             # optional, ≥8 chars; WRITE-ONLY, not in state
+  secret_key_version = "v1"                        # required for change detection when secret_key set
+  status             = "enabled"                   # enabled | disabled
+  policy             = jsonencode({ ... })         # optional — policy NAME or JSON
+}
+# secret_key is NOT exported. Supply/track it yourself (e.g. from a secret store).
+```
+
+---
+
+## Clarifications
+
+**Group membership trio**
+- `minio_iam_group_membership` (`name` + `group` + `users`) — group-centric,
+  authoritative over that named set. *Use when* you own a group's full member list.
+- `minio_iam_user_group_membership` (`user` + `groups`) — user-centric,
+  authoritative; the user ends up in exactly those groups. *Use when* you own one
+  user's complete group set.
+- `minio_iam_group_user_attachment` (`group_name` + `user_name`) — one edge,
+  non-authoritative. *Use when* adding one user to one group (composes with `for_each`).
+
+**`minio_s3_bucket_lifecycle` vs `minio_ilm_policy`** — same underlying config,
+never both on one bucket. Lifecycle uses AWS-parity blocks with integer `days`;
+ilm_policy uses scalar strings and durations like `"90d"`. Prefer
+`minio_s3_bucket_lifecycle` for new work; `minio_ilm_policy` only for legacy.
+
+**`minio_s3_bucket_anonymous_access` vs `minio_s3_bucket_policy`** — both write
+the bucket's single policy; never both. Anonymous-access gives canned
+`access_type`; bucket_policy takes full custom JSON. Use anonymous-access for
+simple public exposure, bucket_policy for cross-principal/custom rules.
+
+**`minio_iam_service_account` vs `minio_accesskey`** — both mint creds for a user.
+Service account exports `access_key` + `secret_key` (use them downstream, e.g. a
+replication target); accesskey's `secret_key` is write-only and never exported
+(supply it from a secret store, never lands in state). Choose by whether
+Terraform needs the secret value downstream.
+
+**`secret` / `update_secret` vs `secret_wo`** — `secret` stores the key in state;
+`update_secret=true` rotates it. `secret_wo` + `secret_wo_version` is write-only
+(never persisted); bump the version to rotate. Write-only args need Terraform ≥ 1.11.
+
+**Inline vs managed policy** — inline (`minio_iam_group_policy`) embeds JSON that
+lives and dies with the group. Managed (`minio_iam_policy`) is reusable and is
+attached via `minio_iam_{user,group}_policy_attachment`. Use inline for one-off
+group rules, managed+attachment for policies shared across principals.
+
+---
+
+## Import syntax
+
+Every resource is importable. IDs by resource:
+
+| Resource | Import ID | Example |
+|---|---|---|
+| `minio_s3_bucket` | bucket name | `terraform import minio_s3_bucket.b my-bucket` |
+| `minio_s3_bucket_policy` | bucket name | `... minio_s3_bucket_policy.p my-bucket` |
+| `minio_s3_bucket_versioning` | bucket name | `... .v my-bucket` |
+| `minio_s3_bucket_lifecycle` | bucket name | `... .l my-bucket` (re-apply once to reconcile) |
+| `minio_s3_bucket_replication` | bucket name | `... .r my-bucket` |
+| `minio_s3_object` | `bucket/object` | `... .o my-bucket/path/file.txt` |
+| `minio_iam_user` | user name | `... minio_iam_user.u alice` |
+| `minio_iam_group` | group name | `... minio_iam_group.g developers` |
+| `minio_iam_group_membership` | group name | `... .m developers` |
+| `minio_iam_user_group_membership` | user name | `... .m alice` |
+| `minio_iam_group_user_attachment` | `group/user` | `... .a developers/alice` |
+| `minio_iam_policy` | policy name | `... minio_iam_policy.p my-policy` |
+| `minio_iam_user_policy_attachment` | `user/policy` | `... .a alice/my-policy` |
+| `minio_iam_group_policy_attachment` | `group/policy` | `... .a developers/my-policy` |
+| `minio_iam_service_account` | access key id | `... .sa AKIA...` |
+| `minio_accesskey` | access key id | `... .k MYAPPKEY12345` |
+
+Prefer the `import {}` config block (Terraform ≥ 1.5) so the import is reviewed
+in a plan — see `recipes.md` → *Import existing resources*.


### PR DESCRIPTION
## What does this PR do?
Adds a [Claude Code](https://docs.claude.com/en/docs/claude-code) skill under `skills/terraform-minio/` (kubectl-ai-style): turns natural language into correct `aminueza/minio` HCL and runs Terraform with a safe **plan → confirm → apply** flow. Docs/tooling only — no provider code changed.

- `SKILL.md` + `references/` cover all **65 resources / 54 data sources** (exact arg names, recipes, auth).
- `README.md`: new "Claude Code Skill" section with install steps.

## How was it tested?
End-to-end on a real MinIO (Docker, v3.38.1): `init`/`validate`/`plan`/`apply` clean, and the generated prefix-scoped IAM policy correctly **allowed `daily/` and denied outside it**. Inventory diffed against the generated docs — 0 missing.

### Type of Change
- [x] Documentation update