### PR TITLE
test: skip replication acceptance tests when SECOND_MINIO_ENDPOINT is unset

### DIFF
--- a/minio/data_source_minio_s3_bucket_replication_status_test.go
+++ b/minio/data_source_minio_s3_bucket_replication_status_test.go
@@ -45,7 +45,7 @@ func TestAccDataSourceMinioS3BucketReplicationStatus_withReplication(t *testing.
 
 	// Not parallel: remote target endpoints conflict across replication tests.
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{

--- a/minio/data_source_minio_s3_bucket_replication_status_test.go
+++ b/minio/data_source_minio_s3_bucket_replication_status_test.go
@@ -31,10 +31,6 @@ func TestAccDataSourceMinioS3BucketReplicationStatus_basic(t *testing.T) {
 }
 
 func TestAccDataSourceMinioS3BucketReplicationStatus_withReplication(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-ds-replstatus-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -21,11 +21,12 @@ import (
 // available when SECOND_MINIO_ENDPOINT is set (as it is under docker compose).
 func testAccReplicationPreCheck(t *testing.T) {
 	t.Helper()
-	testAccPreCheck(t)
 
 	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
 		t.Skip("Skipping replication acceptance tests: SECOND_MINIO_ENDPOINT is not set")
 	}
+
+	testAccPreCheck(t)
 }
 
 const kOneWayComplexResource = `

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/minio/minio-go/v7/pkg/replication"
 )
 
+// testAccReplicationPreCheck skips the test when a second MinIO instance is not
+// configured. Replication acceptance tests need a remote target, which is only
+// available when SECOND_MINIO_ENDPOINT is set (as it is under docker compose).
+func testAccReplicationPreCheck(t *testing.T) {
+	t.Helper()
+	testAccPreCheck(t)
+
+	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
+		t.Skip("Skipping replication acceptance tests: SECOND_MINIO_ENDPOINT is not set")
+	}
+}
+
 const kOneWayComplexResource = `
 resource "minio_s3_bucket_replication" "replication_in_all" {
   bucket     = minio_s3_bucket.my_bucket_in_a.bucket
@@ -415,7 +427,7 @@ func TestAccS3BucketReplication_oneway_simple(t *testing.T) {
 
 	// Test in parallel cannot work as remote target endpoint would conflict
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -488,7 +500,7 @@ func TestAccS3BucketReplication_resync(t *testing.T) {
 	secondaryMinioEndpoint := os.Getenv("SECOND_MINIO_ENDPOINT")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -533,7 +545,7 @@ func TestAccS3BucketReplication_oneway_simple_update(t *testing.T) {
 
 	// Test in parallel cannot work as remote target endpoint would conflict
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -782,7 +794,7 @@ func TestAccS3BucketReplication_oneway_complex(t *testing.T) {
 
 	// Test in parallel cannot work as remote target endpoint would conflict
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -911,7 +923,7 @@ func TestAccS3BucketReplication_twoway_simple(t *testing.T) {
 
 	// Test in parallel cannot work as remote target endpoint would conflict
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -1103,7 +1115,7 @@ func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
 
 	// Test in parallel cannot work as remote target endpoint would conflict
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccReplicationPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
 		Steps: []resource.TestStep{

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -415,10 +415,6 @@ resource "minio_s3_bucket_replication" "replication_in_a" {
 }`
 
 func TestAccS3BucketReplication_oneway_simple(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -489,10 +485,6 @@ func TestAccS3BucketReplication_oneway_simple(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_resync(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -533,10 +525,6 @@ func TestAccS3BucketReplication_resync(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_oneway_simple_update(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -778,10 +766,6 @@ resource "minio_s3_bucket_replication" "replication_in_b" {
 	})
 }
 func TestAccS3BucketReplication_oneway_complex(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	thirdBucketName := acctest.RandomWithPrefix("tf-acc-test-c")
@@ -911,10 +895,6 @@ func TestAccS3BucketReplication_oneway_complex(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_twoway_simple(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	username := acctest.RandomWithPrefix("tf-acc-usr")
@@ -1099,10 +1079,6 @@ func TestAccS3BucketReplication_attribute_migration(t *testing.T) {
 }
 
 func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
-	if os.Getenv("SECOND_MINIO_ENDPOINT") == "" {
-		t.Skip("Skipping replication acceptance test: SECOND_MINIO_ENDPOINT is not set")
-	}
-
 	bucketName := acctest.RandomWithPrefix("tf-acc-test-a")
 	secondBucketName := acctest.RandomWithPrefix("tf-acc-test-b")
 	thirdBucketName := acctest.RandomWithPrefix("tf-acc-test-c")


### PR DESCRIPTION
Closes #1037.

The `TestAccS3BucketReplication*` tests and `TestAccDataSourceMinioS3BucketReplicationStatus_withReplication` read `SECOND_MINIO_ENDPOINT` but never skip when it is empty, so running them against a single local MinIO builds a config with empty host locals and fails instead of skipping. This adds a `testAccReplicationPreCheck` helper that skips when the endpoint is unset, mirroring the existing env-gated pre-checks for KMS, LDAP and OIDC, and wires it into the replication tests.
