### PR TITLE
docs: add CHANGELOG.md and gate releases on a matching section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -299,6 +299,24 @@ func TestAccMinioExample_basic(t *testing.T) {
 3. **Update Documentation**: Add/update docs for new features
 4. **Check Style**: Run `task lint` and fix any issues
 5. **Sign Commits**: Use `git commit -s` for DCO compliance
+6. **Update the Changelog**: If your change is user-visible, add an entry under
+   `## [Unreleased]` in `CHANGELOG.md`
+
+### When a Changelog Entry Is Expected
+
+Add an entry under `## [Unreleased]` in `CHANGELOG.md` when your change is
+**user-visible**: new resources or attributes, behavior changes, bug fixes
+users could have hit, deprecations, and security fixes (security entries must
+state the action users need to take, e.g. "upgrade **and re-apply**").
+
+Skip the changelog for changes users cannot observe: CI and workflow changes,
+dependency bumps with no behavior change, test-only changes, refactors, and
+documentation fixes. When in doubt, add the entry — a reviewer can always drop
+it.
+
+The release workflow refuses to tag a version that has no matching
+`## [x.y.z]` section in `CHANGELOG.md`, so entries must be moved from
+`[Unreleased]` into a dated section as part of preparing a release.
 
 ### Commit Message Format
 

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -87,6 +87,18 @@ jobs:
             exit 1
           fi
 
+      - name: Check CHANGELOG has a section for this version
+        run: |
+          PLAIN_VERSION="${VERSION#v}"
+          if ! grep -q "^## \[${PLAIN_VERSION}\]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md has no '## [${PLAIN_VERSION}]' section."
+            echo "Move the relevant entries from '## [Unreleased]' into a dated"
+            echo "'## [${PLAIN_VERSION}] - $(date +%Y-%m-%d)' section (and update the"
+            echo "link references at the bottom), then re-run this workflow."
+            exit 1
+          fi
+          echo "CHANGELOG.md contains a section for ${PLAIN_VERSION}."
+
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+All notable, user-visible changes to this provider are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+History older than 3.39.0 lives in the
+[GitHub Releases](https://github.com/aminueza/terraform-provider-minio/releases) pages.
+
+## [Unreleased]
+
+### Fixed
+
+- `minio_iam_group`: `force_destroy` now actually deletes a group that still has
+  members, and no longer fires during ordinary updates (previously an apply that
+  changed any other attribute on a group carrying the flag deleted the group and
+  failed with `Provider produced inconsistent result after apply`) ([#1113](https://github.com/aminueza/terraform-provider-minio/pull/1113)).
+- `minio_iam_group`: deleting a group that still has members now waits for the
+  membership to clear and then fails with a clear error pointing at
+  `force_destroy`, instead of silently leaving the group behind on the server
+  ([#1109](https://github.com/aminueza/terraform-provider-minio/pull/1109)).
+
+## [3.40.1] - 2026-08-04
+
+### Fixed
+
+- `minio_s3_bucket_anonymous_access` and `minio_s3_bucket`'s `acl` now write
+  the canned anonymous policies `mc` recognizes, so `mc anonymous get` reports
+  `download`, `upload` and `public` instead of `custom`. `public-read-write`
+  also grants `s3:GetObject`, which it never did before (anonymous `GET`
+  returned `403`). Re-apply your configuration to replace the old policies;
+  this is a plain `PutBucketPolicy`, with no recreate
+  ([#1094](https://github.com/aminueza/terraform-provider-minio/pull/1094)).
+
+### Removed
+
+- The AIStor-specific anonymous policies, which could not be applied on any
+  backend. `minio_edition` and `minio_server_info.edition` are unchanged
+  ([#1094](https://github.com/aminueza/terraform-provider-minio/pull/1094)).
+
+### Security
+
+- Vulnerability reports now flow exclusively through
+  [GitHub Private Vulnerability Reporting](https://github.com/aminueza/terraform-provider-minio/security/advisories/new);
+  the issue template that created public "security" issues was removed
+  ([#1090](https://github.com/aminueza/terraform-provider-minio/pull/1090),
+  [#1091](https://github.com/aminueza/terraform-provider-minio/pull/1091)).
+
+## [3.40.0] - 2026-08-03
+
+### Security
+
+- **`minio_s3_bucket_anonymous_access` with `access_type = "public"` granted
+  anonymous callers bucket administration** — `s3:PutBucketPolicy`,
+  `s3:DeleteBucketPolicy`, `s3:DeleteBucket` and `s3:CreateBucket` — in
+  addition to object read/write. Any unauthenticated client could rewrite the
+  bucket policy or delete the bucket. Fixed in
+  [#1085](https://github.com/aminueza/terraform-provider-minio/pull/1085).
+
+  **Upgrading the provider alone is not enough.** The corrected policy is only
+  written when the resource is re-applied: after upgrading, run
+  `terraform apply` against every workspace that manages an
+  `access_type = "public"` bucket. The rewrite is a plain `PutBucketPolicy` —
+  no recreate, and no change to who can read or write objects. To verify,
+  `mc anonymous get-json <alias>/<bucket>` should list no `s3:*Bucket*` actions
+  beyond `s3:GetBucketLocation`, `s3:ListBucket` and
+  `s3:ListBucketMultipartUploads`. Only buckets using `access_type = "public"`
+  are affected; `public-read`, `public-write`, `public-read-write` and custom
+  policies are not.
+
+## [3.39.0] - 2026-08-02
+
+### Added
+
+- Support for MinIO servers that require **admin API v4**, by migrating from
+  `madmin-go/v3` to `madmin-go/v4`. Servers that rejected the provider with
+  `Server expects client requests with 'admin' API version 'v4'` now work
+  ([#1074](https://github.com/aminueza/terraform-provider-minio/pull/1074)).
+
+### Changed
+
+- Against servers that only speak admin API v3, each admin request first tries
+  v4 and falls back to v3 after a `426 Upgrade Required` response. Deployments
+  on older MinIO servers that notice added latency per admin operation can set
+  the `MADMIN_API_VERSION=v3` environment variable on the machine running
+  Terraform to skip the fallback entirely.
+
+[Unreleased]: https://github.com/aminueza/terraform-provider-minio/compare/v3.40.1...HEAD
+[3.40.1]: https://github.com/aminueza/terraform-provider-minio/compare/v3.40.0...v3.40.1
+[3.40.0]: https://github.com/aminueza/terraform-provider-minio/compare/v3.39.0...v3.40.0
+[3.39.0]: https://github.com/aminueza/terraform-provider-minio/compare/v3.38.6...v3.39.0


### PR DESCRIPTION
## Pull Request Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code

### Documentation Requirements
- [x] I have updated the README if this is a user-facing change (changelog is the user-facing artifact here)

## Description

### Type of Change
- [x] Documentation update

### What does this PR do?

Implements #1119 in full:

- **`CHANGELOG.md`** (new) in [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format, backfilled from **v3.39.0** — the point where the two most consequential recent releases live. The **v3.40.0 security entry** spells out the load-bearing requirement from the advisory: *upgrading the provider alone is not enough; affected `access_type = "public"` buckets must be re-applied*, with the `mc anonymous get-json` verification command. The **v3.40.1 entry** is sourced from #1094's own release notes (canned policies now classify as `download`/`upload`/`public`; `public-read-write` finally grants read). The **v3.39.0 entry** covers admin API v4 support and documents the `MADMIN_API_VERSION=v3` escape hatch for v3-only servers. `[Unreleased]` already carries #1109 and #1113. Older history points to the GitHub Releases page instead of being reconstructed.
- **Release gate**: `create-release-tag.yml` gains a step that refuses to tag a version with no matching `## [x.y.z]` section in `CHANGELOG.md`, with an error message that says exactly what to move where. Verified both directions: the gate finds `3.40.1` and rejects a version with no section.
- **`CONTRIBUTING.md`**: new checklist item plus a "When a Changelog Entry Is Expected" section — user-visible changes get an entry (security entries must state the action required); CI, deps, tests and refactors do not.

### How was this change tested?

- Workflow YAML parses; the gate's grep was exercised against the real file for both the accept and reject cases.
- Changelog compare links follow the existing tag scheme (`v3.38.6...v3.39.0` etc.).

### Related Issues

- Closes #1119