### PR TITLE
fix(iam): make force_destroy delete the group, and stop it firing on update

### DIFF
--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -109,13 +109,6 @@ func minioUpdateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 		return NewResourceError("error updating IAM Group %s: %s", d.Id(), err)
 	}
 
-	if iamGroupConfig.MinioForceDestroy {
-		err := minioDeleteGroup(ctx, d, meta)
-		if err != nil {
-			return err
-		}
-	}
-
 	return minioReadGroup(ctx, d, meta)
 }
 
@@ -174,37 +167,33 @@ func minioDeleteGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	}
 
-	//force to delete group even if group isn't empty
-	if iamGroupConfig.MinioForceDestroy {
-		err := deleteMinioGroup(ctx, iamGroupConfig, groupDesc.Members)
-
-		if err != nil {
-			return NewResourceError("error deleting IAM Group %s: %s", d.Id(), err)
-		}
-
-		return nil
-	}
-
 	//Group must be empty to be deleted
 	if len(groupDesc.Members) != 0 {
-		members, err := waitForGroupMembersToClear(ctx, func(ctx context.Context) ([]string, error) {
-			desc, err := iamGroupConfig.MinioAdmin.GetGroupDescription(ctx, d.Id())
-			if err != nil {
-				return nil, err
+		if iamGroupConfig.MinioForceDestroy {
+			//force to delete group even if group isn't empty
+			if err := deleteMinioGroup(ctx, iamGroupConfig, groupDesc.Members); err != nil {
+				return NewResourceError("removing IAM group members", d.Id(), err)
 			}
-			return desc.Members, nil
-		}, groupDrainAttempts, groupDrainDelay)
-		if err != nil {
-			return NewResourceError("reading IAM group members", d.Id(), err)
-		}
-		if len(members) != 0 {
-			return NewResourceError("deleting IAM group", d.Id(),
-				fmt.Errorf("group still has %d member(s); set force_destroy = true to delete a group with members", len(members)))
+		} else {
+			members, err := waitForGroupMembersToClear(ctx, func(ctx context.Context) ([]string, error) {
+				desc, err := iamGroupConfig.MinioAdmin.GetGroupDescription(ctx, d.Id())
+				if err != nil {
+					return nil, err
+				}
+				return desc.Members, nil
+			}, groupDrainAttempts, groupDrainDelay)
+			if err != nil {
+				return NewResourceError("reading IAM group members", d.Id(), err)
+			}
+			if len(members) != 0 {
+				return NewResourceError("deleting IAM group", d.Id(),
+					fmt.Errorf("group still has %d member(s); set force_destroy = true to delete a group with members", len(members)))
+			}
 		}
 	}
 
 	if err := deleteMinioGroup(ctx, iamGroupConfig, []string{}); err != nil {
-		return NewResourceError("error deleting IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("deleting IAM group", d.Id(), err)
 	}
 
 	return nil

--- a/minio/resource_minio_iam_group_test.go
+++ b/minio/resource_minio_iam_group_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -250,5 +251,103 @@ func TestWaitForGroupMembersToClearHonoursContext(t *testing.T) {
 	}
 	if diff := cmp.Diff([]string{"alice"}, got); diff != "" {
 		t.Errorf("members mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAccMinioIAMGroup_forceDestroyWithOutsideMember(t *testing.T) {
+	rString := acctest.RandString(8)
+	groupName := fmt.Sprintf("tf-acc-group-fd-%s", rString)
+	outsideUser := fmt.Sprintf("tf-acc-user-fd-%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			// Registered here, not in the test body: without TF_ACC the SDK
+			// skips before PreCheck runs, and a cleanup that reaches
+			// testAccClient() would panic the whole package.
+			t.Cleanup(func() { _ = testAccClient().S3Admin.RemoveUser(context.Background(), outsideUser) })
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioGroupGone(groupName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioGroupConfigForceDestroy(groupName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("minio_iam_group.force", "force_destroy", "true"),
+					testAccAddGroupMemberOutsideTerraform(groupName, outsideUser),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMinioIAMGroup_forceDestroyKeepsGroupOnUpdate(t *testing.T) {
+	var group madmin.GroupDesc
+
+	groupName := fmt.Sprintf("tf-acc-group-fdu-%s", acctest.RandString(8))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckMinioGroupGone(groupName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMinioGroupConfigForceDestroy(groupName, false),
+				Check:  testAccCheckMinioGroupExists("minio_iam_group.force", &group),
+			},
+			{
+				Config: testAccMinioGroupConfigForceDestroy(groupName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMinioGroupExists("minio_iam_group.force", &group),
+					resource.TestCheckResourceAttr("minio_iam_group.force", "disable_group", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMinioGroupConfigForceDestroy(groupName string, disabled bool) string {
+	return fmt.Sprintf(`
+resource "minio_iam_group" "force" {
+  name          = "%s"
+  force_destroy = true
+  disable_group = %t
+}
+`, groupName, disabled)
+}
+
+// testAccAddGroupMemberOutsideTerraform puts a member in the group that no
+// Terraform resource knows about, which is the case force_destroy exists for.
+func testAccAddGroupMemberOutsideTerraform(groupName string, userName string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		minioIam := testAccClient().S3Admin
+
+		if err := minioIam.AddUser(context.Background(), userName, "tfacc-outside-member"); err != nil {
+			return fmt.Errorf("creating user %s outside Terraform: %w", userName, err)
+		}
+
+		return minioIam.UpdateGroupMembers(context.Background(), madmin.GroupAddRemove{
+			Group:   groupName,
+			Members: []string{userName},
+		})
+	}
+}
+
+// testAccCheckMinioGroupGone asserts the group is really gone from MinIO. Only
+// a not-found error proves that: treating every error as success would let a
+// transient admin API failure pass the destroy check.
+func testAccCheckMinioGroupGone(groupName string) func(*terraform.State) error {
+	return func(*terraform.State) error {
+		minioIam := testAccClient().S3Admin
+
+		_, err := minioIam.GetGroupDescription(context.Background(), groupName)
+		if err == nil {
+			return fmt.Errorf("group %s still exists", groupName)
+		}
+		if !strings.Contains(err.Error(), "not exist") {
+			return fmt.Errorf("checking group %s was destroyed: %w", groupName, err)
+		}
+
+		return nil
 	}
 }


### PR DESCRIPTION
Currently `force_destroy` on `minio_iam_group` does the wrong thing in both directions. #1109's body flagged it as a follow-up.

On **update**, it fires at all. `minioUpdateGroup` called `minioDeleteGroup` whenever the flag was set, so an ordinary apply that changed anything else on the group (`disable_group`, say) deleted the group instead of updating it, and the read afterwards cleared the ID. Terraform reports it as `Provider produced inconsistent result after apply`.

On **destroy**, it never finishes the job when the group actually has members. It removes them and returns, but MinIO only drops a group when a delete arrives for the already-empty group, so the group stays on the server while Terraform drops it from state. (On an empty group the old code passed an empty slice, which *is* the delete call, so that case worked.) `force_destroy` documents itself as "Delete group even if it has non-Terraform-managed members", which is exactly what it did not do.

This PR removes the call from the update path, and lets the delete path fall through to the group deletion once `force_destroy` has emptied the group.

## Where to start

`minioDeleteGroup` reads as a bigger diff than it is: the `force_destroy` branch and the drain-and-error branch became the two arms of one `if len(groupDesc.Members) != 0`. The group deletion below them is the same call as before (only its error message changed), and it now catches both arms because the force arm no longer returns early. No change to the non-`force_destroy` behavior added in #1109.

Two error messages changed beyond the restructure: the one the force arm returns on failure, and the one on the group deletion below the `if`. Both read `NewResourceError("error deleting IAM Group %s: %s", d.Id(), err)`, and `NewResourceError` never treats its first argument as a format string (`error.go` interpolates it with `%s`), so those messages reached users with the verbs still in it. They are the messages the `force_destroy` path now surfaces on failure, so they are fixed here. The file had nine calls with that bug; seven remain, including one in `minioDeleteGroup` itself on the branch that fires when reading the group fails for a reason other than not-found. They are left alone because nothing this PR changes routes through them.

The force arm removes the members and falls straight through to the delete, where the non-`force_destroy` arm re-reads through `waitForGroupMembersToClear` first. On a single-node server the removal is already visible to the delete. On a distributed deployment it may not be, and the delete would fail with a clear group-not-empty error that the next apply retries.

The two new acceptance tests are the interesting part, since neither path had coverage before.

## How to test

1. `docker compose up -d minio` and export the env listed in `AGENTS.md`.
2. `go test ./minio -run TestAccMinioIAMGroup_forceDestroy -v`.

Both new tests fail on `main` for the right reasons, which is how they were written:

- `TestAccMinioIAMGroup_forceDestroyWithOutsideMember` adds a member behind Terraform's back, then asserts the group is gone after destroy. On `main`: `group tf-acc-group-fd-... still exists`.
- `TestAccMinioIAMGroup_forceDestroyKeepsGroupOnUpdate` flips `disable_group` on a group carrying the flag. On `main`: `Provider produced inconsistent result after apply`.

They gate different halves: restoring only the update-path call fails the second and not the first, and restoring only the early return in the delete path fails the first and not the second.

`testAccCheckMinioGroupGone` treats only a not-found error as proof of destruction. Accepting any error would make a transient admin API failure, which this suite does see under parallel load, read as a passing destroy check. It matches on the same `"not exist"` substring `minioDeleteGroup` already keys its idempotent-delete branch off, so if MinIO ever rewords that message the test fails in the same place the provider does.

Worth knowing: this is the first destroy check the group resource has actually had. `TestAccAWSGroup_Basic` passes `testAccCheckMinioUserDestroy`, which skips every resource whose type is not `minio_iam_user` and so is a no-op there.

`go test ./minio` with `TF_ACC` unset still passes: the outside-member cleanup registers inside `PreCheck`, which the SDK calls after its skip check, so it never runs against an unconfigured client.

Also ran the surrounding group suite (`TestAccAWSGroup_Basic`, `TestAccMinioGroupMembership*`, `TestAccMinioIAMGroupPolicy*`, `TestAccMinioIAMUserGroupMembership_basic`, `TestValidateMinioIamGroupName`, `TestWaitForGroupMembersToClear`) against a local MinIO: all pass in 79s. CI is green on commit `73d25e6` (Lint & Security 2m0s, acceptance Test job 13m21s).

## Not in this PR

Renaming a group is broken, and worse than it looks. `minioUpdateGroup` guards its rename branch with `d.HasChange(iamGroupConfig.MinioIAMName)`, which passes the group's *value* where a schema field name belongs, so the branch is dead and a rename silently does nothing. Repairing the key would land on a worse bug: the branch calls `UpdateGroupMembers` with the new name, which creates a second group and orphans the first, and madmin has no rename operation at all. `ForceNew: true` on `name` is the likely fix rather than a repaired branch.

Related trap for whoever picks that up: everything in `minioDeleteGroup` keys off `d.Id()` except `deleteMinioGroup`, which uses `iamGroupConfig.MinioIAMName`. Those agree today only because rename never happens.
