### PR TITLE
test(s3): pin the anonymous public policy to data-access-only actions

### DIFF
--- a/minio/public_policy_test.go
+++ b/minio/public_policy_test.go
@@ -25,9 +25,15 @@ func TestPublicPolicy(t *testing.T) {
 	assert.DeepEqual(t, expected, policy)
 }
 
-// Anonymous callers must never be able to administer a bucket they can read and write.
-// Granting any of these lets an unauthenticated request rewrite the bucket policy, delete the
-// bucket, or subscribe to its event stream.
+// The `public` access type grants data access only: reading, writing and listing objects, and
+// nothing that administers, discloses or reconfigures the bucket itself. #1089 reviewed every
+// action #1085 removed and kept all of them out, so this list is deliberate and complete rather
+// than a running tally of whatever has been noticed so far. Anyone who needs more writes it out
+// in the resource's `policy` attribute, which takes precedence over `access_type`.
+//
+// s3:HeadBucket is here because it is redundant, not dangerous: anonymous HEAD on a bucket is
+// already authorized under s3:ListBucket. s3:ListAllMyBuckets is a server-level action with no
+// effect when scoped to a single bucket ARN.
 func TestPublicPolicy_grantsNoAdministrativeActions(t *testing.T) {
 	forbidden := []string{
 		"s3:CreateBucket",
@@ -38,6 +44,8 @@ func TestPublicPolicy_grantsNoAdministrativeActions(t *testing.T) {
 		"s3:GetBucketNotification",
 		"s3:PutBucketNotification",
 		"s3:ListenBucketNotification",
+		"s3:HeadBucket",
+		"s3:ListAllMyBuckets",
 	}
 
 	for _, statement := range PublicPolicy(&S3MinioBucket{MinioBucket: "test"}).Statements {

--- a/minio/resource_minio_s3_bucket_anonymous_access_test.go
+++ b/minio/resource_minio_s3_bucket_anonymous_access_test.go
@@ -176,6 +176,8 @@ func testAccCheckAnonymousAccessGrantsDataAccessOnly(n string) resource.TestChec
 		}
 
 		for _, statement := range parsed.Statements {
+			// Same boundary as TestPublicPolicy_grantsNoAdministrativeActions, checked against
+			// the policy the server actually holds. See #1089 for the per-action decision.
 			for _, action := range []string{
 				"s3:CreateBucket",
 				"s3:DeleteBucket",
@@ -185,6 +187,8 @@ func testAccCheckAnonymousAccessGrantsDataAccessOnly(n string) resource.TestChec
 				"s3:GetBucketNotification",
 				"s3:PutBucketNotification",
 				"s3:ListenBucketNotification",
+				"s3:HeadBucket",
+				"s3:ListAllMyBuckets",
 			} {
 				if statement.Actions.Contains(action) {
 					return fmt.Errorf("server policy grants %s to anonymous callers: %s", action, actualPolicyText)


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have read the [Project Vision](./VISION.md) and understand the scope (the linked file does not exist in the repository)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have signed my commits (`git commit -s`)

### Testing Requirements
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests (no resource changed here; the existing acceptance coverage is extended)
- [x] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [ ] I have updated the documentation templates in `templates/` if needed
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

Nothing user-facing changed, so none of the documentation items apply. The `public` action list is already documented in `templates/resources/s3_bucket_anonymous_access.md.tmpl` from #1085.

### Breaking Changes
- [ ] If this is a breaking change, I have described the impact and migration path
- [ ] If this is a breaking change, I have updated the version appropriately

## Description

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes, code improvement)
- [ ] Performance improvement
- [ ] Security fix

Test-only. No builder, resource or policy shape changes.

### What does this PR do?

#1085 removed ten actions from the `public` access type. The test guarding that boundary pins only eight of them, so `s3:HeadBucket` and `s3:ListAllMyBuckets` could drift back in without failing anything. This adds both to the forbidden list in `TestPublicPolicy_grantsNoAdministrativeActions` and in `testAccCheckAnonymousAccessGrantsDataAccessOnly`, and rewrites the comment above the unit test to state the boundary as decided rather than as a running tally.

#1089 asked whether `public` dropped too much. The answer is no: every removed action stays out. The decision was taken on evidence gathered against MinIO `RELEASE.2025-09-07T16-13-09Z` with `mc RELEASE.2025-08-13T08-35-41Z`, and it is recorded per action below. A standalone decision comment will be posted on #1089 separately.

The anchor is `mc`'s own `public`, captured with `mc anonymous set public` followed by `mc anonymous get-json`:

```json
{"Statement":[{"Action":["s3:GetBucketLocation","s3:ListBucket","s3:ListBucketMultipartUploads"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::B"]},{"Action":["s3:ListMultipartUploadParts","s3:PutObject","s3:AbortMultipartUpload","s3:DeleteObject","s3:GetObject"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::B/*"]}],"Version":"2012-10-17"}
```

That is eight actions, and the provider's `publicBucketActions` and `publicObjectActions` already match it exactly. None of the six actions below appear in it.

| Action | Decision | What it rests on |
| --- | --- | --- |
| `s3:GetBucketPolicy` | stays out | Absent from `mc anonymous get-json`. Anonymous `GET /<bucket>?policy` returns `403 AccessDenied` under the shipped policy; granting the action returns `200` with the full policy document. The one use case anyone named, a public browser showing its own permissions, is speculative and the `policy` attribute covers it. |
| `s3:GetBucketNotification` | stays out | Absent from `mc anonymous get-json`. Anonymous `GET /<bucket>?notification` returns `403` under the shipped policy; granting the action returns the `NotificationConfiguration` document. No anonymous consumer for it was identified. |
| `s3:PutBucketNotification` | stays out | Absent from `mc anonymous get-json`. It lets an unauthenticated caller reconfigure where the bucket's events go, which is the same class as the four actions #1085 removed on security grounds. |
| `s3:ListenBucketNotification` | stays out | Absent from `mc anonymous get-json`. This is the only one of the six with a real capability cost: granted, an anonymous `GET /<bucket>?events=s3:ObjectCreated:*` holds the event stream open; without it the same request returns `403`. Nobody has asked for it, and the evidence for keeping it out is weaker than for the rest, so this is the row to revisit if a report arrives. |
| `s3:HeadBucket` | stays out | Redundant, not merely unused. Under the shipped policy, anonymous `HEAD /<bucket>` returns `200` without it, authorized by `s3:ListBucket`. |
| `s3:ListAllMyBuckets` | stays out | Absent from `mc anonymous get-json`. Server-level, with no effect when scoped to a single bucket ARN. Not in question in #1089, pinned here for completeness. |

### One correction to the reasoning in #1085 and #1089

Both argued that re-adding actions risks the `custom` classification that #1086 exists to fix. That is not true, and this PR does not rely on it.

`policy.GetPolicy` in `minio-go v7.2.1` classifies with `statement.Actions.Intersection(required).Equals(required)`, which is a containment check: extra actions are ignored. Verified live by applying the `mc public` shape plus all five disputed actions to a bucket, after which `mc anonymous get` still reported `public`.

So the exclusions rest on the security and redundancy arguments alone, not on `mc` compatibility. `mc` parity remains the reference line for what `public` should mean; it just is not a technical constraint against widening it. #1086's parity work is unaffected either way, since its bug is a missing required action, not an extra one.

### On demand evidence

There is none, in either direction, and the scan cannot currently produce any. #1085 merged on 2026-08-03 at 19:02 UTC and shipped in v3.40.0 twenty-three minutes later, so no user has had time to hit a regression. The repository's only anonymous-access report, discussion #873, is about the other three access types being classified `custom`, which is #1086.

This PR therefore pins the shipped behavior rather than settling the question forever. If an anonymous consumer does turn up, `s3:ListenBucketNotification` is the likely one, and reverting is a one-line change to `publicBucketActions` plus these two lists.

### How was this change tested?

Against the Docker Compose stack, with the environment from `.github/CONTRIBUTING.md`.

1. Start the primary instance: `docker compose up -d minio`.
2. Unit tests: `go test ./minio -run 'TestPublicPolicy' -v`. All four pass.
3. Confirm the new pins can fail. Temporarily add `s3:HeadBucket` and `s3:ListAllMyBuckets` to `publicBucketActions` in `minio/payload.go` and rerun step 2. `TestPublicPolicy_grantsNoAdministrativeActions` fails with `public policy grants s3:HeadBucket to anonymous callers` and the same for `s3:ListAllMyBuckets`. Revert the change.
4. Targeted acceptance run: `TF_ACC=1 go test -v ./minio -run 'TestAccS3BucketAnonymousAccess_public' -timeout 30m`. Passes in 9.78s.
5. Whole group, to check no sibling broke: `TF_ACC=1 go test -v ./minio -run 'AnonymousAccess' -timeout 30m`. All 7 pass in 24.2s.
6. `go build ./...` and `gofmt -l minio/` are clean.
7. `golangci-lint run` reports only the two pre-existing `errcheck` findings in `minio/madmin_api_version_fallback_test.go`, which are on `main` as well and in a file this PR does not touch.

The live evidence in the table was gathered separately against the same stack, using `mc` inside the MinIO container and `curl` from the host with no credentials. Scratch buckets were removed afterwards.

### Related Issues

- Resolves #1089
- Follows #1085
- Related to #1086, which fixes the other three access types and is unaffected by this change

## Screenshots / Examples

### Example Usage (if applicable)

Unchanged by this PR. The escape hatch referenced above is the existing `policy` attribute, which takes precedence over `access_type`:

```hcl
resource "minio_s3_bucket_anonymous_access" "example" {
  bucket = minio_s3_bucket.example.id

  # `policy` wins over `access_type`, so anyone who genuinely needs an action
  # that `public` does not grant writes it out here.
  policy = data.minio_iam_policy_document.example.json
}
```

## Checklist for Specific Changes

### For Bug Fixes
- [x] Root cause identified and documented
- [x] Regression tests added
- [ ] Error handling follows project patterns using `NewResourceError()` (no error paths changed)
- [x] Edge cases considered and handled

### For Security Changes
- [x] Security implications documented
- [ ] Input validation added if needed
- [ ] Credential handling reviewed
- [x] Security tests added if applicable

## Additional Context

The two lists are deliberately duplicated rather than shared. The unit test checks what the builder produces, and the acceptance check classifies the policy the server actually holds, which is the distinction #1087 is about. A shared constant would let one bug hide both.

`minio/payload.go`, the policy builders and the templates are untouched, since #1086 has changes in flight there.

## Reviewer Focus Areas

### Areas of Concern
- [ ] Error handling and edge cases
- [x] Security considerations
- [x] Documentation accuracy
- [x] Test coverage completeness

The `s3:ListenBucketNotification` row is the one worth a second look. It is the only removed action that enables a feature rather than disclosing or changing configuration, and the case for keeping it out is absence of demand rather than a demonstrated harm.

Also worth confirming that the correction above reads right, since it contradicts a line in #1085's own description.

## Release Notes

```markdown
### Changed
- No user-facing change. Test-only: the `public` anonymous access type is now pinned to data-access-only actions, so the exclusions #1085 introduced cannot silently regress.
```

## Related PRs

This lands alongside #1094 (canned anonymous policy shapes for #1086), #1093 (test-expectation audit for #1087) and #1095 (per-test provider instances for #1088). #1094 and #1095 edit other functions of `resource_minio_s3_bucket_anonymous_access_test.go`; the hunks here are separate, so this PR merges cleanly in any order. Suggested order: #1094 first, #1095 last.
