### PR TITLE
docs: group registry pages with subcategories

### DIFF
--- a/docs/data-sources/account_info.md
+++ b/docs/data-sources/account_info.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_account_info Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Returns storage usage and bucket information for the authenticated account.
 ---

--- a/docs/data-sources/batch_job_template.md
+++ b/docs/data-sources/batch_job_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_batch_job_template Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Returns a starter YAML template for a given MinIO batch job type. Calls GenerateBatchJobV2 (EOS-only API) and falls back to the SDK's bundled static template when the server does not advertise the endpoint.
 ---

--- a/docs/data-sources/batch_jobs.md
+++ b/docs/data-sources/batch_jobs.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_batch_jobs Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Lists active MinIO batch jobs, optionally filtered by job type and status.
 ---

--- a/docs/data-sources/bucket_metadata_export.md
+++ b/docs/data-sources/bucket_metadata_export.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_bucket_metadata_export Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Exports a base64-encoded zip stream containing the metadata (policies, tagging, notification, ILM, etc.) for a single bucket. Use together with minio_bucket_metadata_import to copy metadata between buckets. Note: the full metadata zip is persisted in Terraform state; use a secure state backend.
 ---

--- a/docs/data-sources/config_history.md
+++ b/docs/data-sources/config_history.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_config_history Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Lists MinIO configuration change history. Useful for auditing config changes and identifying restore points.
 ---

--- a/docs/data-sources/data_usage.md
+++ b/docs/data-sources/data_usage.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_data_usage Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Returns cluster-wide data usage statistics including total objects, size, and per-bucket breakdown.
 ---

--- a/docs/data-sources/health_status.md
+++ b/docs/data-sources/health_status.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_health_status - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Checks MinIO cluster health using unauthenticated health endpoints.
 ---

--- a/docs/data-sources/iam_export.md
+++ b/docs/data-sources/iam_export.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_export Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Exports the entire IAM configuration (users, groups, policies, service accounts) from a MinIO server. The payload is the raw zip MinIO returns, base64-encoded. Treat as sensitive: it can include access keys.
 ---

--- a/docs/data-sources/iam_group.md
+++ b/docs/data-sources/iam_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Retrieves information about a specific IAM group by name.
 ---

--- a/docs/data-sources/iam_groups.md
+++ b/docs/data-sources/iam_groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_groups Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Lists all IAM groups with optional name prefix filtering.
 ---

--- a/docs/data-sources/iam_policy.md
+++ b/docs/data-sources/iam_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_policy Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Retrieves an existing IAM policy by name.
 ---

--- a/docs/data-sources/iam_policy_document.md
+++ b/docs/data-sources/iam_policy_document.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_iam_policy_document - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Generates an IAM policy document in JSON format for use with IAM policies.
 ---

--- a/docs/data-sources/iam_service_accounts.md
+++ b/docs/data-sources/iam_service_accounts.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_service_accounts Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Lists service accounts (access keys) for a specific IAM user.
 ---

--- a/docs/data-sources/iam_user.md
+++ b/docs/data-sources/iam_user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_iam_user - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Retrieves information about a specific IAM user by name.
 ---

--- a/docs/data-sources/iam_user_policies.md
+++ b/docs/data-sources/iam_user_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_user_policies Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Returns all IAM policies effective for a user, including policies attached directly and inherited from group membership.
 ---

--- a/docs/data-sources/iam_users.md
+++ b/docs/data-sources/iam_users.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_iam_users - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Lists IAM users with optional filtering by name prefix and status.
 ---

--- a/docs/data-sources/ilm_policy.md
+++ b/docs/data-sources/ilm_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_ilm_policy Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   Reads the ILM lifecycle rules configured on an existing S3 bucket.
 ---

--- a/docs/data-sources/ilm_tier_stats.md
+++ b/docs/data-sources/ilm_tier_stats.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_ilm_tier_stats Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   Returns transition statistics for all configured ILM storage tiers including object counts and total bytes.
 ---

--- a/docs/data-sources/ilm_tiers.md
+++ b/docs/data-sources/ilm_tiers.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_ilm_tiers Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   Lists all configured ILM remote storage tiers.
 ---

--- a/docs/data-sources/kms_metrics.md
+++ b/docs/data-sources/kms_metrics.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_kms_metrics Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Exposes operational metrics for the KMS connected to the MinIO server. The KES latency histogram is intentionally not mapped; use the KES Prometheus endpoint directly if you need buckets.
 ---

--- a/docs/data-sources/kms_status.md
+++ b/docs/data-sources/kms_status.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_kms_status Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Reports status and connectivity information about the KMS configured on the MinIO server. version exposes the KMS server version (from the version endpoint); the server-side runtime snapshot in state[0] carries its own version reported by the status endpoint — they may differ.
 ---

--- a/docs/data-sources/license_info.md
+++ b/docs/data-sources/license_info.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_license_info Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Retrieves MinIO license information.
 ---

--- a/docs/data-sources/notify_amqp.md
+++ b/docs/data-sources/notify_amqp.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_amqp Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_elasticsearch.md
+++ b/docs/data-sources/notify_elasticsearch.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_elasticsearch Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_kafka.md
+++ b/docs/data-sources/notify_kafka.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_kafka Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_mqtt.md
+++ b/docs/data-sources/notify_mqtt.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_mqtt Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_mysql.md
+++ b/docs/data-sources/notify_mysql.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_mysql Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_nats.md
+++ b/docs/data-sources/notify_nats.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_nats Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_nsq.md
+++ b/docs/data-sources/notify_nsq.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_nsq Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_postgres.md
+++ b/docs/data-sources/notify_postgres.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_postgres Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_redis.md
+++ b/docs/data-sources/notify_redis.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_redis Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/notify_webhook.md
+++ b/docs/data-sources/notify_webhook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_webhook Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   
 ---

--- a/docs/data-sources/pool_rebalance_status.md
+++ b/docs/data-sources/pool_rebalance_status.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_pool_rebalance_status Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Reports the current status of a MinIO storage pool rebalance. Returns stopped when no rebalance is in progress.
 ---

--- a/docs/data-sources/pool_status.md
+++ b/docs/data-sources/pool_status.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_pool_status Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Reports status information about the storage pools in a MinIO cluster.
 ---

--- a/docs/data-sources/prometheus_scrape_config.md
+++ b/docs/data-sources/prometheus_scrape_config.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_prometheus_scrape_config Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Generates Prometheus scrape configuration for MinIO metrics endpoints.
 ---

--- a/docs/data-sources/s3_bucket.md
+++ b/docs/data-sources/s3_bucket.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads properties of an existing S3 bucket including versioning, region, and object lock status.
 ---

--- a/docs/data-sources/s3_bucket_anonymous_access.md
+++ b/docs/data-sources/s3_bucket_anonymous_access.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_anonymous_access Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the anonymous access policy for an existing MinIO bucket, returning the raw policy JSON and the derived canned access type when the policy matches one of the known canned forms.
 ---

--- a/docs/data-sources/s3_bucket_cors_config.md
+++ b/docs/data-sources/s3_bucket_cors_config.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_cors_config Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the CORS configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_encryption.md
+++ b/docs/data-sources/s3_bucket_encryption.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_encryption Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the server-side encryption configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_notification_config.md
+++ b/docs/data-sources/s3_bucket_notification_config.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_notification_config Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Reads the event notification configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_object_lock_configuration.md
+++ b/docs/data-sources/s3_bucket_object_lock_configuration.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_object_lock_configuration Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the object lock configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_policy.md
+++ b/docs/data-sources/s3_bucket_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_policy Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the bucket policy document for an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_quota.md
+++ b/docs/data-sources/s3_bucket_quota.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_quota Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the quota configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_replication.md
+++ b/docs/data-sources/s3_bucket_replication.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_replication Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Replication"
 description: |-
   Reads the replication configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_replication_metrics.md
+++ b/docs/data-sources/s3_bucket_replication_metrics.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_replication_metrics Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Replication"
 description: |-
   Reads replication health metrics for a bucket: pending, failed, replicated and queued sizes and counts. Useful for monitoring replication lag. Counts and sizes are returned as strings to represent uint64 values safely.
 ---

--- a/docs/data-sources/s3_bucket_replication_status.md
+++ b/docs/data-sources/s3_bucket_replication_status.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_replication_status Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Replication"
 description: |-
   Reads replication status and metrics for a bucket including rule count, replicated/pending sizes, and error counts.
 ---

--- a/docs/data-sources/s3_bucket_retention.md
+++ b/docs/data-sources/s3_bucket_retention.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_retention Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the object lock retention configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_tags.md
+++ b/docs/data-sources/s3_bucket_tags.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_tags Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads tags from an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_bucket_versioning.md
+++ b/docs/data-sources/s3_bucket_versioning.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_versioning Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Reads the versioning configuration of an existing S3 bucket.
 ---

--- a/docs/data-sources/s3_buckets.md
+++ b/docs/data-sources/s3_buckets.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_buckets Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Lists all S3 buckets with optional name prefix filtering.
 ---

--- a/docs/data-sources/s3_object.md
+++ b/docs/data-sources/s3_object.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_s3_object - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Reads an object from a MinIO bucket including its content and metadata.
 ---

--- a/docs/data-sources/s3_objects.md
+++ b/docs/data-sources/s3_objects.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_objects Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Lists objects in an S3 bucket with optional prefix, delimiter, and max keys filtering.
 ---

--- a/docs/data-sources/server_info.md
+++ b/docs/data-sources/server_info.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Data Source minio_server_info - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Reads MinIO server information including version, deployment ID, and storage metrics.
 ---

--- a/docs/data-sources/storage_info.md
+++ b/docs/data-sources/storage_info.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_storage_info Data Source - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Returns disk and drive status for all MinIO server nodes. Essential for capacity planning and health monitoring.
 ---

--- a/docs/resources/accesskey.md
+++ b/docs/resources/accesskey.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_accesskey Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/audit_kafka.md
+++ b/docs/resources/audit_kafka.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_audit_kafka Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages a Kafka target for MinIO audit log forwarding. Audit events are published to the specified Kafka topic.
 ---

--- a/docs/resources/audit_webhook.md
+++ b/docs/resources/audit_webhook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_audit_webhook Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages an audit webhook target for MinIO audit logging. Audit webhooks send detailed API audit events to HTTP endpoints for compliance, SIEM integration, and security monitoring.
 ---

--- a/docs/resources/batch_job.md
+++ b/docs/resources/batch_job.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_batch_job Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages a MinIO batch job (replicate, expire, or keyrotate). Batch jobs are asynchronous; this resource submits the job and tracks its status. Use wait_for_status to optionally block until the job reaches a desired state. Import is not supported because the job YAML definition cannot be retrieved from the MinIO API.
 ---

--- a/docs/resources/bucket_metadata_import.md
+++ b/docs/resources/bucket_metadata_import.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_bucket_metadata_import Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Imports a base64-encoded zip stream of bucket metadata produced by minio_bucket_metadata_export. Destroying this resource only removes Terraform state; the imported metadata remains on the bucket. Use the triggers map to force a re-import.
 ---

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_config Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   
 ---

--- a/docs/resources/config_restore.md
+++ b/docs/resources/config_restore.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_config_restore Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Restores MinIO configuration from a previous point in history. Use with minio_config_history data source to identify restore points.
 ---

--- a/docs/resources/iam_group.md
+++ b/docs/resources/iam_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_group_membership.md
+++ b/docs/resources/iam_group_membership.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group_membership Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_group_policy.md
+++ b/docs/resources/iam_group_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group_policy Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_group_policy_attachment.md
+++ b/docs/resources/iam_group_policy_attachment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group_policy_attachment Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_group_user_attachment.md
+++ b/docs/resources/iam_group_user_attachment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_group_user_attachment Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_idp_ldap.md
+++ b/docs/resources/iam_idp_ldap.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_idp_ldap Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Manages an LDAP/Active Directory identity provider configuration for MinIO.
 ---

--- a/docs/resources/iam_idp_openid.md
+++ b/docs/resources/iam_idp_openid.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_idp_openid Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Manages an OpenID Connect (OIDC) identity provider configuration for MinIO SSO.
 ---

--- a/docs/resources/iam_import.md
+++ b/docs/resources/iam_import.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_import Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Imports an IAM configuration into the MinIO server (users, groups, policies, service accounts). Pair with data.minio_iam_export for cross-cluster migration or backup/restore. MinIO's export embeds non-deterministic zip metadata, so chaining data.minio_iam_export -> minio_iam_import in the same root module shows drift on every plan even when IAM is unchanged. For stable plans, run export and import in separate states, or set lifecycle { ignore_changes = [iam_data] } once the initial import has succeeded. Delete is a no-op: MinIO does not provide a primitive to undo an import. To purge imported entities, manage them as individual minio_iam_* resources or remove them out-of-band.
 ---

--- a/docs/resources/iam_ldap_group_policy_attachment.md
+++ b/docs/resources/iam_ldap_group_policy_attachment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_ldap_group_policy_attachment Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Attaches LDAP group to a policy. Can be used against both built-in and user-defined policies.
 ---

--- a/docs/resources/iam_ldap_user_policy_attachment.md
+++ b/docs/resources/iam_ldap_user_policy_attachment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_ldap_user_policy_attachment Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   Attaches LDAP user to a policy. Can be used against both built-in and user-defined policies.
 ---

--- a/docs/resources/iam_policy.md
+++ b/docs/resources/iam_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_policy Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_service_account.md
+++ b/docs/resources/iam_service_account.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_service_account Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_user.md
+++ b/docs/resources/iam_user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_user Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_user_group_membership.md
+++ b/docs/resources/iam_user_group_membership.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_user_group_membership Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/iam_user_policy_attachment.md
+++ b/docs/resources/iam_user_policy_attachment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_iam_user_policy_attachment Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "IAM"
 description: |-
   
 ---

--- a/docs/resources/ilm_policy.md
+++ b/docs/resources/ilm_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_ilm_policy Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   minio_ilm_policy handles lifecycle settings for a given minio_s3_bucket.
 ---

--- a/docs/resources/ilm_tier.md
+++ b/docs/resources/ilm_tier.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_ilm_tier Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   Manages remote storage tiers for MinIO ILM (Information Lifecycle Management). Tiers allow transitioning objects to cheaper remote storage (S3, GCS, Azure, or another MinIO deployment) based on lifecycle rules.
 ---

--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_kms_key Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   
 ---

--- a/docs/resources/logger_webhook.md
+++ b/docs/resources/logger_webhook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_logger_webhook Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages a logger webhook target for MinIO system log forwarding. Logger webhooks send server log events to HTTP endpoints for centralized logging.
 ---

--- a/docs/resources/notify_amqp.md
+++ b/docs/resources/notify_amqp.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_amqp Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages an AMQP/RabbitMQ notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_elasticsearch.md
+++ b/docs/resources/notify_elasticsearch.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_elasticsearch Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages an Elasticsearch notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_kafka.md
+++ b/docs/resources/notify_kafka.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_kafka Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a Kafka notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_mqtt.md
+++ b/docs/resources/notify_mqtt.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_mqtt Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages an MQTT notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_mysql.md
+++ b/docs/resources/notify_mysql.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_mysql Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a MySQL notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_nats.md
+++ b/docs/resources/notify_nats.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_nats Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a NATS notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_nsq.md
+++ b/docs/resources/notify_nsq.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_nsq Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages an NSQ notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_postgres.md
+++ b/docs/resources/notify_postgres.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_postgres Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a PostgreSQL notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_redis.md
+++ b/docs/resources/notify_redis.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_redis Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a Redis notification target for MinIO bucket event notifications.
 ---

--- a/docs/resources/notify_webhook.md
+++ b/docs/resources/notify_webhook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_notify_webhook Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages a webhook notification target for MinIO bucket event notifications. Webhook targets receive bucket events (object created, deleted, etc.) via HTTP POST requests.
 ---

--- a/docs/resources/pool_decommission.md
+++ b/docs/resources/pool_decommission.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_pool_decommission Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Decommissions a storage pool from a MinIO cluster. WARNING: this is a destructive and irreversible operation — once decommission completes, MinIO removes the pool and the data on it cannot be recovered via Terraform. Ensure all data has been migrated before applying.
   Create returns as soon as MinIO accepts the request; the decommission then runs asynchronously on the server. Refresh the resource (or read the minio_pool_status data source) to observe progress in the state and status attributes.

--- a/docs/resources/pool_rebalance.md
+++ b/docs/resources/pool_rebalance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_pool_rebalance Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Starts a MinIO storage pool rebalance operation. Destroying the resource stops the rebalance. Only one rebalance can be in progress per cluster.
 ---

--- a/docs/resources/prometheus_bearer_token.md
+++ b/docs/resources/prometheus_bearer_token.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_prometheus_bearer_token Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO Prometheus bearer tokens for metrics authentication.
   Bearer tokens are JWTs signed with MinIO credentials that authenticate

--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   
 ---

--- a/docs/resources/s3_bucket_anonymous_access.md
+++ b/docs/resources/s3_bucket_anonymous_access.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_anonymous_access Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Manage anonymous access to an existing MinIO bucket using canned access types or fully custom JSON policies.
 ---

--- a/docs/resources/s3_bucket_cors.md
+++ b/docs/resources/s3_bucket_cors.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_cors Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   
 ---

--- a/docs/resources/s3_bucket_lifecycle.md
+++ b/docs/resources/s3_bucket_lifecycle.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_lifecycle Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "ILM"
 description: |-
   Manages S3 bucket lifecycle configuration (expiration, transitions, noncurrent version handling, and multipart upload cleanup). Provides AWS S3 parity with aws_s3_bucket_lifecycle_configuration. Do not configure both minio_s3_bucket_lifecycle and minio_ilm_policy for the same bucket.
 ---

--- a/docs/resources/s3_bucket_notification.md
+++ b/docs/resources/s3_bucket_notification.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_notification Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
   Manages event notification configuration for an S3 bucket. Sends bucket events to configured queue targets.
 ---

--- a/docs/resources/s3_bucket_object_lock_configuration.md
+++ b/docs/resources/s3_bucket_object_lock_configuration.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Resource minio_s3_bucket_object_lock_configuration - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Configures object lock (WORM) retention policies at the bucket level. Sets default retention that applies to all new objects automatically.
   Object locking must be enabled when creating the bucket - can't add it later unless you're on MinIO RELEASE.2025-05-20T20-30-00Z+.

--- a/docs/resources/s3_bucket_policy.md
+++ b/docs/resources/s3_bucket_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_policy Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   
 ---

--- a/docs/resources/s3_bucket_quota.md
+++ b/docs/resources/s3_bucket_quota.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_quota Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
     Manages quota limits for S3 buckets in MinIO.
 ---

--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_replication Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Replication"
 description: |-
   
 ---

--- a/docs/resources/s3_bucket_retention.md
+++ b/docs/resources/s3_bucket_retention.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_retention Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Manages object lock retention settings for a MinIO bucket. Object locking enforces Write-Once Read-Many (WORM) immutability to protect versioned objects from deletion.
   Note: Object locking can only be enabled during bucket creation and requires versioning. You cannot enable object locking on an existing bucket.

--- a/docs/resources/s3_bucket_server_side_encryption.md
+++ b/docs/resources/s3_bucket_server_side_encryption.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_server_side_encryption Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Manages server-side encryption configuration for an S3 bucket. Supports SSE-S3 (AES256) and SSE-KMS (aws:kms) encryption types.
 ---

--- a/docs/resources/s3_bucket_tags.md
+++ b/docs/resources/s3_bucket_tags.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_tags Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
     Manages tags for S3 buckets in MinIO.
 ---

--- a/docs/resources/s3_bucket_versioning.md
+++ b/docs/resources/s3_bucket_versioning.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_bucket_versioning Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   
 ---

--- a/docs/resources/s3_incomplete_upload_cleanup.md
+++ b/docs/resources/s3_incomplete_upload_cleanup.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_incomplete_upload_cleanup Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Cleans up incomplete/stuck multipart uploads in a MinIO bucket. Uses ListIncompleteUploads and RemoveIncompleteUpload to find and abort multipart uploads that were never completed.
 ---

--- a/docs/resources/s3_object.md
+++ b/docs/resources/s3_object.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_object Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   
 ---

--- a/docs/resources/s3_object_legal_hold.md
+++ b/docs/resources/s3_object_legal_hold.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_object_legal_hold Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Manages legal hold status for S3 objects in a MinIO bucket. The bucket must have object locking enabled.
 ---

--- a/docs/resources/s3_object_retention.md
+++ b/docs/resources/s3_object_retention.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_object_retention Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Manages retention policy for individual S3 objects. The bucket must have object locking enabled.
 ---

--- a/docs/resources/s3_object_tags.md
+++ b/docs/resources/s3_object_tags.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_s3_object_tags Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
   Manages tags for S3 objects in a MinIO bucket.
 ---

--- a/docs/resources/server_config_api.md
+++ b/docs/resources/server_config_api.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_api Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO API server configuration including request throttling, CORS, transition workers, and stale upload cleanup.
 ---

--- a/docs/resources/server_config_etcd.md
+++ b/docs/resources/server_config_etcd.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_etcd Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO etcd configuration for federated deployments and external IAM storage.
 ---

--- a/docs/resources/server_config_heal.md
+++ b/docs/resources/server_config_heal.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_heal Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO object healing configuration. Controls background bitrot scanning and data repair settings.
 ---

--- a/docs/resources/server_config_region.md
+++ b/docs/resources/server_config_region.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_region Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO server region/site name configuration.
 ---

--- a/docs/resources/server_config_scanner.md
+++ b/docs/resources/server_config_scanner.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_scanner Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO object scanner configuration. The scanner handles background tasks like lifecycle expiration, healing, and versioning cleanup.
 ---

--- a/docs/resources/server_config_storage_class.md
+++ b/docs/resources/server_config_storage_class.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_server_config_storage_class Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Manages MinIO storage class configuration for erasure coding parity. Controls data protection levels for STANDARD and REDUCED_REDUNDANCY storage classes.
 ---

--- a/docs/resources/service_action.md
+++ b/docs/resources/service_action.md
@@ -1,6 +1,6 @@
 ---
 page_title: "minio_service_action Resource - terraform-provider-minio"
-subcategory: ""
+subcategory: "Server"
 description: |-
   Performs a one-shot MinIO service control operation (restart, stop, freeze, or unfreeze). This resource is not stateful - taking it down does not undo the action.
 ---

--- a/docs/resources/site_replication.md
+++ b/docs/resources/site_replication.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Replication"
 description: |-
   Provides a MinIO Site Replication resource. This allows you to configure and manage site replication across multiple MinIO clusters, synchronizing buckets, IAM policies, users, groups, and other configurations.
 

--- a/templates/data-sources/account_info.md.tmpl
+++ b/templates/data-sources/account_info.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/batch_job_template.md.tmpl
+++ b/templates/data-sources/batch_job_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/batch_jobs.md.tmpl
+++ b/templates/data-sources/batch_jobs.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/bucket_metadata_export.md.tmpl
+++ b/templates/data-sources/bucket_metadata_export.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/config_history.md.tmpl
+++ b/templates/data-sources/config_history.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/data_usage.md.tmpl
+++ b/templates/data-sources/data_usage.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/health_status.md.tmpl
+++ b/templates/data-sources/health_status.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_export.md.tmpl
+++ b/templates/data-sources/iam_export.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_group.md.tmpl
+++ b/templates/data-sources/iam_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_groups.md.tmpl
+++ b/templates/data-sources/iam_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_policy.md.tmpl
+++ b/templates/data-sources/iam_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_policy_document.md.tmpl
+++ b/templates/data-sources/iam_policy_document.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_service_accounts.md.tmpl
+++ b/templates/data-sources/iam_service_accounts.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_user.md.tmpl
+++ b/templates/data-sources/iam_user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_user_policies.md.tmpl
+++ b/templates/data-sources/iam_user_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/iam_users.md.tmpl
+++ b/templates/data-sources/iam_users.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/ilm_policy.md.tmpl
+++ b/templates/data-sources/ilm_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/ilm_tier_stats.md.tmpl
+++ b/templates/data-sources/ilm_tier_stats.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/ilm_tiers.md.tmpl
+++ b/templates/data-sources/ilm_tiers.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/kms_metrics.md.tmpl
+++ b/templates/data-sources/kms_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/kms_status.md.tmpl
+++ b/templates/data-sources/kms_status.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/license_info.md.tmpl
+++ b/templates/data-sources/license_info.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_amqp.md.tmpl
+++ b/templates/data-sources/notify_amqp.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_elasticsearch.md.tmpl
+++ b/templates/data-sources/notify_elasticsearch.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_kafka.md.tmpl
+++ b/templates/data-sources/notify_kafka.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_mqtt.md.tmpl
+++ b/templates/data-sources/notify_mqtt.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_mysql.md.tmpl
+++ b/templates/data-sources/notify_mysql.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_nats.md.tmpl
+++ b/templates/data-sources/notify_nats.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_nsq.md.tmpl
+++ b/templates/data-sources/notify_nsq.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_postgres.md.tmpl
+++ b/templates/data-sources/notify_postgres.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_redis.md.tmpl
+++ b/templates/data-sources/notify_redis.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/notify_webhook.md.tmpl
+++ b/templates/data-sources/notify_webhook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/pool_rebalance_status.md.tmpl
+++ b/templates/data-sources/pool_rebalance_status.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/pool_status.md.tmpl
+++ b/templates/data-sources/pool_status.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/prometheus_scrape_config.md.tmpl
+++ b/templates/data-sources/prometheus_scrape_config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket.md.tmpl
+++ b/templates/data-sources/s3_bucket.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_anonymous_access.md.tmpl
+++ b/templates/data-sources/s3_bucket_anonymous_access.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_cors_config.md.tmpl
+++ b/templates/data-sources/s3_bucket_cors_config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_encryption.md.tmpl
+++ b/templates/data-sources/s3_bucket_encryption.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_notification_config.md.tmpl
+++ b/templates/data-sources/s3_bucket_notification_config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_object_lock_configuration.md.tmpl
+++ b/templates/data-sources/s3_bucket_object_lock_configuration.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_policy.md.tmpl
+++ b/templates/data-sources/s3_bucket_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_quota.md.tmpl
+++ b/templates/data-sources/s3_bucket_quota.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_replication.md.tmpl
+++ b/templates/data-sources/s3_bucket_replication.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Replication"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_replication_metrics.md.tmpl
+++ b/templates/data-sources/s3_bucket_replication_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Replication"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_replication_status.md.tmpl
+++ b/templates/data-sources/s3_bucket_replication_status.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Replication"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_retention.md.tmpl
+++ b/templates/data-sources/s3_bucket_retention.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_tags.md.tmpl
+++ b/templates/data-sources/s3_bucket_tags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_bucket_versioning.md.tmpl
+++ b/templates/data-sources/s3_bucket_versioning.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_buckets.md.tmpl
+++ b/templates/data-sources/s3_buckets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_object.md.tmpl
+++ b/templates/data-sources/s3_object.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/s3_objects.md.tmpl
+++ b/templates/data-sources/s3_objects.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/server_info.md.tmpl
+++ b/templates/data-sources/server_info.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/storage_info.md.tmpl
+++ b/templates/data-sources/storage_info.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/accesskey.md.tmpl
+++ b/templates/resources/accesskey.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/audit_kafka.md.tmpl
+++ b/templates/resources/audit_kafka.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/audit_webhook.md.tmpl
+++ b/templates/resources/audit_webhook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/batch_job.md.tmpl
+++ b/templates/resources/batch_job.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/bucket_metadata_import.md.tmpl
+++ b/templates/resources/bucket_metadata_import.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/config.md.tmpl
+++ b/templates/resources/config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/config_restore.md.tmpl
+++ b/templates/resources/config_restore.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_group.md.tmpl
+++ b/templates/resources/iam_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_group_membership.md.tmpl
+++ b/templates/resources/iam_group_membership.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_group_policy.md.tmpl
+++ b/templates/resources/iam_group_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_group_policy_attachment.md.tmpl
+++ b/templates/resources/iam_group_policy_attachment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_group_user_attachment.md.tmpl
+++ b/templates/resources/iam_group_user_attachment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_idp_ldap.md.tmpl
+++ b/templates/resources/iam_idp_ldap.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_idp_openid.md.tmpl
+++ b/templates/resources/iam_idp_openid.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_import.md.tmpl
+++ b/templates/resources/iam_import.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_ldap_group_policy_attachment.md.tmpl
+++ b/templates/resources/iam_ldap_group_policy_attachment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_ldap_user_policy_attachment.md.tmpl
+++ b/templates/resources/iam_ldap_user_policy_attachment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_policy.md.tmpl
+++ b/templates/resources/iam_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_service_account.md.tmpl
+++ b/templates/resources/iam_service_account.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_user.md.tmpl
+++ b/templates/resources/iam_user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_user_group_membership.md.tmpl
+++ b/templates/resources/iam_user_group_membership.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/iam_user_policy_attachment.md.tmpl
+++ b/templates/resources/iam_user_policy_attachment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "IAM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/ilm_policy.md.tmpl
+++ b/templates/resources/ilm_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/ilm_tier.md.tmpl
+++ b/templates/resources/ilm_tier.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/kms_key.md.tmpl
+++ b/templates/resources/kms_key.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/logger_webhook.md.tmpl
+++ b/templates/resources/logger_webhook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_amqp.md.tmpl
+++ b/templates/resources/notify_amqp.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_elasticsearch.md.tmpl
+++ b/templates/resources/notify_elasticsearch.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_kafka.md.tmpl
+++ b/templates/resources/notify_kafka.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_mqtt.md.tmpl
+++ b/templates/resources/notify_mqtt.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_mysql.md.tmpl
+++ b/templates/resources/notify_mysql.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_nats.md.tmpl
+++ b/templates/resources/notify_nats.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_nsq.md.tmpl
+++ b/templates/resources/notify_nsq.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_postgres.md.tmpl
+++ b/templates/resources/notify_postgres.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_redis.md.tmpl
+++ b/templates/resources/notify_redis.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/notify_webhook.md.tmpl
+++ b/templates/resources/notify_webhook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/pool_decommission.md.tmpl
+++ b/templates/resources/pool_decommission.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/pool_rebalance.md.tmpl
+++ b/templates/resources/pool_rebalance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/prometheus_bearer_token.md.tmpl
+++ b/templates/resources/prometheus_bearer_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket.md.tmpl
+++ b/templates/resources/s3_bucket.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_anonymous_access.md.tmpl
+++ b/templates/resources/s3_bucket_anonymous_access.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   Manage anonymous access to an existing MinIO bucket using canned access types or fully custom JSON policies.
 ---

--- a/templates/resources/s3_bucket_cors.md.tmpl
+++ b/templates/resources/s3_bucket_cors.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_lifecycle.md.tmpl
+++ b/templates/resources/s3_bucket_lifecycle.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "ILM"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_notification.md.tmpl
+++ b/templates/resources/s3_bucket_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Notifications"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_object_lock_configuration.md.tmpl
+++ b/templates/resources/s3_bucket_object_lock_configuration.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_policy.md.tmpl
+++ b/templates/resources/s3_bucket_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_quota.md.tmpl
+++ b/templates/resources/s3_bucket_quota.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_replication.md.tmpl
+++ b/templates/resources/s3_bucket_replication.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Replication"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_retention.md.tmpl
+++ b/templates/resources/s3_bucket_retention.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_server_side_encryption.md.tmpl
+++ b/templates/resources/s3_bucket_server_side_encryption.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_tags.md.tmpl
+++ b/templates/resources/s3_bucket_tags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
   {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_bucket_versioning.md.tmpl
+++ b/templates/resources/s3_bucket_versioning.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Buckets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_incomplete_upload_cleanup.md.tmpl
+++ b/templates/resources/s3_incomplete_upload_cleanup.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_object.md.tmpl
+++ b/templates/resources/s3_object.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_object_legal_hold.md.tmpl
+++ b/templates/resources/s3_object_legal_hold.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_object_retention.md.tmpl
+++ b/templates/resources/s3_object_retention.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/s3_object_tags.md.tmpl
+++ b/templates/resources/s3_object_tags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "S3 Objects"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_api.md.tmpl
+++ b/templates/resources/server_config_api.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_etcd.md.tmpl
+++ b/templates/resources/server_config_etcd.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_heal.md.tmpl
+++ b/templates/resources/server_config_heal.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_region.md.tmpl
+++ b/templates/resources/server_config_region.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_scanner.md.tmpl
+++ b/templates/resources/server_config_scanner.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/server_config_storage_class.md.tmpl
+++ b/templates/resources/server_config_storage_class.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/service_action.md.tmpl
+++ b/templates/resources/service_action.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "Server"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/site_replication.md.tmpl
+++ b/templates/resources/site_replication.md.tmpl
@@ -1,4 +1,5 @@
 ---
+subcategory: "Replication"
 description: |-
   Provides a MinIO Site Replication resource. This allows you to configure and manage site replication across multiple MinIO clusters, synchronizing buckets, IAM policies, users, groups, and other configurations.
 


### PR DESCRIPTION
## Description

### Type of Change
- [x] Documentation update

### What does this PR do?

Implements #1120: every resource and data source doc page gets one of **seven subcategories**, so the Terraform Registry sidebar renders as a table of contents instead of a flat alphabetical list of 119 pages.

| Subcategory | Pages (resources + data sources) |
| --- | --- |
| Server | 30 |
| IAM | 26 |
| S3 Buckets | 23 |
| Notifications | 22 |
| S3 Objects | 7 |
| ILM | 6 |
| Replication | 5 |

Judgment calls, so review can focus on them:
- **All notification pages live under Notifications**, including `s3_bucket_notification` (resource) and `s3_bucket_notification_config` (data source) — grouping the whole notification story together beat splitting it between S3 Buckets and Notifications.
- **`s3_bucket_lifecycle` sits under ILM** with `ilm_policy`/`ilm_tier`, since lifecycle *is* ILM.
- **`account_info` sits under IAM** (it describes the calling identity's account).
- **`site_replication.md.tmpl` had no `subcategory` field at all** — the reason it escaped the empty-value count in the issue. It gains one under Replication, inserted at the top of its frontmatter (that template also has no `page_title` line, unlike every other template — pre-existing inconsistency, left as is).

The generated `docs/` mirror the same frontmatter change, which is byte-for-byte what tfplugindocs regeneration produces for a frontmatter-only edit; the auto-generate workflow on `main` will confirm zero drift after merge.

### Acceptance criteria from #1120

- [x] `grep -rl 'subcategory: ""' templates/ | wc -l` returns 0 (and `grep -rLE 'subcategory: "'` finds no page missing the field entirely, which catches the `site_replication` case the issue's own count missed)
- [x] 7 distinct subcategories, each used by ≥5 pages — no singletons
- [x] `docs/` updated in the same PR
- [ ] Registry sidebar spot-check after the next release publishes

### Related Issues

- Closes #1120