### PR TITLE
test: add acceptance tests for license_info, bucket notification config and replication status data sources

### DIFF
--- a/minio/data_source_minio_license_info.go
+++ b/minio/data_source_minio_license_info.go
@@ -3,13 +3,15 @@ package minio
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioLicenseInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Retrieves MinIO license information.",
-		Read:        dataSourceMinioLicenseInfoRead,
+		ReadContext: dataSourceMinioLicenseInfoRead,
 		Schema: map[string]*schema.Schema{
 			"license_id":   {Type: schema.TypeString, Computed: true},
 			"organization": {Type: schema.TypeString, Computed: true},
@@ -21,23 +23,41 @@ func dataSourceMinioLicenseInfo() *schema.Resource {
 	}
 }
 
-func dataSourceMinioLicenseInfoRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioLicenseInfoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	info, err := admin.GetLicenseInfo(context.Background())
+	tflog.Debug(ctx, "Reading license info")
+
+	info, err := admin.GetLicenseInfo(ctx)
 	if err != nil {
+		// Servers without a license subsystem (community MinIO) report the
+		// unlicensed state instead of failing the read.
 		d.SetId("unlicensed")
-		_ = d.Set("plan", "")
+		if err := d.Set("plan", ""); err != nil {
+			return NewResourceError("setting plan", d.Id(), err)
+		}
 		return nil
 	}
 
 	d.SetId(info.ID)
-	_ = d.Set("license_id", info.ID)
-	_ = d.Set("organization", info.Organization)
-	_ = d.Set("plan", info.Plan)
-	_ = d.Set("issued_at", info.IssuedAt.String())
-	_ = d.Set("expires_at", info.ExpiresAt.String())
-	_ = d.Set("trial", info.Trial)
+	if err := d.Set("license_id", info.ID); err != nil {
+		return NewResourceError("setting license_id", d.Id(), err)
+	}
+	if err := d.Set("organization", info.Organization); err != nil {
+		return NewResourceError("setting organization", d.Id(), err)
+	}
+	if err := d.Set("plan", info.Plan); err != nil {
+		return NewResourceError("setting plan", d.Id(), err)
+	}
+	if err := d.Set("issued_at", info.IssuedAt.String()); err != nil {
+		return NewResourceError("setting issued_at", d.Id(), err)
+	}
+	if err := d.Set("expires_at", info.ExpiresAt.String()); err != nil {
+		return NewResourceError("setting expires_at", d.Id(), err)
+	}
+	if err := d.Set("trial", info.Trial); err != nil {
+		return NewResourceError("setting trial", d.Id(), err)
+	}
 
 	return nil
 }

--- a/minio/data_source_minio_license_info_test.go
+++ b/minio/data_source_minio_license_info_test.go
@@ -1,0 +1,28 @@
+package minio
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceMinioLicenseInfo_basic(t *testing.T) {
+	dataSourceName := "data.minio_license_info.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "minio_license_info" "test" {}`,
+				Check: resource.ComposeTestCheckFunc(
+					// The test fixture runs community MinIO, which has no
+					// license subsystem, so the read reports the unlicensed
+					// fallback instead of failing.
+					resource.TestCheckResourceAttr(dataSourceName, "id", "unlicensed"),
+					resource.TestCheckResourceAttr(dataSourceName, "plan", ""),
+				),
+			},
+		},
+	})
+}

--- a/minio/data_source_minio_s3_bucket_notification_config_test.go
+++ b/minio/data_source_minio_s3_bucket_notification_config_test.go
@@ -1,0 +1,62 @@
+package minio
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceMinioS3BucketNotificationConfig_basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-ds-notif")
+	dataSourceName := "data.minio_s3_bucket_notification_config.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBucketNotificationConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "bucket", name),
+					resource.TestCheckResourceAttr(dataSourceName, "queue.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "queue.0.arn", "arn:minio:sqs::primary:webhook"),
+					resource.TestCheckResourceAttr(dataSourceName, "queue.0.events.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "queue.0.prefix", "tf-acc-test/"),
+					resource.TestCheckResourceAttr(dataSourceName, "queue.0.suffix", ".png"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceBucketNotificationConfig(name string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+}
+
+resource "minio_s3_bucket_notification" "notification" {
+  bucket = minio_s3_bucket.bucket.id
+
+  queue {
+    id        = "notification-queue"
+    queue_arn = "arn:minio:sqs::primary:webhook"
+
+    events = [
+      "s3:ObjectCreated:*",
+      "s3:ObjectRemoved:Delete",
+    ]
+
+    filter_prefix = "tf-acc-test/"
+    filter_suffix = ".png"
+  }
+}
+
+data "minio_s3_bucket_notification_config" "test" {
+  bucket = minio_s3_bucket_notification.notification.bucket
+}
+`, name)
+}

--- a/minio/data_source_minio_s3_bucket_replication_status_test.go
+++ b/minio/data_source_minio_s3_bucket_replication_status_test.go
@@ -1,0 +1,81 @@
+package minio
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceMinioS3BucketReplicationStatus_basic(t *testing.T) {
+	bucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus")
+	dataSourceName := "data.minio_s3_bucket_replication_status.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBucketReplicationStatusConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "bucket", bucketName),
+					// A bucket without replication configuration reports zero rules.
+					resource.TestCheckResourceAttr(dataSourceName, "rule_count", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceMinioS3BucketReplicationStatus_withReplication(t *testing.T) {
+	bucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-a")
+	secondBucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-b")
+	username := acctest.RandomWithPrefix("tf-acc-usr")
+	dataSourceName := "data.minio_s3_bucket_replication_status.test"
+
+	primaryMinioEndpoint := os.Getenv("MINIO_ENDPOINT")
+	secondaryMinioEndpoint := os.Getenv("SECOND_MINIO_ENDPOINT")
+
+	// Not parallel: remote target endpoints conflict across replication tests.
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketReplicationConfigLocals(primaryMinioEndpoint, secondaryMinioEndpoint) +
+					testAccBucketReplicationConfigBucket("my_bucket_in_a", "minio", bucketName) +
+					testAccBucketReplicationConfigBucket("my_bucket_in_b", "secondminio", secondBucketName) +
+					testAccBucketReplicationConfigPolicy(bucketName, secondBucketName) +
+					testAccBucketReplicationConfigServiceAccount(username, 2) +
+					kOneWaySimpleResource + `
+data "minio_s3_bucket_replication_status" "test" {
+  bucket = minio_s3_bucket_replication.replication_in_b.bucket
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(dataSourceName, "rule_count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "rules.0.status", "Enabled"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.target"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceBucketReplicationStatusConfig(bucketName string) string {
+	return `
+resource "minio_s3_bucket" "test" {
+  bucket = "` + bucketName + `"
+}
+
+data "minio_s3_bucket_replication_status" "test" {
+  bucket = minio_s3_bucket.test.bucket
+}
+`
+}


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read the [Project Vision](../VISION.md) and understand the scope
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have signed my commits (`git commit -s`)

### Testing Requirements
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes with a real MinIO setup

## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes, code improvement)

### What does this PR do?

Adds acceptance coverage for the three registered data sources that had no test referencing them anywhere in the suite, as described in #1020:

- **`minio_license_info`** — `_basic` asserts the unlicensed fallback path (`id = "unlicensed"`, empty `plan`) that community MinIO exercises.
- **`minio_s3_bucket_notification_config`** — `_basic` creates a bucket + `minio_s3_bucket_notification` against the compose fixture's webhook target (`arn:minio:sqs::primary:webhook`) and reads it back, asserting ARN, event count, prefix and suffix.
- **`minio_s3_bucket_replication_status`** — `_basic` asserts `rule_count = 0` for a bucket without replication; `_withReplication` reuses the existing replication config helpers (`testAccBucketReplicationConfigLocals`/`...Bucket`/`...Policy`/`...ServiceAccount` + `kOneWaySimpleResource`) to build a real one-way replication to `secondminio` and asserts `rule_count = 1`, the rule's `Enabled` status, and that `id`/`target` are populated. It runs with `resource.Test` (not parallel) for the same remote-target-conflict reason as the other replication tests.

It also modernizes `data_source_minio_license_info.go` while touching it, as the issue suggests: legacy `Read:` → `ReadContext:` (plumbing `ctx` into `GetLicenseInfo`), every `d.Set` error now handled via `NewResourceError`, and a `tflog.Debug` at the start of the read. The unlicensed fallback behavior is unchanged.

### How was this change tested?

`TEST_PATTERN='TestAccDataSourceMinioLicenseInfo|TestAccDataSourceMinioS3BucketNotificationConfig|TestAccDataSourceMinioS3BucketReplicationStatus' docker compose run --rm test`:

```
--- PASS: TestAccDataSourceMinioS3BucketReplicationStatus_withReplication (4.64s)
--- PASS: TestAccDataSourceMinioLicenseInfo_basic (2.35s)
--- PASS: TestAccDataSourceMinioS3BucketReplicationStatus_basic (2.65s)
--- PASS: TestAccDataSourceMinioS3BucketNotificationConfig_basic (2.73s)
```

`go build ./...`, `go vet ./minio/`, `gofmt`, `golangci-lint run --config .github/golangci.yml` and the unit test suite all pass.

### Related Issues

- Fixes #1020
