### PR TITLE
fix(data-source): use deterministic bucket id for notification config

### DIFF
--- a/minio/data_source_minio_s3_bucket_notification_config.go
+++ b/minio/data_source_minio_s3_bucket_notification_config.go
@@ -2,27 +2,28 @@ package minio
 
 import (
 	"context"
-	"strconv"
-	"time"
+	"errors"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/minio-go/v7"
 )
 
 func dataSourceMinioS3BucketNotificationConfig() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the event notification configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketNotificationConfigRead,
+		ReadContext: dataSourceMinioS3BucketNotificationConfigRead,
 		Schema: map[string]*schema.Schema{
-			"bucket": {Type: schema.TypeString, Required: true},
+			"bucket": {Type: schema.TypeString, Required: true, Description: "Bucket name"},
 			"queue": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"arn":    {Type: schema.TypeString, Computed: true},
-						"events": {Type: schema.TypeList, Computed: true, Elem: &schema.Schema{Type: schema.TypeString}},
-						"prefix": {Type: schema.TypeString, Computed: true},
-						"suffix": {Type: schema.TypeString, Computed: true},
+						"arn":    {Type: schema.TypeString, Computed: true, Description: "ARN of the queue"},
+						"events": {Type: schema.TypeList, Computed: true, Elem: &schema.Schema{Type: schema.TypeString}, Description: "Events to notify on"},
+						"prefix": {Type: schema.TypeString, Computed: true, Description: "Object key prefix filter"},
+						"suffix": {Type: schema.TypeString, Computed: true, Description: "Object key suffix filter"},
 					},
 				},
 			},
@@ -30,17 +31,21 @@ func dataSourceMinioS3BucketNotificationConfig() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketNotificationConfigRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketNotificationConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
-	cfg, err := client.GetBucketNotification(context.Background(), bucket)
+	cfg, err := client.GetBucketNotification(ctx, bucket)
 	if err != nil {
-		d.SetId(bucket)
-		return nil
+		var respErr minio.ErrorResponse
+		if errors.As(err, &respErr) && respErr.Code == "NoSuchBucket" {
+			d.SetId("")
+			return nil
+		}
+		return NewResourceError("reading bucket notification configuration", bucket, err)
 	}
 
-	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	d.SetId(bucket)
 
 	var queues []map[string]interface{}
 	for _, q := range cfg.QueueConfigs {
@@ -66,7 +71,11 @@ func dataSourceMinioS3BucketNotificationConfigRead(d *schema.ResourceData, meta 
 		})
 	}
 
-	_ = d.Set("bucket", bucket)
-	_ = d.Set("queue", queues)
+	if err := d.Set("bucket", bucket); err != nil {
+		return NewResourceError("setting bucket", d.Id(), err)
+	}
+	if err := d.Set("queue", queues); err != nil {
+		return NewResourceError("setting queue", d.Id(), err)
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1038

- Replaces time.Now().Unix() with bucket name as the deterministic id
- Migrates to ReadContext with diag.Diagnostics return type
- Uses NewResourceError for error handling
- Checks d.Set errors
- Handles NoSuchBucket gracefully