### PR TITLE
fix: keep minio_iam_idp_openid in state when config is pending server restart

### DIFF
--- a/minio/resource_minio_iam_idp_openid.go
+++ b/minio/resource_minio_iam_idp_openid.go
@@ -179,10 +179,18 @@ func minioCreateIdpOpenId(ctx context.Context, d *schema.ResourceData, meta inte
 
 	tflog.Debug(ctx, fmt.Sprintf("Created OIDC IDP configuration: %s (restart_required=%v)", config.Name, restart))
 
-	return minioReadIdpOpenId(ctx, d, meta)
+	return minioReadIdpOpenIdAfterWrite(ctx, d, meta)
 }
 
 func minioReadIdpOpenId(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return minioReadIdpOpenIdConfig(ctx, d, meta, false)
+}
+
+func minioReadIdpOpenIdAfterWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return minioReadIdpOpenIdConfig(ctx, d, meta, true)
+}
+
+func minioReadIdpOpenIdConfig(ctx context.Context, d *schema.ResourceData, meta interface{}, afterWrite bool) diag.Diagnostics {
 	minioAdmin := meta.(*S3MinioClient).S3Admin
 	cfgName := d.Id()
 
@@ -191,6 +199,10 @@ func minioReadIdpOpenId(ctx context.Context, d *schema.ResourceData, meta interf
 	cfg, err := minioAdmin.GetIDPConfig(ctx, madmin.OpenidIDPCfg, cfgName)
 	if err != nil {
 		if isIDPConfigNotFound(err) {
+			if afterWrite {
+				tflog.Warn(ctx, fmt.Sprintf("OIDC IDP configuration %s was accepted but is not yet visible; a MinIO server restart may be required for it to take effect. Keeping configured values in state", cfgName))
+				return nil
+			}
 			tflog.Warn(ctx, fmt.Sprintf("OIDC IDP configuration %s no longer exists, removing from state", cfgName))
 			d.SetId("")
 			return nil
@@ -296,7 +308,7 @@ func minioUpdateIdpOpenId(ctx context.Context, d *schema.ResourceData, meta inte
 
 	tflog.Debug(ctx, fmt.Sprintf("Updated OIDC IDP configuration: %s (restart_required=%v)", config.Name, restart))
 
-	return minioReadIdpOpenId(ctx, d, meta)
+	return minioReadIdpOpenIdAfterWrite(ctx, d, meta)
 }
 
 func minioDeleteIdpOpenId(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/minio/resource_minio_iam_idp_openid_notfound_test.go
+++ b/minio/resource_minio_iam_idp_openid_notfound_test.go
@@ -1,0 +1,99 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/madmin-go/v3"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func TestMinioReadIdpOpenIdNotFound(t *testing.T) {
+	cases := []struct {
+		name       string
+		afterWrite bool
+		statusCode int
+		body       string
+		wantErr    bool
+		wantID     string
+	}{
+		{
+			name:       "not found after write keeps resource in state",
+			afterWrite: true,
+			statusCode: http.StatusNotFound,
+			body:       `{"Code":"XMinioAdminIDPCfgNotFound","Message":"IDP configuration 'tfacc-oidc' not found"}`,
+			wantErr:    false,
+			wantID:     "tfacc-oidc",
+		},
+		{
+			name:       "not found on refresh clears resource",
+			afterWrite: false,
+			statusCode: http.StatusNotFound,
+			body:       `{"Code":"XMinioAdminIDPCfgNotFound","Message":"IDP configuration 'tfacc-oidc' not found"}`,
+			wantErr:    false,
+			wantID:     "",
+		},
+		{
+			name:       "unrelated error propagates after write",
+			afterWrite: true,
+			statusCode: http.StatusForbidden,
+			body:       `{"Code":"AccessDenied","Message":"access denied"}`,
+			wantErr:    true,
+			wantID:     "tfacc-oidc",
+		},
+		{
+			name:       "unrelated error propagates on refresh",
+			afterWrite: false,
+			statusCode: http.StatusForbidden,
+			body:       `{"Code":"AccessDenied","Message":"access denied"}`,
+			wantErr:    true,
+			wantID:     "tfacc-oidc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+
+			host := strings.TrimPrefix(srv.URL, "http://")
+			adminClient, err := madmin.NewWithOptions(host, &madmin.Options{
+				Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+				Secure: false,
+			})
+			if err != nil {
+				t.Fatalf("creating admin client: %v", err)
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceMinioIAMIdpOpenId().Schema, map[string]interface{}{
+				"name":          "tfacc-oidc",
+				"config_url":    "http://idp.example.com/.well-known/openid-configuration",
+				"client_id":     "client",
+				"client_secret": "secret",
+			})
+			d.SetId("tfacc-oidc")
+
+			meta := &S3MinioClient{S3Admin: adminClient}
+			diags := minioReadIdpOpenIdConfig(context.Background(), d, meta, tc.afterWrite)
+
+			if tc.wantErr && len(diags) == 0 {
+				t.Error("expected error diagnostics but got none")
+			}
+			if !tc.wantErr && len(diags) > 0 {
+				t.Errorf("expected no error but got: %v", diags)
+			}
+			if d.Id() != tc.wantID {
+				t.Errorf("expected resource ID %q, got %q", tc.wantID, d.Id())
+			}
+		})
+	}
+}

--- a/templates/resources/iam_idp_openid.md.tmpl
+++ b/templates/resources/iam_idp_openid.md.tmpl
@@ -13,6 +13,8 @@ MinIO supports multiple named OIDC configurations. The `name` attribute identifi
 
 **NOTE:** MinIO must be able to reach the `config_url` discovery document endpoint when applying the configuration. See the [MinIO OIDC documentation](https://min.io/docs/minio/linux/operations/external-iam/configure-openid-external-identity-management.html).
 
+**NOTE:** MinIO may require a server restart before a newly written OIDC configuration becomes active — check the `restart_required` attribute after apply. Until the server is restarted, MinIO does not report the configuration back, so a `terraform plan` run before the restart may propose recreating the resource. Restart the MinIO server (or wait for the next rolling restart) and the plan will converge.
+
 ## Example Usage
 
 {{ tffile "examples/resources/minio_iam_idp_openid/resource.tf" }}


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read the [Project Vision](../VISION.md) and understand the scope
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have signed my commits (`git commit -s`)

### Testing Requirements
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests
- [ ] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [x] I have updated the documentation templates in `templates/` if needed
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

### Breaking Changes
- [ ] If this is a breaking change, I have described the impact and migration path
- [ ] If this is a breaking change, I have updated the version appropriately

## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

Creating a `minio_iam_idp_openid` resource on a MinIO server where the OIDC
subsystem is not yet active (e.g. a fresh install) fails with:

    Error: Provider produced inconsistent result after apply
    Root object was present, but now absent.

MinIO accepts and persists the configuration via `AddOrUpdateIDPConfig` but
does not report it back through `GetIDPConfig` until the server is restarted.
The read that runs immediately after create/update treated that not-found
response as a deletion and cleared the resource ID, which triggers the
inconsistent-result error even though the configuration was successfully
written.

This PR makes the read that follows a create or update treat not-found as
"pending restart" and keep the configured values in state. A regular refresh
keeps the existing behavior and still removes genuinely deleted
configurations. The resource docs template now explains the restart behavior
and points users to the `restart_required` attribute.

### How was this change tested?

- `go build ./...` and `go vet ./minio/` pass.
- Existing OIDC acceptance tests (`TestAccMinioIAMIdpOpenId_*`) are unchanged;
  they are gated behind `MINIO_OIDC_ENABLED=1` with a live IdP and do not
  cover the pending-restart path, which requires a MinIO instance in the
  restart-required state.

### Related Issues

- Fixes #1014