### PR TITLE
docs: clarify which env vars are required vs optional for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,7 +587,7 @@ ResourcesMap: map[string]*schema.Resource{
 
 **Environment variables:**
 
-`testAccPreCheck` requires the variables for all four instances to be set, even if a test only talks to the primary one. The `test` service in `docker-compose.yml` is the source of truth for the full set. For local runs against the published ports:
+`testAccPreCheck` requires the 16 variables below for the four core instances (primary, SECOND_, THIRD_, FOURTH_). The `test` service in `docker-compose.yml` also defines `KMS_MINIO_*` and `LDAP_MINIO_*` variables — these are optional and only needed when running the KMS key or LDAP identity provider test suites. For local runs against the published ports:
 
 ```bash
 export TF_ACC=1


### PR DESCRIPTION
Fixes #1034

Rewords the AGENTS.md env vars section to clarify that:
- Only the 16 vars for the 4 core instances are required by testAccPreCheck
- KMS_MINIO_* and LDAP_MINIO_* vars are optional and only needed for their specific suites