### PR TITLE
fix: stop printf verbs leaking into NewResourceError messages

### DIFF
--- a/minio/error_test.go
+++ b/minio/error_test.go
@@ -53,6 +53,33 @@ func TestNewResourceError_WithMinioError(t *testing.T) {
 	}
 }
 
+// NewResourceError takes msg as a plain string, not a format string. A message
+// carrying printf verbs is rendered verbatim, so the verbs leak to the user.
+// This guards the operation-phrase convention that the resource CRUD funcs follow.
+func TestNewResourceError_MessageNotFormatted(t *testing.T) {
+	err := errors.New("group not found")
+
+	diags := NewResourceError("updating IAM group", "my-group", err)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+
+	got := diags[0].Summary
+	want := "[FATAL] updating IAM group (my-group): group not found"
+	if got != want {
+		t.Errorf("Summary = %q, want %q", got, want)
+	}
+
+	// A message with a stray verb must survive untouched (no interpolation).
+	leaky := NewResourceError("updating IAM group %s: %s", "my-group", err)
+	if len(leaky) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	if !strings.Contains(leaky[0].Summary, "%s") {
+		t.Errorf("expected verbs to survive verbatim, got %q", leaky[0].Summary)
+	}
+}
+
 func TestEnhanceConnectionError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/minio/resource_minio_iam_group.go
+++ b/minio/resource_minio_iam_group.go
@@ -68,12 +68,12 @@ func minioCreateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	err := iamGroupConfig.MinioAdmin.UpdateGroupMembers(ctx, groupAddRemove)
 	if err != nil {
-		return NewResourceError("creating group failed", d.Id(), err)
+		return NewResourceError("creating group", d.Id(), err)
 	}
 
 	err = minioStatusGroup(ctx, d, meta)
 	if err != nil {
-		return NewResourceError("error updating IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("updating IAM group", d.Id(), err)
 	}
 
 	d.SetId(iamGroupConfig.MinioIAMName)
@@ -98,7 +98,7 @@ func minioUpdateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 		err := iamGroupConfig.MinioAdmin.UpdateGroupMembers(ctx, groupAddRemove)
 		if err != nil {
-			return NewResourceError("error updating IAM Group %s: %s", d.Id(), err)
+			return NewResourceError("updating IAM group", d.Id(), err)
 		}
 
 		d.SetId(nn.(string))
@@ -106,7 +106,7 @@ func minioUpdateGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	err := minioStatusGroup(ctx, d, meta)
 	if err != nil {
-		return NewResourceError("error updating IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("updating IAM group", d.Id(), err)
 	}
 
 	return minioReadGroup(ctx, d, meta)
@@ -123,17 +123,17 @@ func minioReadGroup(ctx context.Context, d *schema.ResourceData, meta interface{
 			d.SetId("")
 			return nil
 		}
-		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("reading IAM group", d.Id(), err)
 	}
 
 	tflog.Warn(ctx, fmt.Sprintf("(%v)", output))
 
 	if err := d.Set("group_name", output.Name); err != nil {
-		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("reading IAM group", d.Id(), err)
 	}
 
 	if err := d.Set("disable_group", output.Status == string(madmin.GroupDisabled)); err != nil {
-		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("reading IAM group", d.Id(), err)
 	}
 
 	return nil
@@ -151,7 +151,7 @@ func minioDeleteGroup(ctx context.Context, d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return nil
 		}
-		return NewResourceError("error reading IAM Group %s: %s", d.Id(), err)
+		return NewResourceError("reading IAM group", d.Id(), err)
 	}
 
 	if groupDesc.Name == "" {

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -174,7 +174,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	hasSecretWOChange := d.HasChange("secret_wo_version") && hasSecretWOVersion
 	if iamUserConfig.MinioUpdateKey {
 		if secretKey, err := generateSecretAccessKey(); err != nil {
-			return NewResourceError("creating user", d.Id(), err)
+			return NewResourceError("generating IAM user secret key", d.Id(), err)
 		} else {
 			wantedSecret = secretKey
 		}

--- a/minio/resource_minio_iam_user.go
+++ b/minio/resource_minio_iam_user.go
@@ -119,13 +119,13 @@ func minioCreateUser(ctx context.Context, d *schema.ResourceData, meta interface
 
 	if secretKey == "" {
 		if secretKey, err = generateSecretAccessKey(); err != nil {
-			return NewResourceError("error creating user", accessKey, err)
+			return NewResourceError("creating user", accessKey, err)
 		}
 	}
 
 	err = iamUserConfig.MinioAdmin.AddUser(ctx, accessKey, secretKey)
 	if err != nil {
-		return NewResourceError("error creating user", accessKey, err)
+		return NewResourceError("creating user", accessKey, err)
 	}
 
 	d.SetId(accessKey)
@@ -138,7 +138,7 @@ func minioCreateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	if iamUserConfig.MinioDisableUser {
 		err = iamUserConfig.MinioAdmin.SetUserStatus(ctx, accessKey, madmin.AccountDisabled)
 		if err != nil {
-			return NewResourceError("error disabling IAM User %s: %s", d.Id(), err)
+			return NewResourceError("disabling IAM user", d.Id(), err)
 		}
 	}
 
@@ -158,7 +158,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	if userServerInfo.Status != wantedStatus {
 		err := iamUserConfig.MinioAdmin.SetUserStatus(ctx, iamUserConfig.MinioIAMName, wantedStatus)
 		if err != nil {
-			return NewResourceError("error to disable IAM User %s: %s", d.Id(), err)
+			return NewResourceError("disabling IAM user", d.Id(), err)
 		}
 	}
 
@@ -174,7 +174,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	hasSecretWOChange := d.HasChange("secret_wo_version") && hasSecretWOVersion
 	if iamUserConfig.MinioUpdateKey {
 		if secretKey, err := generateSecretAccessKey(); err != nil {
-			return NewResourceError("error creating user", d.Id(), err)
+			return NewResourceError("creating user", d.Id(), err)
 		} else {
 			wantedSecret = secretKey
 		}
@@ -187,7 +187,7 @@ func minioUpdateUser(ctx context.Context, d *schema.ResourceData, meta interface
 	if d.HasChange("secret") || hasSecretWOChange || iamUserConfig.MinioSecret != wantedSecret {
 		err := iamUserConfig.MinioAdmin.SetUser(ctx, iamUserConfig.MinioIAMName, wantedSecret, wantedStatus)
 		if err != nil {
-			return NewResourceError("error updating IAM User Key %s: %s", d.Id(), err)
+			return NewResourceError("updating IAM user key", d.Id(), err)
 		}
 		if hasSecretWO {
 			_ = d.Set("secret", "")
@@ -216,7 +216,7 @@ func minioReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}
 	}
 
 	if err != nil {
-		return NewResourceError("error reading IAM User", d.Id(), err)
+		return NewResourceError("reading IAM user", d.Id(), err)
 	}
 
 	tflog.Warn(ctx, fmt.Sprintf("(%v)", output))
@@ -226,7 +226,7 @@ func minioReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}
 	}
 
 	if err := d.Set("status", string(output.Status)); err != nil {
-		return NewResourceError("reading IAM user failed", d.Id(), err)
+		return NewResourceError("reading IAM user", d.Id(), err)
 	}
 
 	return nil
@@ -241,13 +241,13 @@ func minioDeleteUser(ctx context.Context, d *schema.ResourceData, meta interface
 		if iamUserConfig.MinioForceDestroy {
 			// Ignore errors when deleting group memberships, continue deleting user
 		} else {
-			return NewResourceError("error removing IAM User (%s) group memberships: %s", d.Id(), err)
+			return NewResourceError("removing IAM user group memberships", d.Id(), err)
 		}
 	}
 
 	err := deleteMinioIamUser(ctx, iamUserConfig)
 	if err != nil {
-		return NewResourceError("error deleting IAM User", d.Id(), err)
+		return NewResourceError("deleting IAM user", d.Id(), err)
 	}
 
 	// Actively set resource as deleted as the update path might force a deletion via MinioForceDestroy

--- a/minio/resource_minio_s3_bucket_policy.go
+++ b/minio/resource_minio_s3_bucket_policy.go
@@ -198,7 +198,7 @@ func minioDeleteBucketPolicy(ctx context.Context, d *schema.ResourceData, meta i
 	err := bucketPolicyConfig.MinioClient.SetBucketPolicy(ctx, bucketPolicyConfig.MinioBucket, "")
 
 	if err != nil {
-		return NewResourceError("deleting bucket", bucketPolicyConfig.MinioBucket, err)
+		return NewResourceError("deleting bucket policy", bucketPolicyConfig.MinioBucket, err)
 	}
 
 	return nil

--- a/minio/resource_minio_s3_bucket_policy.go
+++ b/minio/resource_minio_s3_bucket_policy.go
@@ -52,7 +52,7 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 	policy, err := structure.NormalizeJsonString(bucketPolicyConfig.MinioBucketPolicy)
 
 	if err != nil {
-		return NewResourceError("unable to set bucket policy with invalid JSON: %w", policy, err)
+		return NewResourceError("setting bucket policy with invalid JSON", policy, err)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put policy: %s", bucketPolicyConfig.MinioBucket, policy))
@@ -69,7 +69,7 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := waitForBucketReady(ctx, bucketPolicyConfig.MinioClient, bucketPolicyConfig.MinioBucket, waitTimeout); err != nil {
-		return NewResourceError("error waiting for bucket to be ready", bucketPolicyConfig.MinioBucket, err)
+		return NewResourceError("waiting for bucket to be ready", bucketPolicyConfig.MinioBucket, err)
 	}
 
 	// Retry SetBucketPolicy for transient NoSuchBucket errors
@@ -86,7 +86,7 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return NewResourceError("error putting bucket policy: %s", policy, err)
+		return NewResourceError("putting bucket policy", policy, err)
 	}
 
 	// MinIO multi-drive deployments can lose bucket versioning when a policy
@@ -121,7 +121,7 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 				d.SetId("")
 				return nil
 			}
-			return NewResourceError("error waiting for bucket to be ready", d.Id(), err)
+			return NewResourceError("waiting for bucket to be ready", d.Id(), err)
 		}
 	}
 
@@ -136,7 +136,7 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 			return nil
 		}
 		if !d.IsNewResource() {
-			return NewResourceError("failed to load bucket policy", d.Id(), readPolicyErr)
+			return NewResourceError("loading bucket policy", d.Id(), readPolicyErr)
 		}
 	}
 
@@ -161,7 +161,7 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 		})
 		if retryErr != nil {
 			if d.IsNewResource() {
-				return NewResourceError("failed to load bucket policy", d.Id(), retryErr)
+				return NewResourceError("loading bucket policy", d.Id(), retryErr)
 			}
 			tflog.Warn(ctx, fmt.Sprintf("Bucket %s policy is empty, assuming deleted externally", d.Id()))
 			d.SetId("")
@@ -176,7 +176,7 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 
 	policy, err := NormalizeAndCompareJSONPolicies(existingPolicy, actualPolicyText)
 	if err != nil {
-		return NewResourceError("error while comparing policies", d.Id(), err)
+		return NewResourceError("comparing policies", d.Id(), err)
 	}
 
 	if err := d.Set("policy", policy); err != nil {
@@ -198,7 +198,7 @@ func minioDeleteBucketPolicy(ctx context.Context, d *schema.ResourceData, meta i
 	err := bucketPolicyConfig.MinioClient.SetBucketPolicy(ctx, bucketPolicyConfig.MinioBucket, "")
 
 	if err != nil {
-		return NewResourceError("error deleting bucket", bucketPolicyConfig.MinioBucket, err)
+		return NewResourceError("deleting bucket", bucketPolicyConfig.MinioBucket, err)
 	}
 
 	return nil

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -135,7 +135,7 @@ func minioCreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	if serviceAccountConfig.MinioExpiration != "" {
 		expiration, err := time.Parse(time.RFC3339, serviceAccountConfig.MinioExpiration)
 		if err != nil {
-			return NewResourceError("Failed to parse expiration", serviceAccountConfig.MinioExpiration, err)
+			return NewResourceError("parsing expiration", serviceAccountConfig.MinioExpiration, err)
 		}
 		expirationPtr = &expiration
 	}
@@ -150,7 +150,7 @@ func minioCreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 
 	serviceAccount, err := serviceAccountConfig.MinioAdmin.AddServiceAccount(ctx, addReq)
 	if err != nil {
-		return NewResourceError("error creating service account", targetUser, err)
+		return NewResourceError("creating service account", targetUser, err)
 	}
 	accessKey := serviceAccount.AccessKey
 	secretKey := serviceAccount.SecretKey
@@ -170,7 +170,7 @@ func minioCreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	if serviceAccountConfig.MinioDisableUser {
 		err = serviceAccountConfig.MinioAdmin.UpdateServiceAccount(ctx, accessKey, madmin.UpdateServiceAccountReq{NewStatus: "off"})
 		if err != nil {
-			return NewResourceError("error disabling service account %s: %s", d.Id(), err)
+			return NewResourceError("disabling service account", d.Id(), err)
 		}
 	}
 
@@ -191,7 +191,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 
 	serviceAccountServerInfo, err := serviceAccountConfig.MinioAdmin.InfoServiceAccount(ctx, serviceAccountConfig.MinioAccessKey)
 	if err != nil {
-		return NewResourceError("error to disable service account", d.Id(), err)
+		return NewResourceError("disabling service account", d.Id(), err)
 	}
 	if serviceAccountServerInfo.AccountStatus != wantedStatus {
 		err := serviceAccountConfig.MinioAdmin.UpdateServiceAccount(ctx, serviceAccountConfig.MinioAccessKey, madmin.UpdateServiceAccountReq{
@@ -199,7 +199,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy: processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error to disable service account", d.Id(), err)
+			return NewResourceError("disabling service account", d.Id(), err)
 		}
 	}
 
@@ -215,7 +215,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	hasSecretWOChange := d.HasChange("secret_key_wo_version") && hasSecretWOVersion
 	if serviceAccountConfig.MinioUpdateKey {
 		if secretKey, err := generateSecretAccessKey(); err != nil {
-			return NewResourceError("error creating user", d.Id(), err)
+			return NewResourceError("creating user", d.Id(), err)
 		} else {
 			wantedSecret = secretKey
 		}
@@ -231,7 +231,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy:    processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error updating service account Key %s: %s", d.Id(), err)
+			return NewResourceError("updating service account key", d.Id(), err)
 		}
 
 		if hasSecretWO {
@@ -246,7 +246,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy: processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error updating service account policy %s: %s", d.Id(), err)
+			return NewResourceError("updating service account policy", d.Id(), err)
 		}
 
 		_ = d.Set("policy", policy)
@@ -261,7 +261,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy: processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error updating service account name %s: %s", d.Id(), err)
+			return NewResourceError("updating service account name", d.Id(), err)
 		}
 	}
 
@@ -274,7 +274,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy:      processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error updating service account description %s: %s", d.Id(), err)
+			return NewResourceError("updating service account description", d.Id(), err)
 		}
 	}
 
@@ -283,7 +283,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		if serviceAccountConfig.MinioExpiration != "" {
 			expiration, err := time.Parse(time.RFC3339, serviceAccountConfig.MinioExpiration)
 			if err != nil {
-				return NewResourceError("error parsing service account expiration %s: %s", d.Id(), err)
+				return NewResourceError("parsing service account expiration", d.Id(), err)
 			}
 			expirationPtr = &expiration
 		}
@@ -292,7 +292,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 			NewPolicy:     processServiceAccountPolicy(policy),
 		})
 		if err != nil {
-			return NewResourceError("error updating service account expiration %s: %s", d.Id(), err)
+			return NewResourceError("updating service account expiration", d.Id(), err)
 		}
 	}
 
@@ -308,7 +308,7 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 		return nil
 	}
 	if err != nil {
-		return NewResourceError("error reading service account %s: %s", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("(%v)", output))
@@ -318,14 +318,14 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err := d.Set("status", output.AccountStatus); err != nil {
-		return NewResourceError("reading service account failed", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 
 	_ = d.Set("disable_user", output.AccountStatus == "off")
 
 	targetUser := parseUserFromParentUser(output.ParentUser)
 	if err := d.Set("target_user", targetUser); err != nil {
-		return NewResourceError("reading service account failed", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 
 	if !output.ImpliedPolicy {
@@ -333,10 +333,10 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err := d.Set("name", output.Name); err != nil {
-		return NewResourceError("reading service account failed", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 	if err := d.Set("description", output.Description); err != nil {
-		return NewResourceError("reading service account failed", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 
 	var expiration string
@@ -344,7 +344,7 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 		expiration = output.Expiration.Format(time.RFC3339)
 	}
 	if err := d.Set("expiration", expiration); err != nil {
-		return NewResourceError("reading service account failed", d.Id(), err)
+		return NewResourceError("reading service account", d.Id(), err)
 	}
 
 	return nil
@@ -356,7 +356,7 @@ func minioDeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 
 	err := deleteMinioServiceAccount(ctx, serviceAccountConfig)
 	if err != nil {
-		return NewResourceError("error deleting service account %s: %s", d.Id(), err)
+		return NewResourceError("deleting service account", d.Id(), err)
 	}
 
 	// Actively set resource as deleted

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -215,7 +215,7 @@ func minioUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	hasSecretWOChange := d.HasChange("secret_key_wo_version") && hasSecretWOVersion
 	if serviceAccountConfig.MinioUpdateKey {
 		if secretKey, err := generateSecretAccessKey(); err != nil {
-			return NewResourceError("creating user", d.Id(), err)
+			return NewResourceError("generating service account secret key", d.Id(), err)
 		} else {
 			wantedSecret = secretKey
 		}


### PR DESCRIPTION
Closes #1114

## What changed

The 21 `NewResourceError` calls that passed printf verbs in the message argument, across `resource_minio_service_account.go` (9), `resource_minio_iam_group.go` (7), `resource_minio_iam_user.go` (4) and `resource_minio_s3_bucket_policy.go` (1), rewritten to the verb-free operation phrase the wrapper expects.

While in these four files, I also dropped the redundant `error ` prefix and the `failed`/`unable to` framing on the sibling calls, so every message in them reads the same way as the newer call sites (`"updating IAM group"`, not `"error updating IAM Group %s: %s"`). The informational messages that pass a value as the third argument (the `"Minio does not support removing service account names"` ones) and the already-correct calls are left alone.

One unit test in `error_test.go` pins the contract that makes this a bug: `NewResourceError` renders its message verbatim, so a message carrying a `%s` survives untouched instead of being interpolated.

## Why

`NewResourceError` never treats its first argument as a format string. `error.go` stores it as `Message` and formats the whole thing with `%s`, so any verbs in the message reach the user as-is:

```
Error: error updating IAM Group %s: %s (my-group): group not found
```

#1113 fixed the two occurrences its `force_destroy` change routed through and pointed at the rest as a follow-up. This is that sweep.

The acceptance criterion from the issue holds:

```sh
grep -rEn 'NewResourceError\("[^"]*%[sdv]' minio/ --include="*.go" | grep -v _test
```

now returns nothing. I did not add the optional `forbidigo` guard: the repo's `.github/golangci.yml` runs `default: none` with a fixed linter set and no `forbidigo`, so wiring it in would be a lint-config change of its own rather than part of this fix. The new test covers the reintroduction case at the wrapper level instead.

## How to test

No server needed for the change itself, the messages are the only thing that moved:

```sh
go test ./minio -run TestNewResourceError
golangci-lint run --config .github/golangci.yml ./minio
```

Both green, along with `go vet ./minio` and the full unit suite (`go test ./minio`, acceptance tests skip without `TF_ACC`).
