### PR TITLE
test: harden flaky audit webhook and iam policy acceptance checks

### DIFF
--- a/minio/resource_minio_audit_webhook_test.go
+++ b/minio/resource_minio_audit_webhook_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -176,11 +178,16 @@ func testAccCheckMinioAuditWebhookExists(resourceName string) resource.TestCheck
 
 		minioC := testAccProvider.Meta().(*S3MinioClient)
 		configKey := auditWebhookConfigKey(rs.Primary.ID)
-		_, err := minioC.S3Admin.GetConfigKV(context.Background(), configKey)
-		if err != nil {
-			return fmt.Errorf("audit webhook %s not found: %w", rs.Primary.ID, err)
-		}
-		return nil
+		// The admin config API can return transient errors (e.g. signature
+		// mismatches) while parallel tests churn server configuration, so
+		// poll briefly instead of failing on the first attempt.
+		err := retry.RetryContext(context.Background(), 10*time.Second, func() *retry.RetryError {
+			if _, err := minioC.S3Admin.GetConfigKV(context.Background(), configKey); err != nil {
+				return retry.RetryableError(fmt.Errorf("audit webhook %s not found: %w", rs.Primary.ID, err))
+			}
+			return nil
+		})
+		return err
 	}
 }
 

--- a/minio/resource_minio_iam_policy_test.go
+++ b/minio/resource_minio_iam_policy_test.go
@@ -248,7 +248,7 @@ func testAccCheckMinioIAMPolicyDestroy(s *terraform.State) error {
 		// so a just-deleted canned policy can briefly still be returned by
 		// InfoCannedPolicyV2. Poll for a short while before declaring the policy
 		// leaked to avoid flaky CheckDestroy failures.
-		err := retry.RetryContext(context.Background(), 10*time.Second, func() *retry.RetryError {
+		err := retry.RetryContext(context.Background(), 30*time.Second, func() *retry.RetryError {
 			if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID); info != nil {
 				return retry.RetryableError(fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID))
 			}


### PR DESCRIPTION
Hardens two acceptance-test checks that flaked in CI run 29415386841 (both were infrastructure flakes, unrelated to the change under test):

- TestAccMinioAuditWebhook_basic failed with a transient SignatureDoesNotMatch from the admin config API while parallel tests churned server configuration. The existence check now retries GetConfigKV for up to 10s (same pattern as #1017) instead of failing on the first attempt.
- TestAccMinioIAMPolicy_recreate failed post-test destroy despite the 10s retry from #1017 — under CI load MinIO's IAM eventual consistency can exceed that window. Widened to 30s. The retry exits on first success, so the extra budget costs nothing when the server is consistent.

Test-only change; no provider code is affected. gofmt, go vet, and unit tests pass.

Follow-up to #1017