### PR TITLE
fix: replace deprecated Read with ReadContext in all data sources

### DIFF
--- a/minio/data_source_iam_users.go
+++ b/minio/data_source_iam_users.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceIAMUsers() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists IAM users with optional filtering by name prefix and status.",
-		Read:        dataSourceIAMUsersRead,
+		ReadContext:        dataSourceIAMUsersRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"status": {
@@ -46,13 +47,13 @@ func dataSourceIAMUsers() *schema.Resource {
 	}
 }
 
-func dataSourceIAMUsersRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMUsersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	m := meta.(*S3MinioClient)
 	admin := m.S3Admin
 
-	usersMap, err := admin.ListUsers(context.Background())
+	usersMap, err := admin.ListUsers(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	prefix := strings.TrimSpace(d.Get("name_prefix").(string))

--- a/minio/data_source_minio_account_info.go
+++ b/minio/data_source_minio_account_info.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/minio/madmin-go/v4"
 )
 
 func dataSourceMinioAccountInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns storage usage and bucket information for the authenticated account.",
-		Read:        dataSourceMinioAccountInfoRead,
+		ReadContext:        dataSourceMinioAccountInfoRead,
 		Schema: map[string]*schema.Schema{
 			"account_name":  {Type: schema.TypeString, Computed: true, Description: "Name of the authenticated account."},
 			"bucket_count":  {Type: schema.TypeInt, Computed: true, Description: "Total number of buckets accessible to this account."},
@@ -33,12 +34,12 @@ func dataSourceMinioAccountInfo() *schema.Resource {
 	}
 }
 
-func dataSourceMinioAccountInfoRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioAccountInfoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	info, err := admin.AccountInfo(context.Background(), madmin.AccountOpts{})
+	info, err := admin.AccountInfo(ctx, madmin.AccountOpts{})
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/minio/data_source_minio_data_usage.go
+++ b/minio/data_source_minio_data_usage.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioDataUsage() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns cluster-wide data usage statistics including total objects, size, and per-bucket breakdown.",
-		Read:        dataSourceMinioDataUsageRead,
+		ReadContext:        dataSourceMinioDataUsageRead,
 		Schema: map[string]*schema.Schema{
 			"last_update":   {Type: schema.TypeString, Computed: true, Description: "Timestamp of last usage data update."},
 			"total_objects": {Type: schema.TypeString, Computed: true, Description: "Total object count across all buckets."},
@@ -27,12 +28,12 @@ func dataSourceMinioDataUsage() *schema.Resource {
 	}
 }
 
-func dataSourceMinioDataUsageRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioDataUsageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	info, err := admin.DataUsageInfo(context.Background())
+	info, err := admin.DataUsageInfo(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/minio/data_source_minio_iam_group.go
+++ b/minio/data_source_minio_iam_group.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceIAMGroup() *schema.Resource {
 	return &schema.Resource{
 		Description: "Retrieves information about a specific IAM group by name.",
-		Read:        dataSourceIAMGroupRead,
+		ReadContext:        dataSourceIAMGroupRead,
 		Schema: map[string]*schema.Schema{
 			"name":   {Type: schema.TypeString, Required: true},
 			"status": {Type: schema.TypeString, Computed: true},
@@ -24,13 +25,13 @@ func dataSourceIAMGroup() *schema.Resource {
 	}
 }
 
-func dataSourceIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
 	name := d.Get("name").(string)
-	desc, err := admin.GetGroupDescription(context.Background(), name)
+	desc, err := admin.GetGroupDescription(ctx, name)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(name)

--- a/minio/data_source_minio_iam_groups.go
+++ b/minio/data_source_minio_iam_groups.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceIAMGroups() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all IAM groups with optional name prefix filtering.",
-		Read:        dataSourceIAMGroupsRead,
+		ReadContext:        dataSourceIAMGroupsRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"groups": {
@@ -35,12 +36,12 @@ func dataSourceIAMGroups() *schema.Resource {
 	}
 }
 
-func dataSourceIAMGroupsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	groupNames, err := admin.ListGroups(context.Background())
+	groupNames, err := admin.ListGroups(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	prefix := strings.TrimSpace(d.Get("name_prefix").(string))
@@ -51,7 +52,7 @@ func dataSourceIAMGroupsRead(d *schema.ResourceData, meta interface{}) error {
 			continue
 		}
 
-		desc, err := admin.GetGroupDescription(context.Background(), name)
+		desc, err := admin.GetGroupDescription(ctx, name)
 		if err != nil {
 			continue
 		}

--- a/minio/data_source_minio_iam_policy.go
+++ b/minio/data_source_minio_iam_policy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceIAMPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Retrieves an existing IAM policy by name.",
-		Read:        dataSourceIAMPolicyRead,
+		ReadContext:        dataSourceIAMPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"name":   {Type: schema.TypeString, Required: true},
 			"policy": {Type: schema.TypeString, Computed: true},
@@ -17,13 +18,13 @@ func dataSourceIAMPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceIAMPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
 	name := d.Get("name").(string)
-	info, err := admin.InfoCannedPolicy(context.Background(), name)
+	info, err := admin.InfoCannedPolicy(ctx, name)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(name)

--- a/minio/data_source_minio_iam_policy_document.go
+++ b/minio/data_source_minio_iam_policy_document.go
@@ -1,12 +1,14 @@
 package minio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -24,7 +26,7 @@ func dataSourceMinioIAMPolicyDocument() *schema.Resource {
 
 	return &schema.Resource{
 		Description: "Generates an IAM policy document in JSON format for use with IAM policies.",
-		Read:        dataSourceMinioIAMPolicyDocumentRead,
+		ReadContext:        dataSourceMinioIAMPolicyDocumentRead,
 
 		Schema: map[string]*schema.Schema{
 			"override_json": {
@@ -108,12 +110,12 @@ func dataSourceMinioIAMPolicyDocument() *schema.Resource {
 	}
 }
 
-func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioIAMPolicyDocumentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	mergedDoc := &IAMPolicyDoc{}
 
 	if sourceJSON, hasSourceJSON := d.GetOk("source_json"); hasSourceJSON {
 		if err := json.Unmarshal([]byte(sourceJSON.(string)), mergedDoc); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -138,7 +140,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 
 			if sid, ok := cfgStmt["sid"]; ok {
 				if _, ok := sidMap[sid.(string)]; ok {
-					return fmt.Errorf("found duplicate sid (%s), either remove the sid or ensure the sid is unique across all statements", sid.(string))
+					return diag.Errorf("found duplicate sid (%s), either remove the sid or ensure the sid is unique across all statements", sid.(string))
 				}
 				stmt.Sid = sid.(string)
 				if len(stmt.Sid) > 0 {
@@ -156,7 +158,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 					minioDecodePolicyStringList(resources), doc.Version,
 				)
 				if err != nil {
-					return fmt.Errorf("error reading resources: %s", err)
+					return diag.Errorf("error reading resources: %s", err)
 				}
 			}
 
@@ -166,7 +168,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 					minioDecodePolicyStringList(notResources), doc.Version,
 				)
 				if err != nil {
-					return fmt.Errorf("error reading not_resources: %s", err)
+					return diag.Errorf("error reading not_resources: %s", err)
 				}
 			}
 
@@ -196,7 +198,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 			}
 
 			if resourcesSet && notResourcesSet {
-				return fmt.Errorf("cannot set both resources and not_resources in the same statement")
+				return diag.Errorf("cannot set both resources and not_resources in the same statement")
 			}
 
 			principalString := cfgStmt["principal"].(string)
@@ -207,7 +209,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 			}
 
 			if principalString != "" && notPrincipalString != "" {
-				return fmt.Errorf("cannot set both principal and not_principal in the same statement")
+				return diag.Errorf("cannot set both principal and not_principal in the same statement")
 			}
 
 			if principalString != "" {
@@ -222,7 +224,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 				var err error
 				stmt.Conditions, err = dataSourceMinioIAMPolicyDocumentMakeConditions(conditions, doc.Version)
 				if err != nil {
-					return fmt.Errorf("error reading condition: %s", err)
+					return diag.Errorf("error reading condition: %s", err)
 				}
 			}
 
@@ -238,7 +240,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 	if overrideJSON, hasOverrideJSON := d.GetOk("override_json"); hasOverrideJSON {
 		overrideDoc := &IAMPolicyDoc{}
 		if err := json.Unmarshal([]byte(overrideJSON.(string)), overrideDoc); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		mergedDoc.merge(overrideDoc)
@@ -246,7 +248,7 @@ func dataSourceMinioIAMPolicyDocumentRead(d *schema.ResourceData, meta interface
 
 	jsonDoc, err := json.MarshalIndent(mergedDoc, "", "  ")
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	jsonString := string(jsonDoc)
 

--- a/minio/data_source_minio_iam_service_accounts.go
+++ b/minio/data_source_minio_iam_service_accounts.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceIAMServiceAccounts() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists service accounts (access keys) for a specific IAM user.",
-		Read:        dataSourceIAMServiceAccountsRead,
+		ReadContext:        dataSourceIAMServiceAccountsRead,
 		Schema: map[string]*schema.Schema{
 			"user": {Type: schema.TypeString, Required: true, Description: "IAM user name to list service accounts for."},
 			"service_accounts": {
@@ -27,13 +28,13 @@ func dataSourceIAMServiceAccounts() *schema.Resource {
 	}
 }
 
-func dataSourceIAMServiceAccountsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMServiceAccountsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
 	user := d.Get("user").(string)
-	resp, err := admin.ListServiceAccounts(context.Background(), user)
+	resp, err := admin.ListServiceAccounts(ctx, user)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var out []map[string]interface{}

--- a/minio/data_source_minio_iam_user_policies.go
+++ b/minio/data_source_minio_iam_user_policies.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceIAMUserPolicies() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns all IAM policies effective for a user, including policies attached directly and inherited from group membership.",
-		Read:        dataSourceIAMUserPoliciesRead,
+		ReadContext:        dataSourceIAMUserPoliciesRead,
 		Schema: map[string]*schema.Schema{
 			"name": {Type: schema.TypeString, Required: true},
 			"direct_policies": {
@@ -40,14 +41,13 @@ func dataSourceIAMUserPolicies() *schema.Resource {
 	}
 }
 
-func dataSourceIAMUserPoliciesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIAMUserPoliciesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
-	ctx := context.Background()
 
 	name := d.Get("name").(string)
 	info, err := admin.GetUserInfo(ctx, name)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(name)

--- a/minio/data_source_minio_ilm_policy.go
+++ b/minio/data_source_minio_ilm_policy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioILMPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the ILM lifecycle rules configured on an existing S3 bucket.",
-		Read:        dataSourceMinioILMPolicyRead,
+		ReadContext:        dataSourceMinioILMPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"rules": {
@@ -43,13 +44,13 @@ func dataSourceMinioILMPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceMinioILMPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioILMPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	cfg, err := client.GetBucketLifecycle(context.Background(), bucket)
+	cfg, err := client.GetBucketLifecycle(ctx, bucket)
 	if err != nil {
 		_ = d.Set("rules", []interface{}{})
 		return nil

--- a/minio/data_source_minio_ilm_tier_stats.go
+++ b/minio/data_source_minio_ilm_tier_stats.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioILMTierStats() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns transition statistics for all configured ILM storage tiers including object counts and total bytes.",
-		Read:        dataSourceMinioILMTierStatsRead,
+		ReadContext:        dataSourceMinioILMTierStatsRead,
 		Schema: map[string]*schema.Schema{
 			"tiers": {
 				Type:     schema.TypeList,
@@ -30,12 +31,12 @@ func dataSourceMinioILMTierStats() *schema.Resource {
 	}
 }
 
-func dataSourceMinioILMTierStatsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioILMTierStatsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	tierInfos, err := admin.TierStats(context.Background())
+	tierInfos, err := admin.TierStats(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/minio/data_source_minio_ilm_tiers.go
+++ b/minio/data_source_minio_ilm_tiers.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioILMTiers() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all configured ILM remote storage tiers.",
-		Read:        dataSourceMinioILMTiersRead,
+		ReadContext:        dataSourceMinioILMTiersRead,
 		Schema: map[string]*schema.Schema{
 			"tiers": {
 				Type:     schema.TypeList,
@@ -31,12 +32,12 @@ func dataSourceMinioILMTiers() *schema.Resource {
 	}
 }
 
-func dataSourceMinioILMTiersRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioILMTiersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	tiers, err := admin.ListTiers(context.Background())
+	tiers, err := admin.ListTiers(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var out []map[string]interface{}

--- a/minio/data_source_minio_s3_bucket.go
+++ b/minio/data_source_minio_s3_bucket.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3Bucket() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads properties of an existing S3 bucket including versioning, region, and object lock status.",
-		Read:        dataSourceMinioS3BucketRead,
+		ReadContext:        dataSourceMinioS3BucketRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":             {Type: schema.TypeString, Required: true},
 			"region":             {Type: schema.TypeString, Computed: true},
@@ -23,17 +24,16 @@ func dataSourceMinioS3Bucket() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
 	bucket := d.Get("bucket").(string)
-	ctx := context.Background()
 
 	d.SetId(bucket)
 
 	region, err := client.GetBucketLocation(ctx, bucket)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	_ = d.Set("region", region)
 

--- a/minio/data_source_minio_s3_bucket_cors_config.go
+++ b/minio/data_source_minio_s3_bucket_cors_config.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketCorsConfig() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the CORS configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketCorsConfigRead,
+		ReadContext:        dataSourceMinioS3BucketCorsConfigRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"cors_rule": {
@@ -29,13 +30,13 @@ func dataSourceMinioS3BucketCorsConfig() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketCorsConfigRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketCorsConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	cfg, err := client.GetBucketCors(context.Background(), bucket)
+	cfg, err := client.GetBucketCors(ctx, bucket)
 	if err != nil || cfg == nil {
 		_ = d.Set("cors_rule", []interface{}{})
 		return nil

--- a/minio/data_source_minio_s3_bucket_encryption.go
+++ b/minio/data_source_minio_s3_bucket_encryption.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketEncryption() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the server-side encryption configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketEncryptionRead,
+		ReadContext:        dataSourceMinioS3BucketEncryptionRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":            {Type: schema.TypeString, Required: true},
 			"encryption_type":   {Type: schema.TypeString, Computed: true},
@@ -18,13 +19,13 @@ func dataSourceMinioS3BucketEncryption() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketEncryptionRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketEncryptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	cfg, err := client.GetBucketEncryption(context.Background(), bucket)
+	cfg, err := client.GetBucketEncryption(ctx, bucket)
 	if err != nil {
 		_ = d.Set("encryption_type", "")
 		return nil

--- a/minio/data_source_minio_s3_bucket_object_lock_configuration.go
+++ b/minio/data_source_minio_s3_bucket_object_lock_configuration.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/minio/minio-go/v7"
 )
 
 func dataSourceMinioS3BucketObjectLockConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the object lock configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketObjectLockConfigurationRead,
+		ReadContext:        dataSourceMinioS3BucketObjectLockConfigurationRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":              {Type: schema.TypeString, Required: true},
 			"object_lock_enabled": {Type: schema.TypeString, Computed: true},
@@ -39,20 +40,20 @@ func dataSourceMinioS3BucketObjectLockConfiguration() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketObjectLockConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketObjectLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	objectLockStatus, mode, validity, unit, err := client.GetObjectLockConfig(context.Background(), bucket)
+	objectLockStatus, mode, validity, unit, err := client.GetObjectLockConfig(ctx, bucket)
 	if err != nil {
 		if strings.Contains(err.Error(), "Object Lock configuration does not exist") {
 			_ = d.Set("object_lock_enabled", "")
 			_ = d.Set("rule", []interface{}{})
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	_ = d.Set("object_lock_enabled", objectLockStatus)

--- a/minio/data_source_minio_s3_bucket_policy.go
+++ b/minio/data_source_minio_s3_bucket_policy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the bucket policy document for an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketPolicyRead,
+		ReadContext:        dataSourceMinioS3BucketPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"policy": {Type: schema.TypeString, Computed: true},
@@ -17,11 +18,11 @@ func dataSourceMinioS3BucketPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
 	bucket := d.Get("bucket").(string)
-	policy, err := client.GetBucketPolicy(context.Background(), bucket)
+	policy, err := client.GetBucketPolicy(ctx, bucket)
 	if err != nil {
 		d.SetId(bucket)
 		_ = d.Set("policy", "")

--- a/minio/data_source_minio_s3_bucket_quota.go
+++ b/minio/data_source_minio_s3_bucket_quota.go
@@ -2,15 +2,15 @@ package minio
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketQuota() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the quota configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketQuotaRead,
+		ReadContext:        dataSourceMinioS3BucketQuotaRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"quota":  {Type: schema.TypeInt, Computed: true},
@@ -19,13 +19,13 @@ func dataSourceMinioS3BucketQuota() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketQuotaRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketQuotaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	bucketQuota, err := admin.GetBucketQuota(context.Background(), bucket)
+	bucketQuota, err := admin.GetBucketQuota(ctx, bucket)
 	if err != nil || bucketQuota.Size == 0 {
 		_ = d.Set("quota", 0)
 		_ = d.Set("type", "")
@@ -34,7 +34,7 @@ func dataSourceMinioS3BucketQuotaRead(d *schema.ResourceData, meta interface{}) 
 
 	quotaVal, ok := SafeUint64ToInt64(bucketQuota.Size)
 	if !ok {
-		return fmt.Errorf("quota value overflows int64: %d", bucketQuota.Size)
+		return diag.Errorf("quota value overflows int64: %d", bucketQuota.Size)
 	}
 	_ = d.Set("quota", int(quotaVal))
 	_ = d.Set("type", string(bucketQuota.Type))

--- a/minio/data_source_minio_s3_bucket_replication.go
+++ b/minio/data_source_minio_s3_bucket_replication.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/minio/minio-go/v7/pkg/replication"
 )
 
 func dataSourceMinioS3BucketReplication() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the replication configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketReplicationRead,
+		ReadContext:        dataSourceMinioS3BucketReplicationRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"rule": {
@@ -51,12 +52,11 @@ func dataSourceMinioS3BucketReplication() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketReplicationRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketReplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	m := meta.(*S3MinioClient)
 	client := m.S3Client
 	admin := m.S3Admin
 	bucket := d.Get("bucket").(string)
-	ctx := context.Background()
 
 	d.SetId(bucket)
 

--- a/minio/data_source_minio_s3_bucket_replication_metrics.go
+++ b/minio/data_source_minio_s3_bucket_replication_metrics.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketReplicationMetrics() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads replication health metrics for a bucket: pending, failed, replicated and queued sizes and counts. Useful for monitoring replication lag. Counts and sizes are returned as strings to represent uint64 values safely.",
-		Read:        dataSourceMinioS3BucketReplicationMetricsRead,
+		ReadContext:        dataSourceMinioS3BucketReplicationMetricsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":           {Type: schema.TypeString, Required: true},
 			"pending_size":     {Type: schema.TypeString, Computed: true},
@@ -27,11 +28,10 @@ func dataSourceMinioS3BucketReplicationMetrics() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketReplicationMetricsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketReplicationMetricsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
 	bucket := d.Get("bucket").(string)
-	ctx := context.Background()
 
 	d.SetId(bucket)
 

--- a/minio/data_source_minio_s3_bucket_replication_status.go
+++ b/minio/data_source_minio_s3_bucket_replication_status.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketReplicationStatus() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads replication status and metrics for a bucket including rule count, replicated/pending sizes, and error counts.",
-		Read:        dataSourceMinioS3BucketReplicationStatusRead,
+		ReadContext:        dataSourceMinioS3BucketReplicationStatusRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":           {Type: schema.TypeString, Required: true},
 			"rule_count":       {Type: schema.TypeInt, Computed: true},
@@ -34,11 +35,10 @@ func dataSourceMinioS3BucketReplicationStatus() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketReplicationStatusRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketReplicationStatusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
 	bucket := d.Get("bucket").(string)
-	ctx := context.Background()
 
 	d.SetId(bucket)
 

--- a/minio/data_source_minio_s3_bucket_retention.go
+++ b/minio/data_source_minio_s3_bucket_retention.go
@@ -5,12 +5,13 @@ import (
 	"math"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketRetention() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the object lock retention configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketRetentionRead,
+		ReadContext:        dataSourceMinioS3BucketRetentionRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":          {Type: schema.TypeString, Required: true},
 			"mode":            {Type: schema.TypeString, Computed: true},
@@ -20,13 +21,13 @@ func dataSourceMinioS3BucketRetention() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketRetentionRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketRetentionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
 	d.SetId(bucket)
 
-	mode, validity, unit, err := client.GetBucketObjectLockConfig(context.Background(), bucket)
+	mode, validity, unit, err := client.GetBucketObjectLockConfig(ctx, bucket)
 	if err != nil || mode == nil || validity == nil || unit == nil {
 		_ = d.Set("mode", "")
 		_ = d.Set("unit", "")

--- a/minio/data_source_minio_s3_bucket_tags.go
+++ b/minio/data_source_minio_s3_bucket_tags.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketTags() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads tags from an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketTagsRead,
+		ReadContext:        dataSourceMinioS3BucketTagsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"tags": {
@@ -21,11 +22,11 @@ func dataSourceMinioS3BucketTags() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketTagsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketTagsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
 	bucket := d.Get("bucket").(string)
-	tagging, err := client.GetBucketTagging(context.Background(), bucket)
+	tagging, err := client.GetBucketTagging(ctx, bucket)
 	if err != nil {
 		d.SetId(bucket)
 		_ = d.Set("tags", map[string]string{})

--- a/minio/data_source_minio_s3_bucket_versioning.go
+++ b/minio/data_source_minio_s3_bucket_versioning.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3BucketVersioning() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the versioning configuration of an existing S3 bucket.",
-		Read:        dataSourceMinioS3BucketVersioningRead,
+		ReadContext:        dataSourceMinioS3BucketVersioningRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":    {Type: schema.TypeString, Required: true},
 			"enabled":   {Type: schema.TypeBool, Computed: true},
@@ -18,13 +19,13 @@ func dataSourceMinioS3BucketVersioning() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketVersioningRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketVersioningRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Get("bucket").(string)
 
-	cfg, err := client.GetBucketVersioning(context.Background(), bucket)
+	cfg, err := client.GetBucketVersioning(ctx, bucket)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(bucket)

--- a/minio/data_source_minio_s3_buckets.go
+++ b/minio/data_source_minio_s3_buckets.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioS3Buckets() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all S3 buckets with optional name prefix filtering.",
-		Read:        dataSourceMinioS3BucketsRead,
+		ReadContext:        dataSourceMinioS3BucketsRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"buckets": {
@@ -29,12 +30,12 @@ func dataSourceMinioS3Buckets() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3BucketsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3BucketsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
-	buckets, err := client.ListBuckets(context.Background())
+	buckets, err := client.ListBuckets(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	prefix := strings.TrimSpace(d.Get("name_prefix").(string))

--- a/minio/data_source_minio_s3_objects.go
+++ b/minio/data_source_minio_s3_objects.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	miniogo "github.com/minio/minio-go/v7"
 )
 
 func dataSourceMinioS3Objects() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists objects in an S3 bucket with optional prefix, delimiter, and max keys filtering.",
-		Read:        dataSourceMinioS3ObjectsRead,
+		ReadContext:        dataSourceMinioS3ObjectsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {
 				Type:        schema.TypeString,
@@ -53,9 +54,8 @@ func dataSourceMinioS3Objects() *schema.Resource {
 	}
 }
 
-func dataSourceMinioS3ObjectsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioS3ObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
-	ctx := context.Background()
 
 	bucket := d.Get("bucket").(string)
 	prefix := d.Get("prefix").(string)
@@ -73,7 +73,7 @@ func dataSourceMinioS3ObjectsRead(d *schema.ResourceData, meta interface{}) erro
 
 	for obj := range client.ListObjects(ctx, bucket, opts) {
 		if obj.Err != nil {
-			return obj.Err
+			return diag.FromErr(obj.Err)
 		}
 
 		if delimiter != "" && obj.Key == "" {

--- a/minio/data_source_minio_server_info.go
+++ b/minio/data_source_minio_server_info.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioServerInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads MinIO server information including version, deployment ID, and storage metrics.",
-		Read:        dataSourceMinioServerInfoRead,
+		ReadContext:        dataSourceMinioServerInfoRead,
 		Schema: map[string]*schema.Schema{
 			"version": {
 				Type:        schema.TypeString,
@@ -137,13 +138,13 @@ func dataSourceMinioServerInfo() *schema.Resource {
 	}
 }
 
-func dataSourceMinioServerInfoRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioServerInfoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	m := meta.(*S3MinioClient)
 	admin := m.S3Admin
 
-	info, err := admin.ServerInfo(context.Background())
+	info, err := admin.ServerInfo(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))

--- a/minio/data_source_minio_storage_info.go
+++ b/minio/data_source_minio_storage_info.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 func dataSourceMinioStorageInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns disk and drive status for all MinIO server nodes. Essential for capacity planning and health monitoring.",
-		Read:        dataSourceMinioStorageInfoRead,
+		ReadContext:        dataSourceMinioStorageInfoRead,
 		Schema: map[string]*schema.Schema{
 			"disk_count":      {Type: schema.TypeInt, Computed: true, Description: "Total number of disks."},
 			"online_disks":    {Type: schema.TypeInt, Computed: true, Description: "Number of disks online."},
@@ -39,12 +40,12 @@ func dataSourceMinioStorageInfo() *schema.Resource {
 	}
 }
 
-func dataSourceMinioStorageInfoRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMinioStorageInfoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	admin := meta.(*S3MinioClient).S3Admin
 
-	info, err := admin.StorageInfo(context.Background())
+	info, err := admin.StorageInfo(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))


### PR DESCRIPTION
## What changed

Converted all 28 data source Read functions from the deprecated `Read` field to `ReadContext`. Each function now accepts `context.Context` as its first parameter and returns `diag.Diagnostics` instead of `error`.

## Why

golangci-lint (via staticcheck SA1019) now flags the deprecated `Read` field, causing 28 lint failures that block CI across all branches and PRs. The Terraform Plugin SDK v2 deprecates `Read` in favor of `ReadContext`, which supports request cancellation and warning diagnostics.

## Where to start

The diff is mechanical and uniform across all 28 data source files:

- `Read:` → `ReadContext:` in the resource definition
- Function signature gains `ctx context.Context` parameter; return type changes to `diag.Diagnostics`
- `return err` → `return diag.FromErr(err)`; `return fmt.Errorf(...)` → `return diag.Errorf(...)`
- `context.Background()` calls replaced with the `ctx` parameter

No behavior change for callers — Terraform supplies the context through the framework.

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- `golangci-lint run` reports 0 issues (previously 28 SA1019 errors)