### PR TITLE
ci: run the notify_redis acceptance test in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,16 @@ services:
       - ./testdata/dex/config.yaml:/etc/dex/config.docker.yaml
     ports:
       - "5556:5556"
+  redis: # This is used to test the notify_redis target
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
   secondminio: #  This is used to test bucket replication
     image: *minio_image
     ports:
@@ -205,6 +215,7 @@ services:
       MINIO_OIDC_CONFIG_URL: "http://dex:5556/.well-known/openid-configuration"
       MINIO_OIDC_CLIENT_ID: "minio-client"
       MINIO_OIDC_CLIENT_SECRET: "minio-client-secret"
+      TF_ACC_REDIS_ADDRESS: "redis:6379"
     depends_on:
       minio:
         condition: service_healthy
@@ -224,6 +235,8 @@ services:
         # startup and the OIDC tests only reach it minutes later, so waiting for
         # the container to start is enough.
         condition: service_started
+      redis:
+        condition: service_healthy
     profiles:
       - test
 


### PR DESCRIPTION
Adds a `redis:7-alpine` container to the compose stack and points `TF_ACC_REDIS_ADDRESS` at it, so `TestAccMinioNotifyRedis_basic` runs on every CI run instead of skipping.

Currently, all broker-based notify target tests skip because the compose fixture never sets their gate variables. Redis is the cheapest of those gates from #1024, and the notify tests only stage the target with `enable = false` (no broker connection happens on apply), so this one needs no restart handling (unlike the OIDC gate in #1055). The `test` service now waits for `redis` to be healthy before running.

This is the notify-broker increment from #1024. The OIDC gate landed in #1055, which already met the issue's "done when" bar. The remaining etcd and config-history gates were investigated and dropped from scope:

- etcd: the `etcd` config is restart-pending, so the test's import step reads back empty `endpoints`, and restarting the shared server into etcd-backend mode is unsafe. It would need a dedicated instance.
- config-history: on community MinIO the `data.minio_config_history` data source comes back empty, so the test errors on apply, and it restores an arbitrary history entry on the shared server. It would need a test redesign.

So this is the last gate PR for #1024.

### How was this change tested?

Ran it against a real MinIO + Redis via Docker Compose:

1. `docker compose up -d --force-recreate minio redis`
2. `TEST_PATTERN='TestAccMinioNotifyRedis|TestAccMinioLoggerWebhook' docker compose run --rm test`

Both pass:

~~~
--- PASS: TestAccMinioNotifyRedis_basic (5.77s)
--- PASS: TestAccMinioLoggerWebhook_basic (9.57s)
~~~

### Related Issues

- Part of #1024
