### PR TITLE
fix(s3-bucket): preserve tags state when backend does not implement tagging

### DIFF
--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -352,7 +352,8 @@ func minioReadBucket(ctx context.Context, d *schema.ResourceData, meta interface
 		if errors.As(err, &minioErr) && minioErr.Code == "NoSuchTagSet" {
 			_ = d.Set("tags", map[string]string{})
 		} else if IsS3TaggingNotImplemented(err) {
-			return nil
+			tflog.Info(ctx, "Bucket tagging is not supported by backend; preserving state")
+			preserveBucketTagsState(d)
 		} else {
 			return NewResourceError("error reading bucket tags", d.Id(), err)
 		}

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -1713,8 +1713,7 @@ resource "minio_s3_bucket" "bucket" {
 // TestMinioReadBucket_taggingNotImplemented verifies that Read still writes
 // tags into state when the backend does not implement bucket tagging (e.g.
 // Hetzner Object Storage / Ceph RGW). If tags never exists in state, the
-// Optional+Computed attribute is planned as unknown on every run and never
-// converges (regression reported in #1000 against 3.38.2).
+// Optional+Computed attribute is planned as unknown on every run and never converges.
 func TestMinioReadBucket_taggingNotImplemented(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -1745,7 +1744,6 @@ func TestMinioReadBucket_taggingNotImplemented(t *testing.T) {
 					_, _ = fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>NotImplemented</Code><Message>This operation is not implemented.</Message></Error>`)
 					return
 				}
-				// BucketExists (HEAD) succeeds.
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer srv.Close()

--- a/minio/resource_minio_s3_bucket_test.go
+++ b/minio/resource_minio_s3_bucket_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -1706,4 +1708,74 @@ resource "minio_s3_bucket" "bucket" {
   }
 }
 `, randInt)
+}
+
+// TestMinioReadBucket_taggingNotImplemented verifies that Read still writes
+// tags into state when the backend does not implement bucket tagging (e.g.
+// Hetzner Object Storage / Ceph RGW). If tags never exists in state, the
+// Optional+Computed attribute is planned as unknown on every run and never
+// converges (regression reported in #1000 against 3.38.2).
+func TestMinioReadBucket_taggingNotImplemented(t *testing.T) {
+	cases := []struct {
+		name      string
+		rawConfig map[string]interface{}
+		wantAttrs map[string]string
+	}{
+		{
+			name:      "no tags writes empty map into state",
+			rawConfig: map[string]interface{}{"bucket": "test-bucket"},
+			wantAttrs: map[string]string{"tags.%": "0"},
+		},
+		{
+			name: "known tags are preserved",
+			rawConfig: map[string]interface{}{
+				"bucket": "test-bucket",
+				"tags":   map[string]interface{}{"env": "prod"},
+			},
+			wantAttrs: map[string]string{"tags.%": "1", "tags.env": "prod"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Has("tagging") {
+					w.Header().Set("Content-Type", "application/xml")
+					w.WriteHeader(http.StatusNotImplemented)
+					_, _ = fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>NotImplemented</Code><Message>This operation is not implemented.</Message></Error>`)
+					return
+				}
+				// BucketExists (HEAD) succeeds.
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			s3Client, err := minio.New(strings.TrimPrefix(srv.URL, "http://"), &minio.Options{
+				Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+				Secure: false,
+				Region: "us-east-1",
+			})
+			if err != nil {
+				t.Fatalf("creating S3 client: %v", err)
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceMinioBucket().Schema, tc.rawConfig)
+			d.SetId("test-bucket")
+
+			meta := &S3MinioClient{S3Client: s3Client}
+			if diags := minioReadBucket(context.Background(), d, meta); len(diags) > 0 {
+				t.Fatalf("read returned diagnostics: %v", diags)
+			}
+
+			state := d.State()
+			if state == nil {
+				t.Fatal("expected non-nil state after read")
+			}
+			for k, want := range tc.wantAttrs {
+				if got := state.Attributes[k]; got != want {
+					t.Errorf("state attribute %q = %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes the 3.38.2 regression [reported in #1000](https://github.com/aminueza/terraform-provider-minio/issues/1000#issuecomment-4902870352) against non-MinIO S3-compatible backends (Hetzner Object Storage / Ceph RGW), where `tags` was planned as unknown on every run and never converged:

```
.tags: planned value cty.UnknownVal(cty.Map(cty.String)) does not match config value cty.MapValEmpty(cty.String)
```

**Root cause:** #1001 made `tags` `Computed: true`. On backends where `GetBucketTagging` returns a "not implemented" error, `minioReadBucket` returned early without writing `tags` into state. The legacy plugin SDK plans a `Computed` map as unknown whenever the attribute is absent from state and the config is empty (`helper/schema` `diffMap`: *"if it existed in the state, even empty, then it has already been computed"*), and since Read never materialized a value, the plan could never converge. Real MinIO is unaffected because an untagged bucket returns `NoSuchTagSet`, a branch that does write `{}` into state.

**Changes:**

1. **`resource_minio_s3_bucket.go`**: the `IsS3TaggingNotImplemented` branch in `minioReadBucket` now calls `preserveBucketTagsState(d)` (writes `{}` when nothing is known) instead of returning without touching state, matching the `skip_bucket_tagging` path and the same branch in `resource_minio_s3_bucket_tags.go`. Affected states self-heal on the first refresh.

2. **`resource_minio_s3_bucket_test.go`**: added `TestMinioReadBucket_taggingNotImplemented`, a unit test using an httptest mock that answers `GET ?tagging` with 501 `NotImplemented` and asserts `tags` exists in state afterward. It fails against the previous code with exactly the regression condition (`tags.%` absent from state).