### PR TITLE
test(iam-policy): retry CheckDestroy to tolerate MinIO IAM eventual consistency

### DIFF
--- a/minio/resource_minio_iam_policy_test.go
+++ b/minio/resource_minio_iam_policy_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -242,10 +244,19 @@ func testAccCheckMinioIAMPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID); info != nil {
-			return fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID)
+		// MinIO's IAM subsystem is eventually consistent under concurrent load,
+		// so a just-deleted canned policy can briefly still be returned by
+		// InfoCannedPolicyV2. Poll for a short while before declaring the policy
+		// leaked to avoid flaky CheckDestroy failures.
+		err := retry.RetryContext(context.Background(), 10*time.Second, func() *retry.RetryError {
+			if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID); info != nil {
+				return retry.RetryableError(fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID))
+			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

`TestAccMinioIAMPolicy_recreate` and `TestAccMinioIAMPolicy_jsonencode` intermittently fail on `main` at post-test destroy:

```
testing_new.go:85: Error running post-test destroy, there may be dangling resources: iAM Policy (tf-acc-test-...) still exists
```

This is a **flaky race, not a regression**:

- The failing push (#1015 openid fix, #1016 docs) touches no IAM policy code, and the preceding commit passed CI.
- The MinIO server image is pinned (`RELEASE.2025-09-07T16-13-09Z`), so no server-version change is involved.
- In the same run, the sibling tests (`_basic`, `_policy`, `_namePrefix`, `_disappears`) use identical destroy logic and pass; `_basic` passes the exact instant the two failed.

## Root cause

All acceptance tests run in parallel against a single 4-drive erasure-coded MinIO. Under concurrent IAM churn (user/group/membership/import tests running at the same moment), a just-deleted canned policy can briefly still be returned by `InfoCannedPolicyV2` (HTTP 200). `testAccCheckMinioIAMPolicyDestroy` read back **immediately with no retry**, so it occasionally observed the stale policy.

The two affected tests churn the same policy name the hardest (`_recreate`: create -> external-delete -> recreate; `_jsonencode`: multiple applies plus an import), which widens the window.

## Fix

Poll `InfoCannedPolicyV2` with `retry.RetryContext` for up to 10s before declaring the policy leaked, matching the retry pattern already used across the S3 bucket resources. The error message is unchanged.

## Verification

- `go build ./...`, `go vet ./minio/`, `gofmt` clean.
- All six `TestAccMinioIAMPolicy_*` tests pass against a fresh local stack.