### PR TITLE
ci: auto-label PRs from Conventional Commit title

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,74 @@
+# Labels pull requests from their Conventional Commit title prefix so that
+# GitHub's auto-generated release notes can bucket them into the categories
+# defined in .github/release.yml (which matches on labels, not titles).
+#
+# Uses pull_request_target so it can label PRs opened from forks (the default
+# pull_request token is read-only for forks). This is safe here because the
+# workflow never checks out or runs PR code; it only reads the PR title from
+# the event payload and calls the labels API.
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # required to add labels to the PR
+    steps:
+      - name: Label from Conventional Commit title
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+
+            // Conventional Commit type -> repo label. Each label lives in a
+            // category in .github/release.yml; keep the two in sync.
+            const typeToLabel = {
+              feat: "enhancement",
+              feature: "enhancement",
+              fix: "bug",
+              bugfix: "bug",
+              docs: "documentation",
+              chore: "maintenance",
+              refactor: "maintenance",
+              build: "maintenance",
+              ci: "maintenance",
+              perf: "performance",
+              test: "test",
+              deps: "dependencies",
+              security: "security",
+            };
+
+            // Matches "type:", "type(scope):" and "type!:" (breaking change).
+            const m = title.match(/^([a-zA-Z]+)(?:\([^)]*\))?!?:/);
+            if (!m) {
+              core.info(`No Conventional Commit prefix in title: "${title}"`);
+              return;
+            }
+
+            const type = m[1].toLowerCase();
+            const label = typeToLabel[type];
+            if (!label) {
+              core.info(`No label mapped for type "${type}"`);
+              return;
+            }
+
+            if (pr.labels.some((l) => l.name === label)) {
+              core.info(`Label "${label}" already present; nothing to do`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [label],
+            });
+            core.info(`Applied "${label}" for type "${type}"`);


### PR DESCRIPTION
## Why

GitHub's auto-generated release notes categorize PRs by **label** (as defined in `.github/release.yml`), not by the Conventional Commit prefix in the PR title. Nothing currently applies those labels to human-authored PRs, so `docs:`, `fix:`, and `chore:` PRs land in **Other Changes** while the 🐛 Bug Fixes / 📖 Documentation / 🔧 Maintenance categories stay empty.

In the v3.38.4 notes, only the Dependabot/toolchain PR (self-labeled `dependencies`) categorized correctly; every human PR fell through to Other Changes.

## What

A workflow that reads the PR title's Conventional Commit prefix and applies the matching label so each PR lands in the correct release-notes category.

| Title prefix | Label applied | Release category |
|----|----|----|
| `feat:` / `feature:` | `enhancement` | 🚀 Features |
| `fix:` / `bugfix:` | `bug` | 🐛 Bug Fixes |
| `docs:` | `documentation` | 📖 Documentation |
| `security:` | `security` | 🔒 Security |
| `perf:` | `performance` | ⚡ Performance |
| `chore:` / `refactor:` / `build:` / `ci:` | `maintenance` | 🔧 Maintenance |
| `deps:` | `dependencies` | 📦 Dependencies |
| `test:` | `test` | 🧪 Tests |

The prefix regex handles scopes and breaking-change markers: `feat(client):`, `fix!:`, `docs(readme):`.

## Notes

- Uses `pull_request_target` so it can label PRs from forks (the `pull_request` token is read-only for forks). Safe here because the workflow never checks out or executes PR code; it only reads the title from the event payload and calls the labels API.
- Add-only and idempotent: it never removes a human-applied label and skips if the target label is already present.
- The `performance` and `test` labels were created in the repo (the other six already existed).
- Does not retroactively affect already-published release notes.
