### PR TITLE
fix(s3-bucket): add `Computed: true` to tags to prevent drift during refresh

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -97,6 +97,7 @@ resource "minio_s3_bucket" "customer" {
 ```
 
 - Bucket tagging requires support from the underlying S3-compatible endpoint. If your endpoint does not support tagging, you can set `skip_bucket_tagging = true` in the provider configuration to disable tagging operations and prevent errors.
+- To remove all tags, set `tags = {}` explicitly. Omitting the `tags` argument no longer clears existing tags: `tags` is a computed attribute, so Terraform retains the last known value to avoid perpetual drift during refresh-only plans.
 
 ## Argument Reference
 

--- a/docs/resources/s3_bucket_tags.md
+++ b/docs/resources/s3_bucket_tags.md
@@ -40,6 +40,7 @@ resource "minio_s3_bucket_tags" "example" {
 
 - This resource requires support for bucket tagging from the underlying S3-compatible endpoint. If your endpoint does not support tagging, you can set `skip_bucket_tagging = true` in the provider configuration to disable tagging operations and prevent errors.
 - When `skip_bucket_tagging = true`, this resource will preserve the last known tag state in Terraform state without making API calls to the remote endpoint.
+- To remove all tags, set `tags = {}` explicitly. Omitting the `tags` argument no longer clears existing tags: `tags` is a computed attribute, so Terraform retains the last known value to avoid perpetual drift during refresh-only plans.
 
 ## Import
 

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -121,6 +121,7 @@ func resourceMinioBucket() *schema.Resource {
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "A map of tags to assign to the bucket",
 			},

--- a/minio/resource_minio_s3_bucket_tags.go
+++ b/minio/resource_minio_s3_bucket_tags.go
@@ -29,6 +29,7 @@ func resourceMinioBucketTags() *schema.Resource {
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Map of tags to assign to the bucket",
 			},
@@ -79,15 +80,15 @@ func minioReadBucketTags(ctx context.Context, d *schema.ResourceData, meta inter
 
 	bucketTags, err := cfg.MinioClient.GetBucketTagging(ctx, bucket)
 	if err != nil {
-		if isNoSuchBucketError(err) {
-			tflog.Warn(ctx, fmt.Sprintf("Bucket %s no longer exists, removing tags from state", bucket))
-			d.SetId("")
-			return nil
-		}
 		var minioErr minio.ErrorResponse
 		if errors.As(err, &minioErr) && minioErr.Code == "NoSuchTagSet" {
 			_ = d.Set("bucket", bucket)
 			_ = d.Set("tags", map[string]string{})
+			return nil
+		}
+		if isNoSuchBucketError(err) {
+			tflog.Warn(ctx, fmt.Sprintf("Bucket %s no longer exists, removing tags from state", bucket))
+			d.SetId("")
 			return nil
 		}
 		if IsS3TaggingNotImplemented(err) {

--- a/minio/resource_minio_s3_bucket_tags_test.go
+++ b/minio/resource_minio_s3_bucket_tags_test.go
@@ -102,6 +102,49 @@ func TestAccMinioS3BucketTags_deletedBucket(t *testing.T) {
 	})
 }
 
+func TestAccMinioS3BucketTags_emptyTagsNoDrift(t *testing.T) {
+	bucketName := "tfacc-tags-nodrift-" + acctest.RandString(8)
+	resourceName := "minio_s3_bucket_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioBucketTagsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioS3BucketTagsConfigEmpty(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketTagsExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     bucketName,
+			},
+		},
+	})
+}
+
+func testAccMinioS3BucketTagsConfigEmpty(bucketName string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = "%s"
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "minio_s3_bucket_tags" "test" {
+  bucket = minio_s3_bucket.bucket.id
+  tags   = {}
+}
+`, bucketName)
+}
+
 func testAccMinioS3BucketTagsConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "minio_s3_bucket" "bucket" {

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -1226,7 +1226,7 @@ func TestAccMinioS3Bucket_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMinioS3BucketConfigBasic(rInt),
+				Config: testAccMinioS3BucketConfigWithTags(rInt, map[string]string{}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioS3BucketExists(resourceName),
 					testAccCheckMinioS3BucketTagsRemoved(resourceName),
@@ -1623,6 +1623,71 @@ func TestAccMinioS3Bucket_SkipBucketTagging(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccMinioS3Bucket_tagsNoDrift(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "minio_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioS3BucketConfigBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMinioS3Bucket_emptyTagsNoDrift(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "minio_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioS3BucketConfigEmptyTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}
+
+func testAccMinioS3BucketConfigEmptyTags(rInt int) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "test" {
+	bucket = "test-bucket-%d"
+	tags   = {}
+}
+`, rInt)
 }
 
 func testAccMinioS3BucketConfigWithSkipTagging(randInt string) string {

--- a/templates/resources/s3_bucket.md.tmpl
+++ b/templates/resources/s3_bucket.md.tmpl
@@ -46,6 +46,7 @@ resource "minio_s3_bucket" "customer" {
 ```
 
 - Bucket tagging requires support from the underlying S3-compatible endpoint. If your endpoint does not support tagging, you can set `skip_bucket_tagging = true` in the provider configuration to disable tagging operations and prevent errors.
+- To remove all tags, set `tags = {}` explicitly. Omitting the `tags` argument no longer clears existing tags: `tags` is a computed attribute, so Terraform retains the last known value to avoid perpetual drift during refresh-only plans.
 
 ## Argument Reference
 

--- a/templates/resources/s3_bucket_tags.md.tmpl
+++ b/templates/resources/s3_bucket_tags.md.tmpl
@@ -19,6 +19,7 @@ description: |-
 
 - This resource requires support for bucket tagging from the underlying S3-compatible endpoint. If your endpoint does not support tagging, you can set `skip_bucket_tagging = true` in the provider configuration to disable tagging operations and prevent errors.
 - When `skip_bucket_tagging = true`, this resource will preserve the last known tag state in Terraform state without making API calls to the remote endpoint.
+- To remove all tags, set `tags = {}` explicitly. Omitting the `tags` argument no longer clears existing tags: `tags` is a computed attribute, so Terraform retains the last known value to avoid perpetual drift during refresh-only plans.
 
 ## Import
 


### PR DESCRIPTION
Fixes #1000, by applying the following changes:

1. **`resource_minio_s3_bucket.go`**: Added `Computed: true` to `tags` schema field.

2. **`resource_minio_s3_bucket_tags.go`**: 
   - Added `Computed: true` to `tags` schema field.
   - Fixed error handling ordering: check `NoSuchTagSet` before `isNoSuchBucketError`. The latter matches any error with 404 status code, which includes MinIO `NoSuchTagSet` responses, causing `GetBucketTagging` on a bucket with no tags to incorrectly remove the resource from state.