### PR TITLE
fix(deps): bump google.golang.org/grpc to v1.82.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 h1:eZCjr/aAF8c5ccm5pb6T4EXgIei5MlAAPWPJk+5ArfY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
Bumps `google.golang.org/grpc` from v1.81.1 to v1.82.1 to clear the code-scanning alert [GHSA-hrxh-6v49-42gf](https://github.com/aminueza/terraform-provider-minio/security/code-scanning/152) (HIGH, "gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities").

Currently, the module pins grpc at v1.81.1, which the advisory flags as vulnerable (affected range `< 1.82.1`, first patched in v1.82.1). It's an indirect dependency, so this is just a version bump in `go.mod`/`go.sum`, no code changes.

### Type of Change
- [x] Security fix

### How was this change tested?
- `go mod tidy` (only the grpc lines change)
- `go build ./...` passes
- `go list -m google.golang.org/grpc` reports `v1.82.1`

### Related Issues
Resolves the code-scanning alert #152.

### For Security Changes
- [x] Security implications documented (see advisory link above)

## Release Notes

```markdown
### Security
- Bump `google.golang.org/grpc` to v1.82.1 (GHSA-hrxh-6v49-42gf).
```
