### PR TITLE
docs(security): drop the reporting fallback now that private reporting is enabled

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ blank_issues_enabled: true
 contact_links:
   - name: 🔒 Report a security vulnerability
     url: https://github.com/aminueza/terraform-provider-minio/security/advisories/new
-    about: Vulnerabilities go through GitHub Private Vulnerability Reporting, never a public issue. If that page is unavailable to you, see SECURITY.md for what to do instead.
+    about: Vulnerabilities go through GitHub Private Vulnerability Reporting, never a public issue. Your report stays private until an advisory is published.
   - name: 💬 Questions and discussion
     url: https://github.com/aminueza/terraform-provider-minio/discussions
     about: Usage questions, ideas, and anything that is not a bug report or feature request.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -14,9 +14,7 @@ If you discover a security vulnerability, please **DO NOT** open a public issue.
 
 ### How to Report
 
-Use GitHub's [Private Vulnerability Reporting](https://github.com/aminueza/terraform-provider-minio/security/advisories/new).
-
-If that page is not available to you, open a public issue that contains **only** a request for a private channel: say that you have a security report and ask a maintainer to contact you. Do not include the affected component, reproduction steps, or a proof of concept. A maintainer will open a private advisory and invite you to it, and the rest of the report belongs there.
+Use GitHub's [Private Vulnerability Reporting](https://github.com/aminueza/terraform-provider-minio/security/advisories/new). Your report stays private between you and the maintainers until an advisory is published.
 
 ### What to Include
 


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have read the [Project Vision](./VISION.md) and understand the scope
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have signed my commits (`git commit -s`)

### Testing Requirements
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests
- [ ] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [ ] I have updated the documentation templates in `templates/` if needed
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

### Breaking Changes
- [ ] If this is a breaking change, I have described the impact and migration path
- [ ] If this is a breaking change, I have updated the version appropriately

No provider code or generated docs are touched, so the testing and docs items above do not apply.

## Description

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, code improvement)
- [ ] Performance improvement
- [ ] Security fix

### What does this PR do?

The follow-up promised in #1090. That PR removed the security issue template and routed reporters to Private Vulnerability Reporting, but reporting was still disabled at the time, so the advisory form 404d for anyone without admin. To avoid replacing a misleading path with a dead one, `SECURITY.md` carried a fallback: open a public issue asking for a private channel and nothing else.

Private Vulnerability Reporting is now enabled (`GET /repos/aminueza/terraform-provider-minio/private-vulnerability-reporting` returns `{"enabled": true}`), so the advisory form works for every reporter. The fallback now describes a state that no longer exists, and leaving it in would keep inviting the public security issues #1090 set out to stop.

Both the policy and the `config.yml` contact link now say what the old template was faking: your report stays private until an advisory is published.

### How was this change tested?

- Confirmed private reporting is enabled through the API, rather than assuming it.
- Confirmed `.github/ISSUE_TEMPLATE/config.yml` still parses as YAML and still exposes exactly `blank_issues_enabled` and both contact links.
- Grepped `.github/` for leftover fallback wording; there is none.

### Related Issues

Follows up #1090. Both came out of preparing the advisory for #1085.

## Additional Context

Nothing in `SECURITY.md` is gated on the old setting any more. Its "Initial Response: within 48 hours" and coordinated-disclosure promises now have a working intake path, which they did not when #1090 was written.

## Reviewer Focus Areas

### Areas of Concern
- [ ] Error handling and edge cases
- [ ] Performance implications
- [x] Security considerations
- [x] Documentation accuracy
- [ ] Test coverage completeness

Worth one check: if private reporting is ever turned off again, this removal puts the docs back to pointing at a page that 404s. That seems like the right trade rather than documenting an unavailable-channel workaround permanently, but it is the one thing this PR gives up.

## Release Notes

```markdown
### Changed
- `SECURITY.md` now points at GitHub Private Vulnerability Reporting only, since that channel is enabled. The fallback instructions for reaching a maintainer through a public issue are no longer needed.
```
