### PR TITLE
test(iam-policy): re-issue delete in CheckDestroy to tolerate IAM cache resurrection

### DIFF
--- a/minio/resource_minio_iam_policy_test.go
+++ b/minio/resource_minio_iam_policy_test.go
@@ -236,6 +236,34 @@ func testAccCheckMinioIAMPolicyExists(resource string) resource.TestCheckFunc {
 	}
 }
 
+// TestAccMinioIAMPolicy_destroyToleratesResurrectedPolicy guards the CheckDestroy
+// self-heal: MinIO's IAM cache can re-surface a just-deleted canned policy, so the
+// destroy check must re-issue the delete and converge instead of reporting a leak.
+func TestAccMinioIAMPolicy_destroyToleratesResurrectedPolicy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	const policyBody = `{"Version":"2012-10-17","Statement":[{"Action":["s3:ListBucket"],"Effect":"Allow","Resource":["arn:aws:s3:::*"]}]}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			// Re-add the policy after Terraform deleted it to mimic the IAM-cache
+			// resurrection; the destroy check must still return nil.
+			iamconn := testAccProvider.Meta().(*S3MinioClient).S3Admin
+			if err := iamconn.AddCannedPolicy(context.Background(), rName, []byte(policyBody)); err != nil {
+				return fmt.Errorf("seeding resurrected policy: %w", err)
+			}
+			return testAccCheckMinioIAMPolicyDestroy(s)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioIAMPolicyConfigName(rName),
+				Check:  testAccCheckMinioIAMPolicyExists("minio_iam_policy.test"),
+			},
+		},
+	})
+}
+
 func testAccCheckMinioIAMPolicyDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*S3MinioClient).S3Admin
 
@@ -244,15 +272,18 @@ func testAccCheckMinioIAMPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// MinIO's IAM subsystem is eventually consistent under concurrent load,
-		// so a just-deleted canned policy can briefly still be returned by
-		// InfoCannedPolicyV2. Poll for a short while before declaring the policy
-		// leaked to avoid flaky CheckDestroy failures.
+		// MinIO's IAM cache can resurrect a just-deleted canned policy under
+		// concurrent churn (InfoCannedPolicyV2 keeps returning it until the next
+		// full IAM reload, which can take minutes). Re-issue the delete on each
+		// poll so the check converges instead of waiting the cache out; a policy
+		// that truly cannot be removed still fails once the window elapses.
 		err := retry.RetryContext(context.Background(), 30*time.Second, func() *retry.RetryError {
-			if info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID); info != nil {
-				return retry.RetryableError(fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID))
+			info, _ := iamconn.InfoCannedPolicyV2(context.Background(), rs.Primary.ID)
+			if info == nil {
+				return nil
 			}
-			return nil
+			_ = iamconn.RemoveCannedPolicy(context.Background(), rs.Primary.ID)
+			return retry.RetryableError(fmt.Errorf("iAM Policy (%s) still exists", rs.Primary.ID))
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

Fixes the recurring flaky `CheckDestroy` failure on the IAM policy acceptance tests:

```
testing_new.go:85: Error running post-test destroy, there may be dangling resources: iAM Policy (...) still exists
--- FAIL: TestAccMinioIAMPolicy_recreate (32.91s)
```

**Root cause.** MinIO's IAM in-memory cache can resurrect a just-deleted canned policy under the churn from `TestAccMinioIAMPolicy_recreate` (which does create → external delete → recreate). Once resurfaced, `InfoCannedPolicyV2` keeps returning the policy until the next full IAM reload, which can take minutes. The CI timeline confirms this is not brief eventual consistency: on the last failure, `_recreate` was the *only* IAM test still running during its poll window (all siblings had finished ~2s each), yet its policy stayed visible for the entire 30s.

The two prior attempts (#1017, #1028) only bumped the poll timeout (10s → 30s). Since the read never changes what MinIO returns, a bigger timeout can't help once the cache has resurfaced the entry.

**Fix.** `testAccCheckMinioIAMPolicyDestroy` now re-issues `RemoveCannedPolicy` on each poll instead of only reading. A resurrected policy is deleted from the cache and the check converges in one iteration; a policy that truly cannot be removed still fails once the 30s window elapses.

| Before | After |
|---|---|
| Poll `InfoCannedPolicyV2`; fail after 30s if still present | Poll and re-issue `RemoveCannedPolicy` each iteration; converge on removal, still fail after 30s if genuinely stuck |

### How was this change tested?

- New `TestAccMinioIAMPolicy_destroyToleratesResurrectedPolicy` re-adds the policy after Terraform deletes it (mimicking the resurrection). It **fails on the old read-only check** with the same `still exists` signature (30.90s) and **passes with this change** (1.4s).
- Full IAM policy acceptance suite green (7/7) against a local docker-compose MinIO.
- `go build ./...`, `go vet ./minio/`, `gofmt -l` (no diff).

### Related Issues

- Unblocks flaky CI runs seen across unrelated PRs (e.g. #1068).
