### PR TITLE
test: stop building expectations from the code under test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ go test ./minio/...
 - **Requirements:** Each resource must have acceptance tests covering create, read, update, delete, and import
 - **Test structure:** Use `resource.Test` with `TestCase` containing steps
 - **PreCheck:** Implement `testAccPreCheck(t)` for provider configuration validation
+- **Expectations:** An expectation built by the code under test is not an assertion. A check that computes its expected value with the same function that produced the actual value only proves the code agrees with itself, so no change to that function can fail it. Assert against an explicit literal, an explicit list of the actions or fields that matter, or a classification from an independent library (e.g. `policy.GetPolicy` from minio-go, which is what `mc` uses). A golden comparison is fine for change detection, but pair it with an independent assertion instead of leaving it as the only check.
 
 ```bash
 # Run all tests

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/minio/minio-go/v7/pkg/replication"
 )
 
+// wantPathStyleWireValue spells out the value MinIO stores in a remote target's Path
+// for each path style. The resource writes that field with S3PathStyle.String(), so an
+// expectation taken from the same method would only prove the code agrees with itself.
+var wantPathStyleWireValue = map[S3PathStyle]string{
+	S3PathStyleAuto: "auto",
+	S3PathStyleOn:   "on",
+	S3PathStyleOff:  "off",
+}
+
+func TestS3PathStyleString(t *testing.T) {
+	for style, want := range wantPathStyleWireValue {
+		if got := style.String(); got != want {
+			t.Errorf("S3PathStyle(%d).String() = %q, want %q", style, got, want)
+		}
+	}
+}
+
 // testAccReplicationPreCheck skips the test when a second MinIO instance is not
 // configured. Replication acceptance tests need a remote target, which is only
 // available when SECOND_MINIO_ENDPOINT is set (as it is under docker compose).
@@ -1817,8 +1834,12 @@ func testAccCheckBucketHasReplication(n string, config []S3MinioBucketReplicatio
 			if existingTarget.Region != rule.Target.Region {
 				return fmt.Errorf("Mismatch region %q, rule#%d:\n\nexpected: %v\n\ngot: %v", n, i, existingTarget.Region, rule.Target.Region)
 			}
-			if existingTarget.Path != rule.Target.PathStyle.String() {
-				return fmt.Errorf("Mismatch path style %q, rule#%d:\n\nexpected: %v\n\ngot: %v", n, i, existingTarget.Path, rule.Target.PathStyle.String())
+			wantPath, ok := wantPathStyleWireValue[rule.Target.PathStyle]
+			if !ok {
+				return fmt.Errorf("No expected wire value for path style %d, rule#%d", rule.Target.PathStyle, i)
+			}
+			if existingTarget.Path != wantPath {
+				return fmt.Errorf("Mismatch path style %q, rule#%d:\n\nexpected: %v\n\ngot: %v", n, i, wantPath, existingTarget.Path)
 			}
 			// Asserting exact AccessKey value is too painful. Furthermore, since MinIO assert the credential validity before accepting the new remote target, the value is very low
 			if len(existingTarget.Credentials.AccessKey) != 20 {


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have read the [Project Vision](./VISION.md) and understand the scope (the linked file does not exist in the repository)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have signed my commits (`git commit -s`)

### Testing Requirements
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests
- [x] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [ ] I have updated the documentation templates in `templates/` if needed
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

### Breaking Changes
- [ ] If this is a breaking change, I have described the impact and migration path
- [ ] If this is a breaking change, I have updated the version appropriately

## Description

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes, code improvement)
- [ ] Performance improvement
- [ ] Security fix

### What does this PR do?

Currently, `testAccCheckBucketHasReplication` compares the `Path` the server returns for a remote target against `rule.Target.PathStyle.String()`. That is the same method the resource used to write the field (`buildBucketReplicationTarget` in `resource_minio_s3_bucket_replication.go`), so whatever the method produces matches, and the check cannot fail on the one thing it was written to cover.

This PR replaces that expectation with a literal map from each `S3PathStyle` to the value MinIO stores, spelled out in the test. It also adds `TestS3PathStyleString`, which pins `String()` to the same literals, so the `on` and `off` mappings get covered too (no acceptance test exercises them today).

`AGENTS.md` gains a note under `## Testing Guidelines`: an expectation built by the code under test is not an assertion, with the alternatives to reach for instead. It sits there rather than under `### Testing Standards`, so it does not collide with #1088.

### Audit

The starting point was `grep -n "PublicPolicy\|ReadOnlyPolicy\|ReadWritePolicy\|WriteOnlyPolicy" minio/*_test.go`, then a wider sweep: every function, method and package-level constant declared in a non-test file of `minio/`, cross-referenced against every reference to it across all 99 `minio/*_test.go` files. Each hit was read to decide whether the production symbol produced the expected value or only the actual one.

| File | Finding | Action |
| --- | --- | --- |
| `resource_minio_s3_bucket_replication_test.go` | `testAccCheckBucketHasReplication` builds the expected `Path` with `S3PathStyle.String()`, the same method that wrote it | Fixed: literal map in the test, plus `TestS3PathStyleString` |
| `resource_minio_s3_bucket_anonymous_access_test.go` | `testAccCheckBucketHasAnonymousAccess` builds its expectation with the four canned policy builders | Left alone, ships with #1086 |
| `data_source_minio_s3_bucket_anonymous_access_test.go` | The canned-type assertions round-trip: `getAccessTypeFromPolicy` derives `access_type` by comparing the policy against the same four builders that wrote it | Left alone, belongs with #1086 (see the note below) |
| `aistor_policies_test.go` | `TestCanonicalPolicyForAccessType_*` | Left alone, the file goes away with #1086 |
| `public_policy_test.go` | Golden JSON literal, already paired with the forbidden-action list and the `policy.GetPolicy` classification from #1085 | No change, the forbidden list is owned by #1089 |
| `readonly_policy_test.go`, `readwrite_policy_test.go` | Golden JSON literal with no independent pairing | No change: the literal is written by hand, so it is already independent of the builder, and #1086 reshapes these policies along with their goldens |
| `resource_minio_s3_bucket_lifecycle_test.go` | `buildLifecycleRule`, `validateLifecycleRule`, `flattenLifecycleRule` | Fine: hand-written input maps, hand-written expected fields |
| `resource_minio_ilm_policy_test.go` | `createLifecycleRule` | Fine: asserts against hand-written XML fragments |
| `resource_minio_audit_webhook_test.go` | `buildAuditWebhookCfgData`, `auditWebhookConfigKey` | Fine: expectations are literal substrings, and the config key is a lookup input (a wrong key fails the read) |
| `resource_minio_iam_idp_ldap_test.go` | `buildIdpLdapCfgData` | Fine: expectations are literal substrings |
| `resource_minio_pool_decommission_test.go` | `decommissionState` asserted against the `poolState*` constants | Fine: the four constants hold distinct values, so a wrong branch still fails the test |
| `resource_minio_s3_bucket_notification_test.go` | The expected configuration is built with `notification.NewConfig` | Fine: that is minio-go, not the code under test |
| `resource_minio_s3_bucket_versioning_test.go`, `resource_minio_s3_bucket_policy_test.go`, `resource_minio_service_account_test.go`, `resource_minio_iam_*_test.go`, `resource_minio_site_replication_test.go` | Check helpers take the expectation as a parameter, which could hide a builder call | Fine: every call site passes literals or values the Terraform config declares |
| `resource_minio_ilm_tier_test.go`, `resource_minio_s3_bucket_test.go`, `resource_minio_s3_bucket_cors_test.go`, `resource_minio_config_test.go` | `getTier`, `minioReadBucket`, `resourceMinioBucket` called inside checks | Fine: production code produces the actual value here, the expectation stays a literal |
| `resource_minio_bucket_metadata_import_test.go`, `data_source_minio_iam_policy_document_test.go`, `utils_test.go`, `error_test.go`, `tagging_helpers_test.go`, `retry_config_test.go`, `edition_detection_test.go`, `new_client_test.go`, `resource_minio_notify_targets_test.go` | Pure helpers and schema shape | Fine: hand-written tables and golden JSON constants |
| `fuzz_test.go` | `NormalizeAndCompareJSONPolicies`, `ParseBandwidthLimit`, `HashcodeString` | Fine: asserts properties (no panic, non-negative hash), not values |
| Remaining `minio/*_test.go` | No reference to any production symbol | Fine: they assert state against what the Terraform config literally declares |

On the data source: an independent classification is the right fix there, but it cannot land before #1086. Running `policy.GetPolicy` (what `mc` uses) over the four canned policies on `main` today gives `readwrite` for `public` and `none` for `public-read`, `public-read-write` and `public-write`, which is exactly the bug #1086 fixes. Asserting the independent classification now would turn three of the four subtests red for a reason that has nothing to do with this PR.

### How was this change tested?

1. `go build ./...`, `gofmt -l ./minio` (no output) and `golangci-lint run -c .github/golangci.yml ./...` (no issues found).
2. `go test ./minio/...` passes.
3. `TestS3PathStyleString` fails for the right reason when the mapping breaks. Making `S3PathStyle.String()` return `"path"` for `S3PathStyleOn` gives `S3PathStyle(1).String() = "path", want "on"`.
4. Every acceptance test that goes through the modified check passes against a real MinIO stack (the four instances from `docker-compose.yml`): `TestAccS3BucketReplication_oneway_simple`, `_resync`, `_oneway_simple_update`, `_oneway_complex`, `_twoway_simple` and `_twoway_complex`.

```
go test -v ./minio -run 'TestAccS3BucketReplication_(oneway_simple|resync|oneway_simple_update|oneway_complex|twoway_simple|twoway_complex)$' -timeout 25m
```

5. The check now catches a break it used to miss. Making `S3PathStyle.String()` return `"bogus"` for the default (`auto`) case fails `TestAccS3BucketReplication_oneway_simple` with `Mismatch path style ... rule#0`. On `main` that same break passes, because both sides of the comparison come from `String()`.

### Related Issues

Resolves #1087

## Checklist for Specific Changes

### For Bug Fixes
- [x] Root cause identified and documented
- [x] Regression tests added
- [ ] Error handling follows project patterns using `NewResourceError()`
- [x] Edge cases considered and handled

## Additional Context

No provider code changed, so there is nothing to regenerate under `docs/` and no behavior change for users. `S3PathStyleAuto` is the only path style any acceptance test config uses, and it maps to `"auto"` before and after, so the check compares the same value it compared before, only from an independent source now.

Three sets of sites are left out on purpose, because work in flight owns them: the anonymous access checks in the resource and data source tests, and `aistor_policies_test.go`, all handled with #1086; and the forbidden-action list in `public_policy_test.go`, handled with #1089.

## Reviewer Focus Areas

The judgment calls are in the audit table above, in particular the rows marked fine. If any of them looks like a round-trip I talked myself out of, please push back.

### Areas of Concern
- [ ] Error handling and edge cases
- [ ] Performance implications
- [ ] Security considerations
- [ ] Documentation accuracy
- [x] Test coverage completeness

## Release Notes

Test-only change, so nothing for the release notes.

## Related PRs

This lands alongside #1094 (canned anonymous policy shapes for #1086, which also fixes the anonymous-access check this audit deferred), #1095 (per-test provider instances for #1088) and #1092 (pins the `public` boundary from #1089). #1095 edits client-access lines in the replication test file this PR touches; the hunks are far apart, so they should merge cleanly either way. Suggested order: #1094 first, #1095 last.
