### PR TITLE
test: skip replication tests without second endpoint

### DIFF
--- a/minio/data_source_minio_s3_bucket_replication_status_test.go
+++ b/minio/data_source_minio_s3_bucket_replication_status_test.go
@@ -31,6 +31,10 @@ func TestAccDataSourceMinioS3BucketReplicationStatus_basic(t *testing.T) {
 }
 
 func TestAccDataSourceMinioS3BucketReplicationStatus_withReplication(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -1009,10 +1009,6 @@ func TestAccS3BucketReplication_twoway_simple(t *testing.T) {
 	})
 }
 func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	t.Run("TestBandwidthAttributeMigration", func(t *testing.T) {
 		// Test with old attribute (bandwidth_limt)
 		{

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -402,6 +402,10 @@ resource "minio_s3_bucket_replication" "replication_in_a" {
 }`
 
 func TestAccS3BucketReplication_oneway_simple(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -472,6 +476,10 @@ func TestAccS3BucketReplication_oneway_simple(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_resync(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -512,6 +520,10 @@ func TestAccS3BucketReplication_resync(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_oneway_simple_update(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -753,6 +765,10 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
 	})
 }
 func TestAccS3BucketReplication_oneway_complex(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	thirdBucketName := acctest.RandomWithPrefix("tf-acc-test-c")
@@ -882,6 +898,10 @@ func TestAccS3BucketReplication_oneway_complex(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_twoway_simple(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -989,6 +1009,10 @@ func TestAccS3BucketReplication_twoway_simple(t *testing.T) {
 	})
 }
 func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	t.Run("TestBandwidthAttributeMigration", func(t *testing.T) {
 		// Test with old attribute (bandwidth_limt)
 		{
@@ -1066,6 +1090,10 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
+	}
+
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	thirdBucketName := acctest.RandomWithPrefix("tf-acc-test-c")


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the Contributing Guidelines
- [x] I have read the Project Vision and understand the scope
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have signed my commits (`git commit -s`)

### Testing Requirements
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests
- [ ] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [x] Documentation changes are not required for this test-only fix
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Security fix

### What does this PR do?

Fixes #1037.

The bucket replication acceptance tests require a second MinIO instance, but previously proceeded into provider and resource setup even when `SECOND_MINIO_ENDPOINT` was absent. This adds an established top-of-test environment guard to all seven `TestAccS3BucketReplication*` cases and the replication-status data source case.

Without the secondary endpoint, each affected test now skips with a clear message. Configured multi-instance environments retain the existing acceptance path unchanged.

### How was this change tested?

- With `SECOND_MINIO_ENDPOINT` unset and `TF_ACC=1`, the exact focused set completed successfully with all 8 affected tests skipped before setup.
- With the variable configured, the guard was bypassed and the existing Terraform SDK acceptance behavior remained active; the attribute-migration subtest passed.
- `go test ./minio/...` passed.
- `golangci-lint run` reported 0 issues.
- `gofmt` and `git diff --check` passed.

A full configured multi-MinIO replication acceptance run was not performed locally.

### Related Issues

Fixes #1037

## Additional Context

The guard is intentionally inline because that matches the repository's existing acceptance-test pattern and keeps the failure prerequisite visible at each affected entry point.

## Reviewer Focus Areas

- [ ] Error handling and edge cases
- [ ] Performance implications
- [ ] Security considerations
- [ ] Documentation accuracy
- [x] Test coverage completeness

## Release Notes

```markdown
### Fixed
- Replication acceptance tests now skip cleanly when the secondary MinIO endpoint is not configured.
```
