### PR TITLE
fix(iam-policy-document): replace panic with error return

### DIFF
--- a/minio/data_source_minio_iam_policy_document.go
+++ b/minio/data_source_minio_iam_policy_document.go
@@ -273,7 +273,7 @@ func dataSourceMinioIAMPolicyDocumentReplaceVarsInList(in interface{}, version s
 		}
 		return out, nil
 	default:
-		panic("dataSourceAwsIamPolicyDocumentReplaceVarsInList: input not string nor []string")
+		return nil, fmt.Errorf("unexpected type %T in policy document variable replacement, expected string or []string", in)
 	}
 }
 

--- a/minio/data_source_minio_iam_policy_document_test.go
+++ b/minio/data_source_minio_iam_policy_document_test.go
@@ -2,10 +2,24 @@ package minio
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+func TestDataSourceMinioIAMPolicyDocumentReplaceVarsInList_unexpectedType(t *testing.T) {
+	out, err := dataSourceMinioIAMPolicyDocumentReplaceVarsInList(42, "2012-10-17")
+	if err == nil {
+		t.Fatalf("expected an error for unexpected input type, got result: %#v", out)
+	}
+	if out != nil {
+		t.Errorf("expected nil result on error, got: %#v", out)
+	}
+	if !strings.Contains(err.Error(), "int") {
+		t.Errorf("expected error message to name the offending type, got: %q", err.Error())
+	}
+}
 
 func TestAccMinioDataSourceIAMPolicyDocument_basic(t *testing.T) {
 	// This really ought to be able to be a unit test rather than an


### PR DESCRIPTION
## Root cause

`dataSourceMinioIAMPolicyDocumentReplaceVarsInList` had a `panic()` on its "can't happen" branch (input that is neither `string` nor `[]string`). A panic in a provider takes down the whole plugin process mid-plan, so even for an unreachable input, an error diagnostic is the friendlier failure.

## What changed

| File | Change |
| --- | --- |
| `minio/data_source_minio_iam_policy_document.go` | The `panic()` is now an error return reporting the offending type (`%T`). All three call sites already check the returned error, so no signature changes were needed. The old message also carried a stale function name copied from the AWS provider (`dataSourceAwsIamPolicyDocument...`); the new one drops it. |
| `minio/data_source_minio_iam_policy_document_test.go` | Unit test covering the unexpected-type branch (it panics on the old code and gets a proper error on the new one). |

Note: the first version of this PR also carried a partial refactor of `resource_minio_s3_bucket_replication.go`. Dropped it to keep this PR small and independent, as proposed in the issue; the hotspot refactors will come as separate PRs (one file each).

## Verification

- The new unit test fails on the old code (panics) and passes with the fix.
- All 14 `minio_iam_policy_document` acceptance tests pass against a real MinIO instance (`TF_ACC=1 go test ./minio -run 'IAMPolicyDocument' -count=1`).
- `go test ./...`, `golangci-lint run`, `go vet` and `gofmt` are clean.

Part of #1026
