### PR TITLE
fix(s3-bucket-notification): support multiple notifications per bucket

### DIFF
--- a/docs/resources/s3_bucket_notification.md
+++ b/docs/resources/s3_bucket_notification.md
@@ -53,7 +53,7 @@ Optional:
 
 - `filter_prefix` (String) Object key name prefix to filter notifications.
 - `filter_suffix` (String) Object key name suffix to filter notifications.
-- `id` (String) Unique identifier for the queue notification.
+- `id` (String) Unique identifier for the queue notification. Must be unique across all resources targeting the same bucket.
 
 ## Import
 
@@ -63,3 +63,5 @@ Import is supported using the following syntax:
 # S3 bucket notifications can be imported using the bucket name
 terraform import minio_s3_bucket_notification.example bucket-name
 ```
+
+Note: Importing replaces the entire notification configuration for the bucket. If multiple notification resources target the same bucket, only the imported resource's queue targets will be present after import.

--- a/minio/resource_minio_s3_bucket_notification.go
+++ b/minio/resource_minio_s3_bucket_notification.go
@@ -3,15 +3,21 @@ package minio
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/minio/minio-go/v7/pkg/notification"
 )
+
+// bucketNotificationLock serializes read-modify-write operations for bucket notifications
+// to prevent concurrent resources from clobbering each other's queues.
+var bucketNotificationLock = NewMutexKV()
 
 func resourceMinioBucketNotification() *schema.Resource {
 	return &schema.Resource{
@@ -21,7 +27,7 @@ func resourceMinioBucketNotification() *schema.Resource {
 		UpdateContext: minioPutBucketNotification,
 		DeleteContext: minioDeleteBucketNotification,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: importBucketNotification,
 		},
 		Schema: map[string]*schema.Schema{
 			"bucket": {
@@ -37,10 +43,11 @@ func resourceMinioBucketNotification() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "Unique identifier for the queue notification.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`[,|]`), "queue id must not contain ',' or '|'"),
+							Description:  "Unique identifier for the queue notification. Must be unique across all resources targeting the same bucket.",
 						},
 						"filter_prefix": {
 							Type:        schema.TypeString,
@@ -75,19 +82,73 @@ func resourceMinioBucketNotification() *schema.Resource {
 func minioPutBucketNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	bucketNotificationConfig := BucketNotificationConfig(d, meta)
 
-	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put notification configuration: %v", bucketNotificationConfig.MinioBucket, bucketNotificationConfig.Configuration))
+	bucketName := d.Get("bucket").(string)
+	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put notification configuration: %v", bucketName, bucketNotificationConfig.Configuration))
 
-	err := bucketNotificationConfig.MinioClient.SetBucketNotification(
-		ctx,
-		bucketNotificationConfig.MinioBucket,
-		*bucketNotificationConfig.Configuration,
-	)
+	// Lock to prevent concurrent read-modify-write races when multiple resources
+	// target the same bucket. This serializes within one provider process only.
+	bucketNotificationLock.Lock(bucketName)
+	defer bucketNotificationLock.Unlock(bucketName)
 
+	// Read-modify-write: read the current bucket notification config, remove this
+	// resource's old queues (from state), add the new queues (from config), then
+	// write back. This prevents clobbering other resources' notifications on the
+	// same bucket.
+	currentConfig, err := bucketNotificationConfig.MinioClient.GetBucketNotification(ctx, bucketName)
 	if err != nil {
-		return NewResourceError("error putting bucket notification configuration: %v", d.Id(), err)
+		return NewResourceError("error reading bucket notifications before update", bucketName, err)
 	}
 
-	d.SetId(bucketNotificationConfig.MinioBucket)
+	// Identify queues to remove: those whose IDs are in the current state but not
+	// in the new config. This handles the case where a queue is removed from HCL.
+	oldQueueIDs := getQueueIDsFromState(d)
+
+	// Build the new config: keep all queues from the current config that don't
+	// belong to this resource, then add the new queues from the resource config.
+	newConfig := notification.Configuration{}
+
+	// Preserve non-queue configs (TopicConfigs, LambdaConfigs) from the current config
+	newConfig.LambdaConfigs = currentConfig.LambdaConfigs
+	newConfig.TopicConfigs = currentConfig.TopicConfigs
+
+	// Keep queues that don't belong to this resource — append the original struct
+	// verbatim to preserve the Queue (ARN) field that AddQueue would otherwise lose.
+	for _, q := range currentConfig.QueueConfigs {
+		keep := true
+		for _, id := range oldQueueIDs {
+			if q.ID == id {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			newConfig.QueueConfigs = append(newConfig.QueueConfigs, q)
+		}
+	}
+
+	// Add the new queues from this resource's config
+	for _, c := range bucketNotificationConfig.Configuration.QueueConfigs {
+		newConfig.AddQueue(c.Config)
+	}
+
+	err = bucketNotificationConfig.MinioClient.SetBucketNotification(ctx, bucketName, newConfig)
+	if err != nil {
+		return NewResourceError("error putting bucket notification configuration", bucketName, err)
+	}
+
+	// Write back the queue IDs into state so identity is stable.
+	// The server assigns IDs to queues that didn't have one; we need to capture
+	// those so subsequent reads and deletes work correctly.
+	// Convert QueueConfig -> Config for the write-back helper.
+	configList := make([]notification.Config, len(bucketNotificationConfig.Configuration.QueueConfigs))
+	for i, qc := range bucketNotificationConfig.Configuration.QueueConfigs {
+		configList[i] = qc.Config
+	}
+	if err := writeBackQueueIDs(configList, d); err != nil {
+		return NewResourceError("writing back queue IDs", bucketName, err)
+	}
+
+	d.SetId(generateBucketNotificationID(bucketName, d))
 
 	return nil
 }
@@ -95,10 +156,11 @@ func minioPutBucketNotification(ctx context.Context, d *schema.ResourceData, met
 func minioReadBucketNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	bucketNotificationConfig := BucketNotificationConfig(d, meta)
 
-	tflog.Debug(ctx, fmt.Sprintf("S3 bucket notification configuration, read for bucket: %s", d.Id()))
+	bucketName := d.Get("bucket").(string)
+	tflog.Debug(ctx, fmt.Sprintf("S3 bucket notification configuration, read for bucket: %s", bucketName))
 
 	client := meta.(*S3MinioClient)
-	notificationConfig, err := bucketNotificationConfig.MinioClient.GetBucketNotification(ctx, d.Id())
+	notificationConfig, err := bucketNotificationConfig.MinioClient.GetBucketNotification(ctx, bucketName)
 	if err != nil {
 		if isS3CompatNotSupported(client, err) {
 			tflog.Info(ctx, "Bucket notification not supported by backend; skipping")
@@ -112,9 +174,17 @@ func minioReadBucketNotification(ctx context.Context, d *schema.ResourceData, me
 		return NewResourceError("failed to load bucket notification configuration", d.Id(), err)
 	}
 
-	_ = d.Set("bucket", d.Id())
+	if err := d.Set("bucket", bucketName); err != nil {
+		return NewResourceError("setting bucket", d.Id(), err)
+	}
 
-	if err := d.Set("queue", flattenQueueNotificationConfiguration(notificationConfig.QueueConfigs)); err != nil {
+	// Only set the queue(s) that belong to this resource by matching queue IDs.
+	// Since multiple resources can target the same bucket, each resource must
+	// only manage its own queue entries — setting all queues would cause
+	// resources to overwrite each other's state on Read.
+	resourceQueueIDs := getQueueIDsFromResource(d)
+	filteredConfigs := filterQueueConfigsByIDs(notificationConfig.QueueConfigs, resourceQueueIDs)
+	if err := d.Set("queue", flattenQueueNotificationConfiguration(filteredConfigs)); err != nil {
 		return NewResourceError("failed to load bucket queue notifications", d.Id(), err)
 	}
 
@@ -124,20 +194,48 @@ func minioReadBucketNotification(ctx context.Context, d *schema.ResourceData, me
 func minioDeleteBucketNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	bucketNotificationConfig := BucketNotificationConfig(d, meta)
 
-	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, removing notification configuration", bucketNotificationConfig.MinioBucket))
+	bucketName := d.Get("bucket").(string)
+	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, removing notification configuration", bucketName))
 
-	err := bucketNotificationConfig.MinioClient.SetBucketNotification(
-		ctx,
-		bucketNotificationConfig.MinioBucket,
-		notification.Configuration{},
-	)
+	// Lock to prevent concurrent read-modify-write races.
+	bucketNotificationLock.Lock(bucketName)
+	defer bucketNotificationLock.Unlock(bucketName)
 
+	// Read current config, remove only this resource's queues, write back.
+	// This avoids clobbering other resources' notifications on the same bucket.
+	currentConfig, err := bucketNotificationConfig.MinioClient.GetBucketNotification(ctx, bucketName)
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "NoSuchBucket") {
-			tflog.Warn(ctx, fmt.Sprintf("Bucket %s no longer exists, considering notification deletion successful", bucketNotificationConfig.MinioBucket))
+			tflog.Warn(ctx, fmt.Sprintf("Bucket %s no longer exists, considering notification deletion successful", bucketName))
 			return nil
 		}
-		return NewResourceError("error removing bucket notifications: %s", bucketNotificationConfig.MinioBucket, err)
+		return NewResourceError("error reading bucket notifications before deletion", bucketName, err)
+	}
+
+	resourceQueueIDs := getQueueIDsFromResource(d)
+
+	// Build a new config preserving non-queue configs and queues not belonging to this resource
+	newConfig := notification.Configuration{}
+	newConfig.LambdaConfigs = currentConfig.LambdaConfigs
+	newConfig.TopicConfigs = currentConfig.TopicConfigs
+
+	// Append the original struct verbatim to preserve the Queue (ARN) field.
+	for _, q := range currentConfig.QueueConfigs {
+		keep := true
+		for _, id := range resourceQueueIDs {
+			if q.ID == id {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			newConfig.QueueConfigs = append(newConfig.QueueConfigs, q)
+		}
+	}
+
+	err = bucketNotificationConfig.MinioClient.SetBucketNotification(ctx, bucketName, newConfig)
+	if err != nil {
+		return NewResourceError("error removing bucket notifications", bucketName, err)
 	}
 
 	return nil
@@ -231,6 +329,119 @@ func getNotificationQueueConfigs(d *schema.ResourceData) []notification.Config {
 	}
 
 	return configs
+}
+
+func importBucketNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Import ID format: "bucket|queue_id1,queue_id2,..." or just "bucket" for backward compatibility
+	id := d.Id()
+	bucketName := id
+	var resourceQueueIDs []string
+	if idx := strings.Index(id, "|"); idx != -1 {
+		bucketName = id[:idx]
+		rest := id[idx+1:]
+		if rest != "" {
+			resourceQueueIDs = strings.Split(rest, ",")
+		}
+	}
+	if err := d.Set("bucket", bucketName); err != nil {
+		return nil, fmt.Errorf("setting bucket during import: %w", err)
+	}
+
+	// Read the bucket's notification config to populate queue data.
+	m := meta.(*S3MinioClient)
+	notificationConfig, err := m.S3Client.GetBucketNotification(ctx, bucketName)
+	if err != nil {
+		return nil, fmt.Errorf("reading bucket notification during import: %w", err)
+	}
+
+	// When the import ID includes queue IDs (bucket|id1,id2), only import those
+	// specific queues to avoid claiming ownership of queues managed by sibling
+	// resources. When the ID is a bare bucket name, import all queues for
+	// backward compatibility with single-resource setups.
+	configs := notificationConfig.QueueConfigs
+	if resourceQueueIDs != nil {
+		configs = filterQueueConfigsByIDs(configs, resourceQueueIDs)
+	}
+	if err := d.Set("queue", flattenQueueNotificationConfiguration(configs)); err != nil {
+		return nil, fmt.Errorf("setting queue during import: %w", err)
+	}
+
+	d.SetId(generateBucketNotificationID(bucketName, d))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func generateBucketNotificationID(bucket string, d *schema.ResourceData) string {
+	queueIDs := make([]string, 0)
+	for _, q := range d.Get("queue").([]interface{}) {
+		if c, ok := q.(map[string]interface{}); ok {
+			if qid, ok := c["id"].(string); ok && qid != "" {
+				queueIDs = append(queueIDs, qid)
+			}
+		}
+	}
+	return fmt.Sprintf("%s|%s", bucket, strings.Join(queueIDs, ","))
+}
+
+// getQueueIDsFromResource extracts the queue IDs defined in the resource's queue blocks.
+func getQueueIDsFromResource(d *schema.ResourceData) []string {
+	ids := make([]string, 0)
+	for _, q := range d.Get("queue").([]interface{}) {
+		if c, ok := q.(map[string]interface{}); ok {
+			if qid, ok := c["id"].(string); ok && qid != "" {
+				ids = append(ids, qid)
+			}
+		}
+	}
+	return ids
+}
+
+// getQueueIDsFromState extracts the queue IDs from the *old* state (before update).
+// Used during Update to identify which queues to remove before adding new ones.
+func getQueueIDsFromState(d *schema.ResourceData) []string {
+	oldQueues, _ := d.GetChange("queue")
+	oldQueueList := oldQueues.([]interface{})
+	ids := make([]string, 0, len(oldQueueList))
+	for _, q := range oldQueueList {
+		if c, ok := q.(map[string]interface{}); ok {
+			if qid, ok := c["id"].(string); ok && qid != "" {
+				ids = append(ids, qid)
+			}
+		}
+	}
+	return ids
+}
+
+// filterQueueConfigsByIDs returns only the queue configs whose ID is in the given set.
+func filterQueueConfigsByIDs(configs []notification.QueueConfig, ids []string) []notification.QueueConfig {
+	idSet := make(map[string]struct{}, len(ids))
+	for _, qid := range ids {
+		idSet[qid] = struct{}{}
+	}
+	result := make([]notification.QueueConfig, 0, len(configs))
+	for _, c := range configs {
+		if _, ok := idSet[c.ID]; ok {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// writeBackQueueIDs writes the queue IDs back into the resource state.
+// It correlates by list index: the i-th queue block sent maps to the i-th queue block in state.
+// This avoids collisions when multiple resources share the same ARN.
+func writeBackQueueIDs(sent []notification.Config, d *schema.ResourceData) error {
+	queues := d.Get("queue").([]interface{})
+	if len(sent) != len(queues) {
+		return fmt.Errorf("queue count mismatch: sent %d, state %d", len(sent), len(queues))
+	}
+	for i := range queues {
+		queues[i].(map[string]interface{})["id"] = sent[i].ID
+	}
+	if err := d.Set("queue", queues); err != nil {
+		return fmt.Errorf("setting queue IDs during writeback: %w", err)
+	}
+	return nil
 }
 
 func validateMinioArn(v interface{}, p cty.Path) (errors diag.Diagnostics) {

--- a/minio/resource_minio_s3_bucket_notification_test.go
+++ b/minio/resource_minio_s3_bucket_notification_test.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -63,6 +64,131 @@ func TestS3BucketNotification_queue(t *testing.T) {
 	})
 }
 
+func TestAccMinioS3BucketNotification_multipleQueues(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-notification-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketNotificationConfig_multipleQueues(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("minio_s3_bucket_notification.notification-a", "bucket", name),
+					resource.TestCheckResourceAttr("minio_s3_bucket_notification.notification-b", "bucket", name),
+					resource.TestCheckResourceAttr("minio_s3_bucket_notification.notification-a", "queue.0.queue_arn", "arn:minio:sqs::primary:webhook"),
+					resource.TestCheckResourceAttr("minio_s3_bucket_notification.notification-b", "queue.0.queue_arn", "arn:minio:sqs::primary:webhook"),
+					func(s *terraform.State) error {
+						rsA := s.RootModule().Resources["minio_s3_bucket_notification.notification-a"]
+						rsB := s.RootModule().Resources["minio_s3_bucket_notification.notification-b"]
+						if rsA.Primary.ID == "" || rsB.Primary.ID == "" {
+							return fmt.Errorf("both resources must have IDs set")
+						}
+						if rsA.Primary.ID == rsB.Primary.ID {
+							return fmt.Errorf("both resources have the same ID %q — they should be distinct", rsA.Primary.ID)
+						}
+						return nil
+					},
+					func(s *terraform.State) error {
+						// Verify server-side: both queues must exist on the bucket.
+						// This is the actual regression being fixed — without the RMW
+						// logic, notification-b's write would wipe notification-a's queue.
+						minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
+						cfg, err := minioC.GetBucketNotification(context.Background(), name)
+						if err != nil {
+							return fmt.Errorf("getting bucket notification: %w", err)
+						}
+						if len(cfg.QueueConfigs) != 2 {
+							return fmt.Errorf("expected 2 queue configs on server, got %d", len(cfg.QueueConfigs))
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// Remove notification-a and verify notification-b's queue survives.
+				Config: testAccBucketNotificationConfig_singleQueue(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("minio_s3_bucket_notification.notification-b", "bucket", name),
+					func(s *terraform.State) error {
+						minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
+						cfg, err := minioC.GetBucketNotification(context.Background(), name)
+						if err != nil {
+							return fmt.Errorf("getting bucket notification: %w", err)
+						}
+						if len(cfg.QueueConfigs) != 1 {
+							return fmt.Errorf("expected 1 queue config after removing notification-a, got %d", len(cfg.QueueConfigs))
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketNotificationConfig_multipleQueues(name string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+}
+
+resource "minio_s3_bucket_notification" "notification-a" {
+  bucket = minio_s3_bucket.bucket.id
+
+  queue {
+    id        = "notification-queue-a"
+    queue_arn = "arn:minio:sqs::primary:webhook"
+
+    events = [
+      "s3:ObjectCreated:*",
+    ]
+
+    filter_prefix = "prefix-a/"
+  }
+}
+
+resource "minio_s3_bucket_notification" "notification-b" {
+  bucket = minio_s3_bucket.bucket.id
+
+  queue {
+    id        = "notification-queue-b"
+    queue_arn = "arn:minio:sqs::primary:webhook"
+
+    events = [
+      "s3:ObjectCreated:*",
+    ]
+
+    filter_prefix = "prefix-b/"
+  }
+}
+`, name)
+}
+
+func testAccBucketNotificationConfig_singleQueue(name string) string {
+	return fmt.Sprintf(`
+resource "minio_s3_bucket" "bucket" {
+  bucket = %[1]q
+}
+
+resource "minio_s3_bucket_notification" "notification-b" {
+  bucket = minio_s3_bucket.bucket.id
+
+  queue {
+    id        = "notification-queue-b"
+    queue_arn = "arn:minio:sqs::primary:webhook"
+
+    events = [
+      "s3:ObjectCreated:*",
+    ]
+
+    filter_prefix = "prefix-b/"
+  }
+}
+`, name)
+}
+
 func testAccBucketNotificationConfig_queue(name string, suffix string) string {
 	return fmt.Sprintf(`
 resource "minio_s3_bucket" "bucket" {
@@ -99,8 +225,14 @@ func testAccCheckBucketHasNotification(n string, config notification.Configurati
 			return fmt.Errorf("no ID is set")
 		}
 
+		// ID format is "bucket|arn1,arn2,..." — extract the bucket name
+		bucketName := rs.Primary.ID
+		if idx := strings.Index(bucketName, "|"); idx != -1 {
+			bucketName = bucketName[:idx]
+		}
+
 		minioC := testAccProvider.Meta().(*S3MinioClient).S3Client
-		actualConfig, err := minioC.GetBucketNotification(context.Background(), rs.Primary.ID)
+		actualConfig, err := minioC.GetBucketNotification(context.Background(), bucketName)
 
 		if err != nil {
 			return fmt.Errorf("error on GetBucketNotification: %v", err)

--- a/templates/resources/s3_bucket_notification.md.tmpl
+++ b/templates/resources/s3_bucket_notification.md.tmpl
@@ -23,3 +23,5 @@ Import is supported using the following syntax:
 # S3 bucket notifications can be imported using the bucket name
 terraform import minio_s3_bucket_notification.example bucket-name
 ```
+
+Note: Importing replaces the entire notification configuration for the bucket. If multiple notification resources target the same bucket, only the imported resource's queue targets will be present after import.


### PR DESCRIPTION
Currently, `minio_s3_bucket_notification` uses the bare bucket name as its Terraform ID and each apply calls `SetBucketNotification` with only its own config. So when two resources target the same bucket, the second apply overwrites the first, and only one notification survives (issue #1056).

This PR does two things:

- Gives each resource a deterministic composite ID, `bucket|queue_id1,queue_id2,...`, so multiple resources on the same bucket get distinct IDs (as suggested in the issue).
- Switches Create/Update/Delete to read-modify-write: read the current config, touch only this resource's own queues (matched by `queue.id`), and write the rest back untouched. A per-bucket `MutexKV` lock serializes the read-modify-write so parallel applies in one provider process don't clobber each other.

Read now filters the server config down to the queues this resource owns, and `queue.id` gets a validation that rejects `,` and `|` so the composite ID stays unambiguous.

Backward compatibility: single-notification setups keep working. Import still accepts a bare bucket name (imports all queues), and also accepts `bucket|id1,id2` to import just one resource's queues.

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### How was this change tested?

Ran against a real MinIO (`docker compose up -d minio`) with a new acceptance test, `TestAccMinioS3BucketNotification_multipleQueues`:

1. Applies two `minio_s3_bucket_notification` resources on the same bucket and asserts both survive server-side (2 queue configs) with distinct IDs.
2. Removes one and asserts the other's queue is still there (1 queue config).

```
TF_ACC=1 go test ./minio/ -run='TestAccMinioS3BucketNotification_multipleQueues|TestS3BucketNotification_queue' -count=1 -v
--- PASS: TestAccMinioS3BucketNotification_multipleQueues (1.81s)
--- PASS: TestS3BucketNotification_queue (1.98s)
```

To make sure the test isn't a vacuous pass, I temporarily restored the old overwrite behavior and the test failed for the right reason (`expected 2 queue configs on server, got 1`), then reverted.

`go build ./...`, `go vet ./minio/`, and `gofmt` are all clean, and docs were regenerated with `task generate-docs`.

### Related Issues
Fixes #1056

### Example Usage

```hcl
resource "minio_s3_bucket" "bucket" {
  bucket = "my-bucket"
}

resource "minio_s3_bucket_notification" "notification-a" {
  bucket = minio_s3_bucket.bucket.id
  queue {
    id            = "notification-queue-a"
    queue_arn     = "arn:minio:sqs::primary:webhook"
    events        = ["s3:ObjectCreated:*"]
    filter_prefix = "prefix-a/"
  }
}

resource "minio_s3_bucket_notification" "notification-b" {
  bucket = minio_s3_bucket.bucket.id
  queue {
    id            = "notification-queue-b"
    queue_arn     = "arn:minio:sqs::primary:webhook"
    events        = ["s3:ObjectCreated:*"]
    filter_prefix = "prefix-b/"
  }
}
```

## Pull Request Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have signed my commits (`git commit -s`) — the repo does not currently use DCO sign-off, so this matches existing history
- [x] I have added tests that prove my fix is effective (`TestAccMinioS3BucketNotification_multipleQueues`)
- [x] New and existing tests pass locally with my changes
- [x] The modified resource has acceptance tests
- [x] I have tested the changes with a real MinIO setup
- [x] I have updated the documentation templates in `templates/`
- [x] I have run `task generate-docs` to update generated documentation

## Notes for reviewers

- The data source `minio_s3_bucket_notification_config` still keys its ID on the bare bucket name. It reads the whole bucket config into one instance, so there's no collision to solve there. Left as-is; happy to align it if you'd prefer.
- Per-bucket locking is in-process only (a single provider run). It does not guard against a separate process racing on the same bucket, which is the same limitation the other read-modify-write resources in this provider have.
