### PR TITLE
test: unify replication config helper style

### DIFF
--- a/minio/data_source_minio_s3_bucket_replication_status_test.go
+++ b/minio/data_source_minio_s3_bucket_replication_status_test.go
@@ -1,6 +1,7 @@
 package minio
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -69,13 +70,13 @@ data "minio_s3_bucket_replication_status" "test" {
 }
 
 func testAccDataSourceBucketReplicationStatusConfig(bucketName string) string {
-	return `
+	return fmt.Sprintf(`
 resource "minio_s3_bucket" "test" {
-  bucket = "` + bucketName + `"
+  bucket = %[1]q
 }
 
 data "minio_s3_bucket_replication_status" "test" {
   bucket = minio_s3_bucket.test.bucket
 }
-`
+`, bucketName)
 }


### PR DESCRIPTION
## Summary
- Update `testAccDataSourceBucketReplicationStatusConfig` to build its HCL with `fmt.Sprintf` and `%q`.
- Match the style already used by the bucket notification config helper.

Fixes #1036.

## Validation
- `docker run --rm -v "$PWD":/app -w /app golang:1.26.4 gofmt -w minio/data_source_minio_s3_bucket_replication_status_test.go`
- `docker run --rm -v "$PWD":/app -w /app golang:1.26.4 go test ./minio -run 'TestAccDataSourceMinioS3BucketReplicationStatus_basic|TestAccDataSourceMinioS3BucketReplicationStatus_withReplication'`
- `docker run --rm -v "$PWD":/app -w /app golang:1.26.4 go test ./minio`
- `git diff --check`
