### PR TITLE
ci: add docker-compose ecosystem to dependabot and sync golang image with toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,8 @@ updates:
       prefix: "deps:"
     open-pull-requests-limit: 10
 
-  # Enable version updates for Docker
-  - package-ecosystem: "docker"
+  # Enable version updates for Docker Compose images
+  - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/update-go-toolchain.yml
+++ b/.github/workflows/update-go-toolchain.yml
@@ -49,6 +49,14 @@ jobs:
             echo "toolchain=${TOOLCHAIN}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Update docker-compose.yml Go image
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          TOOLCHAIN="${{ steps.diff.outputs.toolchain }}"
+          # Strip the 'go' prefix for the image tag: go1.27.3 -> 1.27.3
+          TAG="${TOOLCHAIN#go}"
+          sed -i "s/^    image: golang:.*/    image: golang:${TAG}/" docker-compose.yml
+
       - name: Open pull request
         if: steps.diff.outputs.changed == 'true'
         env:
@@ -61,7 +69,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "${BRANCH}"
-          git add go.mod go.sum
+          git add go.mod go.sum docker-compose.yml
           git commit -m "chore: update Go toolchain to ${TOOLCHAIN}"
           git push origin "${BRANCH}"
 


### PR DESCRIPTION
Fixes #1022

- Replaces the docker ecosystem (Dockerfiles only) with docker-compose ecosystem in dependabot.yml
- Extends update-go-toolchain.yml to also update the golang image tag in docker-compose.yml when the toolchain is bumped