### PR TITLE
ci: measure test coverage and publish it to Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -109,6 +109,21 @@ jobs:
       - name: Run tests
         run: docker compose run --rm test
 
+      - name: Upload coverage artifact
+        if: always() && hashFiles('coverage.out') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage
+          path: coverage.out
+
+      - name: Upload coverage to Codecov
+        if: always() && hashFiles('coverage.out') != ''
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          files: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: Cleanup test environment
         if: always()
         run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://github.com/aminueza/terraform-provider-minio/actions/workflows/go.yml?query=branch%3Amain">
     <img alt="CI" src="https://img.shields.io/github/actions/workflow/status/aminueza/terraform-provider-minio/go.yml?branch=main&label=ci">
   </a>
+  <a href="https://codecov.io/gh/aminueza/terraform-provider-minio">
+    <img alt="Coverage" src="https://codecov.io/gh/aminueza/terraform-provider-minio/graph/badge.svg">
+  </a>
   <a href="go.mod">
     <img alt="Go version" src="https://img.shields.io/github/go-mod/go-version/aminueza/terraform-provider-minio">
   </a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
         go mod download
         go mod verify
         echo 'Running tests...'
-        go test -v -failfast -timeout 30m ./minio $${TEST_PATTERN:+-run $$TEST_PATTERN}
+        go test -v -failfast -timeout 30m -coverprofile=coverage.out -covermode=atomic ./minio $${TEST_PATTERN:+-run $$TEST_PATTERN}
     environment:
       TF_ACC: "1"
       # Admin API version for madmin-go/v4. The pinned MinIO image only speaks


### PR DESCRIPTION
## Description

### Type of Change
- [x] CI change

### What does this PR do?

Implements #1118.

- `docker-compose.yml`: the test run now writes `coverage.out` (`-coverprofile=coverage.out -covermode=atomic`). The provider runs in-process during acceptance tests, so the profile measures provider code, not only unit tests.
- `go.yml`: the Test job uploads `coverage.out` as a build artifact and to Codecov. Both steps are guarded with `hashFiles('coverage.out') != ''`. The Codecov step sets `fail_ci_if_error: false`: a missing token or a Codecov outage does not block merges. Both actions are SHA-pinned (`upload-artifact` v7.0.1, `codecov-action` v5.5.5), matching the repository convention.
- `README.md`: adds the Codecov badge next to the CI badge.

No threshold is set. Per #1118, the baseline comes first; the ratchet decision is a follow-up after real data exists.

### Verification

- `go test -coverprofile -covermode=atomic ./minio` runs clean locally and prints a coverage total.
- Both workflow files parse as YAML.

### Admin follow-up (required for full effect)

1. Sign in at codecov.io with GitHub and activate this repository.
2. Add the `CODECOV_TOKEN` repository secret. Until then, uploads may be rate-limited; CI stays green either way.
3. The badge and the PR coverage comment activate after the first upload from `main`.

### Related Issues

- Closes #1118