### PR TITLE
docs: expand provider overview to reflect current scope

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,13 @@ description: Manage Minio with Terraform.
 
 # Minio Provider
 
-This is a terraform provider plugin for managing [Minio](https://min.io/) S3 buckets and IAM users.
+The Minio provider manages [MinIO](https://min.io/) object storage with Terraform, from bucket and object operations to identity management and server configuration. It talks to both the MinIO S3 API and the Admin API, so a single configuration can provision storage and administer the server behind it.
+
+It ships a broad set of resources and data sources. On the storage side, it manages S3 buckets with versioning, policies, lifecycle (ILM), replication, object locking and retention, tagging, CORS, quotas, and encryption, along with objects and their metadata. On the administration side, it covers IAM users, groups, policies, service accounts, and LDAP or OpenID identity providers; bucket and site replication; event notifications for targets such as Kafka, AMQP, MQTT, Elasticsearch, and webhooks; and server settings including audit and logger targets, scanner, heal, and storage classes.
+
+For authentication, the provider accepts static credentials or environment variables and supports STS AssumeRole, OIDC web identity for CI/CD pipelines, and mutual TLS.
+
+Although built for MinIO, the provider also works with other S3-compatible stores. Set `s3_compat_mode` to gracefully skip features a backend does not implement; tested backends include Cloudflare R2, Backblaze B2, DigitalOcean Spaces, and Hetzner Object Storage.
 
 ## Example Provider Configuration
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -5,7 +5,13 @@ description: Manage Minio with Terraform.
 
 # Minio Provider
 
-This is a terraform provider plugin for managing [Minio](https://min.io/) S3 buckets and IAM users.
+The Minio provider manages [MinIO](https://min.io/) object storage with Terraform, from bucket and object operations to identity management and server configuration. It talks to both the MinIO S3 API and the Admin API, so a single configuration can provision storage and administer the server behind it.
+
+It ships a broad set of resources and data sources. On the storage side, it manages S3 buckets with versioning, policies, lifecycle (ILM), replication, object locking and retention, tagging, CORS, quotas, and encryption, along with objects and their metadata. On the administration side, it covers IAM users, groups, policies, service accounts, and LDAP or OpenID identity providers; bucket and site replication; event notifications for targets such as Kafka, AMQP, MQTT, Elasticsearch, and webhooks; and server settings including audit and logger targets, scanner, heal, and storage classes.
+
+For authentication, the provider accepts static credentials or environment variables and supports STS AssumeRole, OIDC web identity for CI/CD pipelines, and mutual TLS.
+
+Although built for MinIO, the provider also works with other S3-compatible stores. Set `s3_compat_mode` to gracefully skip features a backend does not implement; tested backends include Cloudflare R2, Backblaze B2, DigitalOcean Spaces, and Hetzner Object Storage.
 
 ## Example Provider Configuration
 


### PR DESCRIPTION
## Description

### Type of Change
- [x] Documentation update

### What does this PR do?

The Terraform Registry "Overview" tab renders `docs/index.md` (generated from `templates/index.md.tmpl`). Its intro was a single stale sentence, "This is a terraform provider plugin for managing Minio S3 buckets and IAM users.", which undersold a provider that now ships 65 resources and 54 data sources.

This rewrites the intro portion of `templates/index.md.tmpl` into four short paragraphs describing the current scope:

- buckets and objects, IAM, ILM, replication, encryption, notifications, and server configuration;
- authentication via static credentials, environment variables, STS AssumeRole, OIDC web identity, and mutual TLS;
- S3-compatible backends (Cloudflare R2, Backblaze B2, DigitalOcean Spaces, Hetzner) via `s3_compat_mode`.

The example configuration, authentication, provider arguments, and all other sections are unchanged.

### How was this change tested?

Ran `task generate-docs` and verified `docs/index.md` renders the new intro. The regeneration changed only `docs/index.md` and `templates/index.md.tmpl` (8 lines each); all 65 resource and 54 data-source docs regenerated byte-identical.

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My change follows the project's coding standards
- [x] I have performed a self-review
- [x] I have signed my commits (`git commit -s`)
- [x] I have updated the documentation templates in `templates/`
- [x] I have run `task generate-docs` to update generated documentation
