### PR TITLE
docs: use absolute URLs for the PR template checklist links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ## Pull Request Checklist
 
 ### General Requirements
-- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
-- [ ] I have read the [Project Vision](./VISION.md) and understand the scope
+- [ ] I have read the [Contributing Guidelines](https://github.com/aminueza/terraform-provider-minio/blob/main/.github/CONTRIBUTING.md)
+- [ ] I have read the [Project Vision](https://github.com/aminueza/terraform-provider-minio/blob/main/.github/VISION.md) and understand the scope
 - [ ] My code follows the project's coding standards
 - [ ] I have performed a self-review of my own code
 - [ ] I have signed my commits (`git commit -s`)


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](https://github.com/aminueza/terraform-provider-minio/blob/main/.github/CONTRIBUTING.md)
- [x] I have read the [Project Vision](https://github.com/aminueza/terraform-provider-minio/blob/main/.github/VISION.md) and understand the scope
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have signed my commits (`git commit -s`)

### Testing Requirements
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new or modified resources have acceptance tests
- [ ] I have tested the changes with a real MinIO setup

### Documentation Requirements
- [ ] I have updated the documentation templates in `templates/` if needed
- [ ] I have run `task generate-docs` to update generated documentation
- [ ] I have added examples to the `examples/` directory if applicable
- [ ] I have updated the README if this is a user-facing change

### Breaking Changes
- [ ] If this is a breaking change, I have described the impact and migration path
- [ ] If this is a breaking change, I have updated the version appropriately

## Description

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes, code improvement)
- [ ] Performance improvement
- [ ] Security fix

### What does this PR do?

Currently, the first two checklist links in the PR template are relative (`./CONTRIBUTING.md` and `./VISION.md`). The template's markdown is rendered inside the pull request description, and in that context the browser resolves relative links against the page URL, not against the repository tree: from a `/pull/<number>` page, `./VISION.md` becomes `https://github.com/aminueza/terraform-provider-minio/pull/VISION.md`, which returns 404. That 404 makes it look like `.github/VISION.md` doesn't exist, even though it has been in the repository since #779. (In the blob view of the template file, the same links resolve fine, which is also why the markdown link check in Docs CI never flagged them.)

This PR replaces both links with absolute URLs, which resolve the same way everywhere the template is rendered.

| Link | Before | After |
| --- | --- | --- |
| Contributing Guidelines | `./CONTRIBUTING.md` | `https://github.com/aminueza/terraform-provider-minio/blob/main/.github/CONTRIBUTING.md` |
| Project Vision | `./VISION.md` | `https://github.com/aminueza/terraform-provider-minio/blob/main/.github/VISION.md` |

The other references to these files stay relative on purpose: `README.md` links `./.github/VISION.md` and `.github/CONTRIBUTING.md` links `./VISION.md`, and both of those are read in the blob view, where relative resolution works.

### How was this change tested?

1. Rendered the old and the new checklist lines through the same pipeline GitHub uses for PR bodies (`gh api markdown -f mode=gfm -f context=aminueza/terraform-provider-minio`): the old line comes out as `<a href="./VISION.md">`, which breaks from a `/pull/` page, while the new one carries the absolute URL.
2. `curl` on both new URLs returns HTTP 200.
3. This description was filled from the fixed template, so the two links at the top of the checklist can be verified right here.

### Related Issues

No open issue for this one; the broken link surfaced while filling this same template in #1095 (that's why the Project Vision box there is unchecked: the link led to a 404).

## Reviewer Focus Areas

### Areas of Concern
- [ ] Error handling and edge cases
- [ ] Performance implications
- [ ] Security considerations
- [x] Documentation accuracy
- [ ] Test coverage completeness
