### PR TITLE
test: remove redundant TF_ACC guard in testAccPreCheck

### DIFF
--- a/minio/provider_test.go
+++ b/minio/provider_test.go
@@ -76,10 +76,6 @@ var kEnvVarNeeded = []string{
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v, _ := os.LookupEnv("TF_ACC"); v == "" {
-		t.Fatal("TF_ACC must be set for acceptance tests")
-	}
-
 	var missing []string
 	for _, envvar := range kEnvVarNeeded {
 		if _, ok := os.LookupEnv(envvar); !ok {


### PR DESCRIPTION
Fixes #1035

The TF_ACC check in testAccPreCheck was dead code - resource.Test
already skips before PreCheck runs when TF_ACC is empty.