### PR TITLE
docs: remove stale write-only NOTE blocks from generated docs

### DIFF
--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -90,14 +90,12 @@ The `policy` argument expects a JSON policy document. Use `jsonencode({...})` to
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `access_key` (String, Sensitive) The access key. If provided, must be between 8 and 20 characters.
 - `description` (String) Description for the access key (max 256 characters).
 - `policy` (String) Policy to attach to the access key (policy name or JSON document).
 - `secret_key` (String, Sensitive) The secret key. If provided, must be at least 8 characters. This is a write-only field and will not be stored in state.
 - `secret_key_version` (String) Version identifier for the secret key. Change this value to trigger a secret key rotation. Can be a hash, version number, timestamp, or any string that changes when the secret changes.
-- `secret_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only secret key for the access key.
+- `secret_key_wo` (String, Sensitive) Write-only secret key for the access key.
 - `secret_key_wo_version` (Number) Version identifier for secret_key_wo. Increment this integer to trigger rotation when using secret_key_wo.
 - `status` (String) The status of the access key (enabled/disabled).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/iam_idp_openid.md
+++ b/docs/resources/iam_idp_openid.md
@@ -86,12 +86,10 @@ Prefer `client_secret_wo` with `client_secret_wo_version` for secret rotation wi
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `claim_name` (String) JWT claim attribute used to identify the policy for the authenticated user. Defaults to 'policy'. Cannot be set together with role_policy.
 - `claim_prefix` (String) Prefix to apply to JWT claim values when looking up policies. Cannot be set together with role_policy.
 - `client_secret` (String, Sensitive) OAuth2 client secret registered with the identity provider. MinIO does not return this value on read; Terraform keeps the value from your configuration.
-- `client_secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only OAuth2 client secret for this OIDC configuration.
+- `client_secret_wo` (String, Sensitive) Write-only OAuth2 client secret for this OIDC configuration.
 - `client_secret_wo_version` (Number) Version identifier for client_secret_wo. Change this value to trigger updates when using client_secret_wo.
 - `comment` (String) Comment or description for this OIDC configuration.
 - `display_name` (String) Display name for this identity provider shown on the MinIO login screen.

--- a/docs/resources/iam_service_account.md
+++ b/docs/resources/iam_service_account.md
@@ -58,14 +58,12 @@ Use `secret_key_wo` with `secret_key_wo_version` to rotate service account secre
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `description` (String) Description of service account (256 bytes max), can't be cleared once set
 - `disable_user` (Boolean) Disable service account
 - `expiration` (String) Expiration of service account in RFC3339 format. Must be between NOW+15min & NOW+365d. If not set, the service account will not expire.
 - `name` (String) Name of service account (32 bytes max), can't be cleared once set
 - `policy` (String) policy of service account as encoded JSON string
-- `secret_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) write-only secret key of service account
+- `secret_key_wo` (String, Sensitive) write-only secret key of service account
 - `secret_key_wo_version` (Number) Version identifier for secret_key_wo. Change this value to trigger secret key rotation when using secret_key_wo.
 - `update_secret` (Boolean) rotate secret key
 

--- a/docs/resources/iam_user.md
+++ b/docs/resources/iam_user.md
@@ -58,12 +58,10 @@ Use `secret_wo` with `secret_wo_version` when you do not want the provided secre
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `disable_user` (Boolean) Disable user
 - `force_destroy` (Boolean) Delete user even if it has non-Terraform-managed IAM access keys
 - `secret` (String, Sensitive) Secret key for the IAM user.
-- `secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only secret key for the IAM user.
+- `secret_wo` (String, Sensitive) Write-only secret key for the IAM user.
 - `secret_wo_version` (Number) Version identifier for secret_wo. Change this value to trigger rotation when using secret_wo.
 - `tags` (Map of String)
 - `update_secret` (Boolean) Rotate Minio User Secret Key


### PR DESCRIPTION
Split out from #1001 to keep that PR focused on the tags-drift fix.

These four generated doc files were regenerated with `tfplugindocs@v0.25.0` (the version pinned in both `Taskfile.yml` and the Docs CI workflow), which drops the standalone `> **NOTE**: Write-only arguments are supported in Terraform 1.11 and later.` callouts:

- docs/resources/accesskey.md
- docs/resources/iam_idp_openid.md
- docs/resources/iam_service_account.md
- docs/resources/iam_user.md

Verified: running `tfplugindocs@v0.25.0` locally reproduces exactly this diff (these 4 files, nothing else). The NOTE on `main` is stale output from an older generator, so this simply brings the committed docs in line with the pinned toolchain. The post-merge Docs CI on `main` would generate the same result.