### PR TITLE
ci(docs): pin Terraform version for tfplugindocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,7 @@ jobs:
           cache: true
 
       - name: Generate docs
-        run: go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0
+        run: go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 generate --tf-version 1.15.7
 
       - name: Open PR with updated docs
         env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
   generate-docs:
     desc: Generate the docs for the provider
     cmds:
-      - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0
+      - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 generate --tf-version 1.15.7
 
   install:
     desc: Build and install the plugin in the correct folder (resolved automatically based on current Operating System).


### PR DESCRIPTION
## Problem

`tfplugindocs generate` introspects the provider schema through a `terraform` binary picked up from `PATH`. Write-only arguments only exist in **Terraform 1.11+**, so generating docs with an older CLI (e.g. 1.5.x) silently drops:

- the `> **NOTE**: Write-only arguments are supported in Terraform 1.11 and later.` callouts, and
- the per-field `, [Write-only](...)` markers on `secret_key_wo`, `secret_wo`, `client_secret_wo`.

This caused local vs CI doc generation to disagree (a doc PR removed those callouts locally, then the post-merge Docs CI re-added them).

## Fix

Pin `--tf-version 1.15.7` (current latest stable) in both the `generate-docs` Task and the Docs CI workflow. `tfplugindocs` downloads that exact Terraform for introspection, so local and CI output are reproducible regardless of what's on `PATH`.

## Verification

Ran `tfplugindocs generate --tf-version 1.15.7` locally with Terraform 1.5.7 on `PATH`; the write-only callouts are now emitted correctly, matching CI output.