### PR TITLE
style: gofmt the data sources and enforce formatting in CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,7 +153,7 @@ go build -o terraform-provider-minio
 
 We follow these coding standards:
 
-- **Formatting**: Use `gofmt` (standard Go formatting)
+- **Formatting**: Use `gofmt -s` (CI enforces it through golangci-lint, whose `gofmt` formatter simplifies by default)
 - **Linting**: Configured via `.github/golangci.yml`
 - **Error Handling**: Always use `NewResourceError()` from `minio/error.go`
 - **Documentation**: Include comments for public functions and complex logic

--- a/.github/golangci.yml
+++ b/.github/golangci.yml
@@ -44,6 +44,15 @@ linters:
         - fieldalignment
         - shadow
 
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      # Pinned rather than left to the default, so the config states what CI
+      # actually enforces: gofmt -s, not plain gofmt.
+      simplify: true
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ if !ok {
 | `task install`       | Build and install to local Terraform plugins directory |
 | `task test`          | Run all acceptance tests via Docker Compose            |
 | `task generate-docs` | Regenerate documentation from templates                |
-| `golangci-lint run`  | Run configured linters                                 |
+| `task lint`          | Run configured linters                                 |
 
 **Run specific tests:**
 
@@ -105,8 +105,8 @@ go test ./minio/...
 
 ## Coding Style
 
-- **Formatting:** Use `gofmt` (standard Go formatting)
-- **Linting:** Configured via `.github/golangci.yml` with errcheck, govet, ineffassign, staticcheck, unused, bodyclose, noctx, unconvert
+- **Formatting:** Use `gofmt -s` (CI enforces it through golangci-lint, whose `gofmt` formatter simplifies by default)
+- **Linting:** Configured via `.github/golangci.yml` with errcheck, govet, ineffassign, staticcheck, unused, bodyclose, noctx, unconvert, and the gofmt formatter
 - **Imports:** Group standard library, external packages, then internal packages
 - **Naming:**
   - Resources: `resource_minio_<name>.go` → `resourceMinio<Name>()`
@@ -253,7 +253,7 @@ func minioCreateX(ctx context.Context, d *schema.ResourceData, meta interface{})
 - Provide clear description of changes
 - Ensure all tests pass
 - Update documentation templates if adding/changing attributes
-- Run `golangci-lint run` and fix any issues
+- Run `task lint` and fix any issues
 
 ---
 

--- a/minio/data_source_iam_users.go
+++ b/minio/data_source_iam_users.go
@@ -6,15 +6,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceIAMUsers() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists IAM users with optional filtering by name prefix and status.",
-		ReadContext:        dataSourceIAMUsersRead,
+		ReadContext: dataSourceIAMUsersRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"status": {

--- a/minio/data_source_minio_account_info.go
+++ b/minio/data_source_minio_account_info.go
@@ -5,15 +5,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/madmin-go/v4"
 )
 
 func dataSourceMinioAccountInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns storage usage and bucket information for the authenticated account.",
-		ReadContext:        dataSourceMinioAccountInfoRead,
+		ReadContext: dataSourceMinioAccountInfoRead,
 		Schema: map[string]*schema.Schema{
 			"account_name":  {Type: schema.TypeString, Computed: true, Description: "Name of the authenticated account."},
 			"bucket_count":  {Type: schema.TypeInt, Computed: true, Description: "Total number of buckets accessible to this account."},

--- a/minio/data_source_minio_data_usage.go
+++ b/minio/data_source_minio_data_usage.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioDataUsage() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns cluster-wide data usage statistics including total objects, size, and per-bucket breakdown.",
-		ReadContext:        dataSourceMinioDataUsageRead,
+		ReadContext: dataSourceMinioDataUsageRead,
 		Schema: map[string]*schema.Schema{
 			"last_update":   {Type: schema.TypeString, Computed: true, Description: "Timestamp of last usage data update."},
 			"total_objects": {Type: schema.TypeString, Computed: true, Description: "Total object count across all buckets."},

--- a/minio/data_source_minio_iam_group.go
+++ b/minio/data_source_minio_iam_group.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceIAMGroup() *schema.Resource {
 	return &schema.Resource{
 		Description: "Retrieves information about a specific IAM group by name.",
-		ReadContext:        dataSourceIAMGroupRead,
+		ReadContext: dataSourceIAMGroupRead,
 		Schema: map[string]*schema.Schema{
 			"name":   {Type: schema.TypeString, Required: true},
 			"status": {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_iam_groups.go
+++ b/minio/data_source_minio_iam_groups.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceIAMGroups() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all IAM groups with optional name prefix filtering.",
-		ReadContext:        dataSourceIAMGroupsRead,
+		ReadContext: dataSourceIAMGroupsRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"groups": {

--- a/minio/data_source_minio_iam_policy.go
+++ b/minio/data_source_minio_iam_policy.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceIAMPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Retrieves an existing IAM policy by name.",
-		ReadContext:        dataSourceIAMPolicyRead,
+		ReadContext: dataSourceIAMPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"name":   {Type: schema.TypeString, Required: true},
 			"policy": {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_iam_policy_document.go
+++ b/minio/data_source_minio_iam_policy_document.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/minio/minio-go/v7/pkg/set"
 )
@@ -26,7 +26,7 @@ func dataSourceMinioIAMPolicyDocument() *schema.Resource {
 
 	return &schema.Resource{
 		Description: "Generates an IAM policy document in JSON format for use with IAM policies.",
-		ReadContext:        dataSourceMinioIAMPolicyDocumentRead,
+		ReadContext: dataSourceMinioIAMPolicyDocumentRead,
 
 		Schema: map[string]*schema.Schema{
 			"override_json": {

--- a/minio/data_source_minio_iam_service_accounts.go
+++ b/minio/data_source_minio_iam_service_accounts.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceIAMServiceAccounts() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists service accounts (access keys) for a specific IAM user.",
-		ReadContext:        dataSourceIAMServiceAccountsRead,
+		ReadContext: dataSourceIAMServiceAccountsRead,
 		Schema: map[string]*schema.Schema{
 			"user": {Type: schema.TypeString, Required: true, Description: "IAM user name to list service accounts for."},
 			"service_accounts": {

--- a/minio/data_source_minio_iam_user_policies.go
+++ b/minio/data_source_minio_iam_user_policies.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceIAMUserPolicies() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns all IAM policies effective for a user, including policies attached directly and inherited from group membership.",
-		ReadContext:        dataSourceIAMUserPoliciesRead,
+		ReadContext: dataSourceIAMUserPoliciesRead,
 		Schema: map[string]*schema.Schema{
 			"name": {Type: schema.TypeString, Required: true},
 			"direct_policies": {

--- a/minio/data_source_minio_ilm_policy.go
+++ b/minio/data_source_minio_ilm_policy.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioILMPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the ILM lifecycle rules configured on an existing S3 bucket.",
-		ReadContext:        dataSourceMinioILMPolicyRead,
+		ReadContext: dataSourceMinioILMPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"rules": {

--- a/minio/data_source_minio_ilm_tier_stats.go
+++ b/minio/data_source_minio_ilm_tier_stats.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioILMTierStats() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns transition statistics for all configured ILM storage tiers including object counts and total bytes.",
-		ReadContext:        dataSourceMinioILMTierStatsRead,
+		ReadContext: dataSourceMinioILMTierStatsRead,
 		Schema: map[string]*schema.Schema{
 			"tiers": {
 				Type:     schema.TypeList,

--- a/minio/data_source_minio_ilm_tiers.go
+++ b/minio/data_source_minio_ilm_tiers.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioILMTiers() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all configured ILM remote storage tiers.",
-		ReadContext:        dataSourceMinioILMTiersRead,
+		ReadContext: dataSourceMinioILMTiersRead,
 		Schema: map[string]*schema.Schema{
 			"tiers": {
 				Type:     schema.TypeList,

--- a/minio/data_source_minio_s3_bucket.go
+++ b/minio/data_source_minio_s3_bucket.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3Bucket() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads properties of an existing S3 bucket including versioning, region, and object lock status.",
-		ReadContext:        dataSourceMinioS3BucketRead,
+		ReadContext: dataSourceMinioS3BucketRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":             {Type: schema.TypeString, Required: true},
 			"region":             {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_cors_config.go
+++ b/minio/data_source_minio_s3_bucket_cors_config.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketCorsConfig() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the CORS configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketCorsConfigRead,
+		ReadContext: dataSourceMinioS3BucketCorsConfigRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"cors_rule": {

--- a/minio/data_source_minio_s3_bucket_encryption.go
+++ b/minio/data_source_minio_s3_bucket_encryption.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketEncryption() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the server-side encryption configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketEncryptionRead,
+		ReadContext: dataSourceMinioS3BucketEncryptionRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":            {Type: schema.TypeString, Required: true},
 			"encryption_type":   {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_object_lock_configuration.go
+++ b/minio/data_source_minio_s3_bucket_object_lock_configuration.go
@@ -5,15 +5,15 @@ import (
 	"math"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/minio-go/v7"
 )
 
 func dataSourceMinioS3BucketObjectLockConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the object lock configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketObjectLockConfigurationRead,
+		ReadContext: dataSourceMinioS3BucketObjectLockConfigurationRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":              {Type: schema.TypeString, Required: true},
 			"object_lock_enabled": {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_policy.go
+++ b/minio/data_source_minio_s3_bucket_policy.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the bucket policy document for an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketPolicyRead,
+		ReadContext: dataSourceMinioS3BucketPolicyRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"policy": {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_quota.go
+++ b/minio/data_source_minio_s3_bucket_quota.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketQuota() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the quota configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketQuotaRead,
+		ReadContext: dataSourceMinioS3BucketQuotaRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"quota":  {Type: schema.TypeInt, Computed: true},

--- a/minio/data_source_minio_s3_bucket_replication.go
+++ b/minio/data_source_minio_s3_bucket_replication.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/minio/minio-go/v7/pkg/replication"
 )
 
 func dataSourceMinioS3BucketReplication() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the replication configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketReplicationRead,
+		ReadContext: dataSourceMinioS3BucketReplicationRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"rule": {

--- a/minio/data_source_minio_s3_bucket_replication_metrics.go
+++ b/minio/data_source_minio_s3_bucket_replication_metrics.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketReplicationMetrics() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads replication health metrics for a bucket: pending, failed, replicated and queued sizes and counts. Useful for monitoring replication lag. Counts and sizes are returned as strings to represent uint64 values safely.",
-		ReadContext:        dataSourceMinioS3BucketReplicationMetricsRead,
+		ReadContext: dataSourceMinioS3BucketReplicationMetricsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":           {Type: schema.TypeString, Required: true},
 			"pending_size":     {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_replication_status.go
+++ b/minio/data_source_minio_s3_bucket_replication_status.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketReplicationStatus() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads replication status and metrics for a bucket including rule count, replicated/pending sizes, and error counts.",
-		ReadContext:        dataSourceMinioS3BucketReplicationStatusRead,
+		ReadContext: dataSourceMinioS3BucketReplicationStatusRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":           {Type: schema.TypeString, Required: true},
 			"rule_count":       {Type: schema.TypeInt, Computed: true},

--- a/minio/data_source_minio_s3_bucket_retention.go
+++ b/minio/data_source_minio_s3_bucket_retention.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"math"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketRetention() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the object lock retention configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketRetentionRead,
+		ReadContext: dataSourceMinioS3BucketRetentionRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":          {Type: schema.TypeString, Required: true},
 			"mode":            {Type: schema.TypeString, Computed: true},

--- a/minio/data_source_minio_s3_bucket_tags.go
+++ b/minio/data_source_minio_s3_bucket_tags.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketTags() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads tags from an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketTagsRead,
+		ReadContext: dataSourceMinioS3BucketTagsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {Type: schema.TypeString, Required: true},
 			"tags": {

--- a/minio/data_source_minio_s3_bucket_versioning.go
+++ b/minio/data_source_minio_s3_bucket_versioning.go
@@ -3,14 +3,14 @@ package minio
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3BucketVersioning() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads the versioning configuration of an existing S3 bucket.",
-		ReadContext:        dataSourceMinioS3BucketVersioningRead,
+		ReadContext: dataSourceMinioS3BucketVersioningRead,
 		Schema: map[string]*schema.Schema{
 			"bucket":    {Type: schema.TypeString, Required: true},
 			"enabled":   {Type: schema.TypeBool, Computed: true},

--- a/minio/data_source_minio_s3_buckets.go
+++ b/minio/data_source_minio_s3_buckets.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioS3Buckets() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists all S3 buckets with optional name prefix filtering.",
-		ReadContext:        dataSourceMinioS3BucketsRead,
+		ReadContext: dataSourceMinioS3BucketsRead,
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {Type: schema.TypeString, Optional: true},
 			"buckets": {

--- a/minio/data_source_minio_s3_objects.go
+++ b/minio/data_source_minio_s3_objects.go
@@ -5,15 +5,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	miniogo "github.com/minio/minio-go/v7"
 )
 
 func dataSourceMinioS3Objects() *schema.Resource {
 	return &schema.Resource{
 		Description: "Lists objects in an S3 bucket with optional prefix, delimiter, and max keys filtering.",
-		ReadContext:        dataSourceMinioS3ObjectsRead,
+		ReadContext: dataSourceMinioS3ObjectsRead,
 		Schema: map[string]*schema.Schema{
 			"bucket": {
 				Type:        schema.TypeString,

--- a/minio/data_source_minio_server_info.go
+++ b/minio/data_source_minio_server_info.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioServerInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads MinIO server information including version, deployment ID, and storage metrics.",
-		ReadContext:        dataSourceMinioServerInfoRead,
+		ReadContext: dataSourceMinioServerInfoRead,
 		Schema: map[string]*schema.Schema{
 			"version": {
 				Type:        schema.TypeString,

--- a/minio/data_source_minio_storage_info.go
+++ b/minio/data_source_minio_storage_info.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMinioStorageInfo() *schema.Resource {
 	return &schema.Resource{
 		Description: "Returns disk and drive status for all MinIO server nodes. Essential for capacity planning and health monitoring.",
-		ReadContext:        dataSourceMinioStorageInfoRead,
+		ReadContext: dataSourceMinioStorageInfoRead,
 		Schema: map[string]*schema.Schema{
 			"disk_count":      {Type: schema.TypeInt, Computed: true, Description: "Total number of disks."},
 			"online_disks":    {Type: schema.TypeInt, Computed: true, Description: "Number of disks online."},


### PR DESCRIPTION
## What changed

`gofmt -w ./minio`, which touches the 28 data source files that #1110 converted, plus a `formatters:` block in `.github/golangci.yml` enabling `gofmt`, plus the formatting guidance in `AGENTS.md` and `.github/CONTRIBUTING.md`.

## Why

The `ReadContext` migration in #1110 renamed a struct key without re-aligning its block and added the `diag` import out of order, so those 28 files have been unformatted ever since:

```diff
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-		ReadContext:        dataSourceIAMUsersRead,
+		ReadContext: dataSourceIAMUsersRead,
```

`golangci.yml` enables errcheck, govet, ineffassign, staticcheck, unused, bodyclose, noctx and unconvert, but no formatter, so the Lint job had nothing to say about it. Enabling `gofmt` there means the next one fails CI rather than sitting in the tree.

The doc edits go with that, because both files would have sent contributors somewhere the new gate is invisible:

- `AGENTS.md` told them to run bare `golangci-lint run`, which does not load `.github/golangci.yml` at all: auto-discovery only looks for `.golangci.{yml,yaml,toml,json}` in the working directory and its parents, and this repo has none. Both mentions now say `task lint`, which passes `--config`. `CONTRIBUTING.md` already used `task lint` in four places, so `AGENTS.md` was the odd one out.
- Both files described the rule as plain `gofmt`. The enforced rule is `gofmt -s`, so a contributor could run `gofmt -w`, be satisfied, and still fail the gate on a simplification.

## Where to start

The `.github/golangci.yml` hunk. Everything else is `gofmt` output: two lines per file, the same import swap and the same key realignment in all 28, no behavior change. `data_source_minio_iam_policy_document.go` is the only one whose diff has two hunks rather than one, and that is positional: a package-level `var dataSourceMinioIAMPolicyDocumentReplacer` and a local `stringSet` sit between its imports and its `schema.Resource` literal, so the two edits cannot share a hunk.

`simplify: true` is written out in the config rather than left to the default. It is the default today, but it is also the difference between `gofmt` and `gofmt -s`, and the docs now promise the stricter one.

## Verification

1. `gofmt -s -l .` is empty on this branch (28 files before). `-s` is what CI checks.
2. `golangci-lint config verify` passes and `golangci-lint run --config .github/golangci.yml ./...` reports 0 issues, in the `golangci/golangci-lint:latest` container.
3. Two tripwires, since a formatter that reports nothing looks identical to a clean tree. Re-breaking the struct alignment in one file gives `File is not properly formatted (gofmt)`, exit 1. A file containing `[]T{T{A: 1}}`, which plain `gofmt -l` accepts and `gofmt -s -l` rejects, is also reported, so the `-s` half is live too.
4. `go build ./...` and `go vet ./...` pass, and CI is green on this commit (Lint & Security 1m59s, acceptance Test job 13m51s).

## Not in this PR

`gofmt` sorts imports inside an existing group but cannot enforce the stdlib / external / internal grouping the docs ask for, and 63 files still violate it. Fixing that wants `gci` with explicit sections rather than `goimports`, which only separates stdlib and then preserves whatever group boundaries it finds. `gci` rewrites 67 files (66 under `minio/`, plus `main.go`), against this PR's 28, so it belongs on its own.
