### PR TITLE
ci(deps): give the compose golang tag one owner, the toolchain workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,9 @@ updates:
     commit-message:
       prefix: "docker(deps):"
     open-pull-requests-limit: 5
+    ignore:
+      # The golang image in docker-compose.yml is generated from the toolchain
+      # directive in go.mod by .github/workflows/update-go-toolchain.yml, which
+      # rewrites that line every Monday. Managing it here as well means the two
+      # take turns overwriting each other.
+      - dependency-name: "golang"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       retries: 6
       start_period: 10s
   test:
-    image: golang:1.27.0
+    image: golang:1.26.7
     volumes:
       - .:/app
       - go-modules:/go/pkg/mod


### PR DESCRIPTION
## What changed

Two things, both about who owns the `image: golang:<tag>` line in `docker-compose.yml`:

1. `.github/dependabot.yml` gets `ignore: - dependency-name: "golang"` on the `docker-compose` ecosystem.
2. `docker-compose.yml` goes back to `golang:1.26.7`, matching `go.mod`'s `toolchain go1.26.7`.

## Why

`.github/workflows/update-go-toolchain.yml` runs `go get toolchain@patch` every Monday and then `sed`s that image tag to match the new `toolchain` directive. Dependabot bumps the same line to the newest published tag. Their policies differ: `toolchain@patch` stays inside the current minor, Dependabot follows the latest release. So they revert each other, and they collide as PRs too, which is why #1108 had to be rebased by hand onto #1109.

The compose tag is the only build input in the repo where the Go version is not derived from `go.mod`. All eight `setup-go` steps across lint, build, docs, the vulnerability scan and the release use `go-version-file: "go.mod"`; only the two acceptance workflows go through `docker compose run --rm test`. Letting Dependabot own it means the acceptance suite runs on a Go minor the module has not adopted, which is the state `main` is in right now: `toolchain go1.26.7` against `image: golang:1.27.0`.

That state does not fix itself in any predictable way. The workflow's `sed` step is gated on `steps.diff.outputs.changed == 'true'`, which is set by `git diff --quiet go.mod go.sum`, so it only runs when `go get toolchain@patch` or the `go mod tidy` beside it moves one of those two files. go1.26.7 is already the newest 1.26 patch, so barring an incidental `go.sum` change nothing reconciles the tag until go1.26.8 ships. Hunk 2 does it here instead.

## Where to start

The `ignore` entry, and whether it is the right lever. The alternatives were dropping the `docker-compose` ecosystem entirely, or deleting the `sed` step and letting the image drive `go.mod`. The narrow ignore keeps `go.mod` as the single source of truth while Dependabot goes on bumping the images it demonstrably does bump: `dexidp/dex` in #1079 and `redis` in #1080. It has never opened one for `minio/minio` or `osixia/openldap`. Those two have different causes: `minio/minio` is not an `image:` value at all but the `x-minio-image: &minio_image` anchor on line 3, dereferenced by six services, and it has its own `sed` in `test-latest-minio.yml`; `osixia/openldap:1.5.0` is a plain image line whose silence is unexplained.

The `ignore` is deliberately unconditional rather than scoped with `update-types`. Dependabot reads `1.26.6 -> 1.26.7` as a patch and `1.26.6 -> 1.27.0` as a minor: ignoring only minors leaves it duplicating the workflow's in-minor PR, and ignoring only patches leaves the cross-minor drift this PR exists to stop.

One consequence worth stating: `toolchain@patch` never leaves the current minor, and in this repo's history Dependabot's `gomod` ecosystem has only ever bumped module requirements, never the `go`/`toolchain` directives. So after this, nothing moves the provider from Go 1.26 to 1.27 on its own. That becomes a deliberate change, and it needs to happen before 1.26 leaves the support window.

## Verification

CI is green on this commit: Lint & Security in 2m4s, the acceptance Test job in 13m12s, all other jobs passing. The other consumer of that image, `test-latest-minio.yml`, runs only on a schedule or a manual dispatch, so it is not exercised by a PR.

Dependabot config only takes effect once merged, so the rule cannot be exercised before then. A rule that matches nothing fails silently, so the check afterwards is worth doing: Insights → Dependency graph → Dependabot → the `docker-compose` row, where the next run should list `golang` as skipped. The evidence that it will match is #1108's own title, `docker(deps): bump golang from 1.26.6 to 1.27.0`, since Dependabot builds that from the same dependency name the `ignore` matches on.

## Follow-up, not here

The `sed` step being gated on `changed` is what let the two files drift in the first place. Reconciling the tag on every run, or comparing it against `go.mod` and opening a PR when they diverge, would make this unrepeatable. That is a change to `update-go-toolchain.yml`, which this PR deliberately does not touch.
