### PR TITLE
test: skip site replication bucket cleanup when TF_ACC is unset

### DIFF
--- a/minio/resource_minio_site_replication_test.go
+++ b/minio/resource_minio_site_replication_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -94,6 +95,13 @@ func testAccPreCheckSiteReplication(t *testing.T) {
 func cleanupAllBuckets(t *testing.T) {
 	t.Helper()
 
+	// resource.Test only skips on a missing TF_ACC after this cleanup has already
+	// run, so guard here too: without it, unit-only runs (TF_ACC unset) dial the
+	// configured endpoints and, with valid credentials, would wipe their buckets.
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("skipping site replication bucket cleanup: TF_ACC not set")
+	}
+
 	cleanupBucketsForEndpoint(t, testAccEndpoint(""), os.Getenv("MINIO_USER"), os.Getenv("MINIO_PASSWORD"))
 
 	cleanupBucketsForEndpoint(t, testAccEndpoint("SECOND_"), os.Getenv("SECOND_MINIO_USER"), os.Getenv("SECOND_MINIO_PASSWORD"))
@@ -111,7 +119,11 @@ func cleanupBucketsForEndpoint(t *testing.T, endpoint, accessKey, secretKey stri
 		return
 	}
 
-	ctx := context.Background()
+	// Bound each endpoint's cleanup so a slow or unreachable instance cannot
+	// stall the suite past the default 10m test binary timeout: minio-go retries
+	// with backoff, and this runs for 3 endpoints x 5 tests.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	buckets, err := minioClient.ListBuckets(ctx)
 	if err != nil {
 		t.Logf("Warning: Failed to list buckets for %s: %v", endpoint, err)


### PR DESCRIPTION
### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?
`cleanupAllBuckets` runs as the first statement of every `TestAccMinioSiteReplication_*` test, before `resource.Test` can skip on a missing `TF_ACC`. With `MINIO_*` endpoints and credentials exported but `TF_ACC` unset (the local-run setup the docs recommend), the cleanup dials all three instances — a slow endpoint can push the run past the 10m test binary timeout — and, if they are reachable with valid credentials, deletes every bucket before the skip.

Two small changes:
- Skip the cleanup when `TF_ACC` is unset, the same condition `resource.Test` uses.
- Bound each endpoint's cleanup with a 30s context timeout, so a single unreachable instance can't stall acceptance runs either (worst case 3 endpoints × 5 tests × 30s = 7.5m, under the 10m default).

### How was this change tested?
- `go test ./minio` with no env vars: passes in ~22s, site replication tests skip in 0.00s.
- The repro from #1033 (endpoints + credentials pointing at a closed port, `TF_ACC` unset): previously ~13s per test dialing the network, now skips instantly.
- `go vet ./minio` clean. Commits signed off.
- Not run against a real MinIO acceptance setup locally (no Docker on this machine); CI covers that path.

### Related Issues
Fixes #1033
