### PR TITLE
chore: remove redundant comment lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ if !ok {
 - Never print with `fmt.Println` / `println`.
 - Never ignore errors from `d.Set` or API calls.
 - Never hardcode test resource names (always randomize).
+- Never leave a comment that restates the code below it, or a commented-out code block.
 
 ## Project Structure
 
@@ -116,6 +117,29 @@ go test ./minio/...
   - Constants: UPPER_SNAKE_CASE
 - **Types:** Use explicit types for all function parameters and return values
 - **Error handling:** Use `NewResourceError()` from `error.go` for consistent diagnostics
+
+## Comment Hygiene
+
+Comments are the exception, not the rule: code should explain itself, and a comment is justified only when the code cannot say what is going on. A comment must explain *why*, never *what*.
+
+**Delete a comment when:**
+
+- it restates the identifier or the statement below it (`// Set the ID to the key` above `d.SetId(key)`)
+- it narrates self-evident steps (`// Initialize S3 client`, `// Parse the config`)
+- it labels a group of entries that are already grouped by their own names (section markers in the resource/data-source maps)
+- it is commented-out code (delete it; history lives in git)
+
+**Keep a comment only when it records something the code cannot:**
+
+- a non-obvious *why*: workarounds for MinIO server or SDK behavior, eventual-consistency handling, legacy/compatibility traps, state-convergence and security decisions
+- contracts and edge cases not visible in the signature (return-value semantics, caller obligations, overflow/nil handling)
+- references to external docs, issues, or tickets (e.g. `See issue #608`)
+
+**Rules:**
+
+- Never leave a stale comment: when you change the code a comment describes, update or delete the comment in the same change.
+- Prefer deleting over trimming; when trimming, keep the *why* and drop the restatement.
+- Doc comments on exported helpers are only warranted when they state behavior callers must know; the type/function name is not enough of a reason.
 
 ## Error Handling Guidelines
 

--- a/minio/check_config.go
+++ b/minio/check_config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// ConfigError represents an error that occurred during configuration
 type ConfigError struct {
 	Field   string
 	Message string
@@ -19,7 +18,6 @@ func (e *ConfigError) Error() string {
 	return fmt.Sprintf("configuration error for field %q: %s", e.Field, e.Message)
 }
 
-// getOptionalField safely gets an optional field from the ResourceData with a default value
 func getOptionalField(d *schema.ResourceData, field string, defaultValue interface{}) interface{} {
 	if v, ok := d.GetOk(field); ok {
 		return v
@@ -27,8 +25,6 @@ func getOptionalField(d *schema.ResourceData, field string, defaultValue interfa
 	return defaultValue
 }
 
-// BucketConfig creates a new configuration for MinIO buckets.
-// It handles the basic bucket configuration including ACL, prefixes, and object locking.
 func BucketConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucket {
 	m := meta.(*S3MinioClient)
 
@@ -47,8 +43,6 @@ func BucketConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucket {
 	}
 }
 
-// BucketVersioningConfig creates configuration for managing MinIO bucket versioning.
-// It handles versioning configuration including excluded prefixes and folders.
 func BucketVersioningConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketVersioning {
 	m := meta.(*S3MinioClient)
 
@@ -61,8 +55,6 @@ func BucketVersioningConfig(d *schema.ResourceData, meta interface{}) *S3MinioBu
 	}
 }
 
-// BucketReplicationConfig creates configuration for managing MinIO bucket replication.
-// It sets up replication rules between buckets.
 func BucketReplicationConfig(ctx context.Context, d *schema.ResourceData, meta interface{}) (*S3MinioBucketReplication, diag.Diagnostics) {
 	m := meta.(*S3MinioClient)
 
@@ -79,8 +71,6 @@ func BucketReplicationConfig(ctx context.Context, d *schema.ResourceData, meta i
 	}, nil
 }
 
-// BucketNotificationConfig creates configuration for managing MinIO bucket notifications.
-// It sets up event notifications for bucket operations.
 func BucketNotificationConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketNotification {
 	m := meta.(*S3MinioClient)
 	config := getNotificationConfiguration(d)
@@ -101,8 +91,6 @@ func BucketCorsConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketCo
 	}
 }
 
-// BucketServerSideEncryptionConfig creates configuration for managing MinIO bucket server-side encryption.
-// It handles encryption settings for bucket objects.
 func BucketServerSideEncryptionConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketServerSideEncryption {
 	m := meta.(*S3MinioClient)
 
@@ -115,7 +103,6 @@ func BucketServerSideEncryptionConfig(d *schema.ResourceData, meta interface{}) 
 	}
 }
 
-// BucketObjectLockConfigurationConfig extracts object lock config from resource data.
 func BucketObjectLockConfigurationConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketObjectLockConfiguration {
 	m := meta.(*S3MinioClient)
 
@@ -126,7 +113,6 @@ func BucketObjectLockConfigurationConfig(d *schema.ResourceData, meta interface{
 	}
 }
 
-// BucketPolicyConfig creates configuration for managing MinIO bucket policies.
 func BucketPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucketPolicy {
 	m := meta.(*S3MinioClient)
 
@@ -137,8 +123,6 @@ func BucketPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioBucket
 	}
 }
 
-// NewConfig creates a new MinIO client configuration.
-// It handles authentication and connection settings.
 func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 	// Get user credentials with fallback to legacy access key
 	user := getOptionalField(d, "minio_user", "").(string)
@@ -201,8 +185,6 @@ func NewConfig(d *schema.ResourceData) *S3MinioConfig {
 	return cfg
 }
 
-// ServiceAccountConfig creates configuration for MinIO service accounts.
-// It handles service account creation and management.
 func ServiceAccountConfig(d *schema.ResourceData, meta interface{}) *S3MinioServiceAccountConfig {
 	m := meta.(*S3MinioClient)
 
@@ -220,8 +202,6 @@ func ServiceAccountConfig(d *schema.ResourceData, meta interface{}) *S3MinioServ
 	}
 }
 
-// IAMUserConfig creates configuration for MinIO IAM users.
-// It handles user creation and management in the IAM system.
 func IAMUserConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMUserConfig {
 	m := meta.(*S3MinioClient)
 
@@ -235,8 +215,6 @@ func IAMUserConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMUserConf
 	}
 }
 
-// IAMGroupConfig creates configuration for MinIO IAM groups.
-// It handles group creation and management.
 func IAMGroupConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMGroupConfig {
 	m := meta.(*S3MinioClient)
 
@@ -248,8 +226,6 @@ func IAMGroupConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMGroupCo
 	}
 }
 
-// IAMGroupAttachmentConfig creates configuration for MinIO IAM group attachments.
-// It handles attaching a single user to a group.
 func IAMGroupAttachmentConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMGroupAttachmentConfig {
 	m := meta.(*S3MinioClient)
 
@@ -260,8 +236,6 @@ func IAMGroupAttachmentConfig(d *schema.ResourceData, meta interface{}) *S3Minio
 	}
 }
 
-// IAMGroupMembershipConfig creates configuration for MinIO IAM group memberships.
-// It handles attaching multiple users to a group.
 func IAMGroupMembershipConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMGroupMembershipConfig {
 	m := meta.(*S3MinioClient)
 
@@ -275,8 +249,6 @@ func IAMGroupMembershipConfig(d *schema.ResourceData, meta interface{}) *S3Minio
 	}
 }
 
-// IAMPolicyConfig creates configuration for MinIO IAM policies.
-// It handles policy creation and management.
 func IAMPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMPolicyConfig {
 	m := meta.(*S3MinioClient)
 
@@ -288,8 +260,6 @@ func IAMPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMPolicy
 	}
 }
 
-// IAMGroupPolicyConfig creates configuration for MinIO IAM group policies.
-// It handles attaching policies to groups.
 func IAMGroupPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMGroupPolicyConfig {
 	m := meta.(*S3MinioClient)
 
@@ -302,8 +272,6 @@ func IAMGroupPolicyConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMG
 	}
 }
 
-// KMSKeyConfig creates configuration for MinIO KMS keys.
-// It handles key management system configuration.
 func KMSKeyConfig(d *schema.ResourceData, meta interface{}) *S3MinioKMSKeyConfig {
 	m := meta.(*S3MinioClient)
 
@@ -313,7 +281,6 @@ func KMSKeyConfig(d *schema.ResourceData, meta interface{}) *S3MinioKMSKeyConfig
 	}
 }
 
-// ObjectTagsConfig creates configuration for managing object tags.
 func ObjectTagsConfig(d *schema.ResourceData, meta interface{}) *S3MinioObjectTags {
 	m := meta.(*S3MinioClient)
 
@@ -324,7 +291,6 @@ func ObjectTagsConfig(d *schema.ResourceData, meta interface{}) *S3MinioObjectTa
 	}
 }
 
-// ObjectLegalHoldConfig creates configuration for managing object legal hold.
 func ObjectLegalHoldConfig(d *schema.ResourceData, meta interface{}) *S3MinioObjectLegalHold {
 	m := meta.(*S3MinioClient)
 
@@ -337,7 +303,6 @@ func ObjectLegalHoldConfig(d *schema.ResourceData, meta interface{}) *S3MinioObj
 	}
 }
 
-// PrometheusBearerTokenConfig creates configuration for MinIO Prometheus bearer token.
 func PrometheusBearerTokenConfig(d *schema.ResourceData, meta interface{}) *S3MinioPrometheusBearerToken {
 	m := meta.(*S3MinioClient)
 
@@ -351,7 +316,6 @@ func PrometheusBearerTokenConfig(d *schema.ResourceData, meta interface{}) *S3Mi
 	}
 }
 
-// PrometheusScrapeConfig creates configuration for MinIO Prometheus scrape config.
 func PrometheusScrapeConfig(d *schema.ResourceData, meta interface{}) *S3MinioPrometheusScrapeConfig {
 	m := meta.(*S3MinioClient)
 
@@ -372,7 +336,6 @@ func PrometheusScrapeConfig(d *schema.ResourceData, meta interface{}) *S3MinioPr
 	return payload
 }
 
-// IdpLdapConfig creates configuration for an LDAP identity provider resource.
 func IdpLdapConfig(d *schema.ResourceData, meta interface{}) *S3MinioIdpLdap {
 	m := meta.(*S3MinioClient)
 
@@ -392,7 +355,6 @@ func IdpLdapConfig(d *schema.ResourceData, meta interface{}) *S3MinioIdpLdap {
 	}
 }
 
-// IdpOpenIdConfig creates configuration for an OpenID Connect identity provider resource.
 func IdpOpenIdConfig(d *schema.ResourceData, meta interface{}) *S3MinioIdpOpenId {
 	m := meta.(*S3MinioClient)
 
@@ -413,7 +375,6 @@ func IdpOpenIdConfig(d *schema.ResourceData, meta interface{}) *S3MinioIdpOpenId
 	}
 }
 
-// AuditWebhookConfig creates configuration for an audit webhook resource.
 func AuditWebhookConfig(d *schema.ResourceData, meta interface{}) *S3MinioAuditWebhook {
 	m := meta.(*S3MinioClient)
 
@@ -430,7 +391,6 @@ func AuditWebhookConfig(d *schema.ResourceData, meta interface{}) *S3MinioAuditW
 	}
 }
 
-// IAMImportConfig extracts IAM import config from resource data.
 func IAMImportConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMImport {
 	m := meta.(*S3MinioClient)
 	return &S3MinioIAMImport{
@@ -439,7 +399,6 @@ func IAMImportConfig(d *schema.ResourceData, meta interface{}) *S3MinioIAMImport
 	}
 }
 
-// IncompleteUploadCleanupConfig extracts incomplete upload cleanup config from resource data.
 func IncompleteUploadCleanupConfig(d *schema.ResourceData, meta interface{}) *S3MinioIncompleteUploadCleanup {
 	m := meta.(*S3MinioClient)
 

--- a/minio/data_source_iam_users.go
+++ b/minio/data_source_iam_users.go
@@ -68,7 +68,6 @@ func dataSourceIAMUsersRead(ctx context.Context, d *schema.ResourceData, meta in
 
 		switch wantStatus {
 		case "all":
-			// keep
 		case "enabled":
 			if status != "enabled" {
 				continue

--- a/minio/data_source_minio_health_status_test.go
+++ b/minio/data_source_minio_health_status_test.go
@@ -24,7 +24,6 @@ func TestAccDataSourceMinioHealthStatus_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.minio_health_status.test", "healthy", "true"),
 					// Standalone instance returns false (can't go down without losing service)
 					resource.TestCheckResourceAttr("data.minio_health_status.test", "safe_for_maintenance", "false"),
-					// Verify outputs contain the actual data
 					resource.TestCheckOutput("health_live", "true"),
 					resource.TestCheckOutput("health_ready", "true"),
 					resource.TestCheckOutput("health_overall", "true"),
@@ -42,10 +41,8 @@ func TestAccDataSourceMinioHealthStatus_multipleReads(t *testing.T) {
 			{
 				Config: testAccDataSourceMinioHealthStatusConfigMultiple(),
 				Check: resource.ComposeTestCheckFunc(
-					// First data source
 					resource.TestCheckResourceAttrSet("data.minio_health_status.first", "id"),
 					resource.TestCheckResourceAttrSet("data.minio_health_status.first", "healthy"),
-					// Second data source
 					resource.TestCheckResourceAttrSet("data.minio_health_status.second", "id"),
 					resource.TestCheckResourceAttrSet("data.minio_health_status.second", "healthy"),
 					// Both should report same health status

--- a/minio/data_source_minio_s3_bucket_anonymous_access_test.go
+++ b/minio/data_source_minio_s3_bucket_anonymous_access_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TestAccDataSourceMinioS3BucketAnonymousAccess_cannedTypes verifies that the data
-// source correctly reads back the policy and derives the matching canned access_type
-// for each of the four supported canned modes.
-//
 // The data source only sees the policy, and `public-read-write` writes the same policy as
 // `public`, so that is what it derives for both.
 func TestAccDataSourceMinioS3BucketAnonymousAccess_cannedTypes(t *testing.T) {
@@ -45,9 +41,6 @@ func TestAccDataSourceMinioS3BucketAnonymousAccess_cannedTypes(t *testing.T) {
 	}
 }
 
-// TestAccDataSourceMinioS3BucketAnonymousAccess_customPolicy verifies that when the
-// bucket has a custom (non-canned) policy the data source returns the raw policy JSON
-// and leaves access_type empty.
 func TestAccDataSourceMinioS3BucketAnonymousAccess_customPolicy(t *testing.T) {
 	bucketName := "tfacc-anon-" + acctest.RandString(6)
 
@@ -80,10 +73,6 @@ func TestAccDataSourceMinioS3BucketAnonymousAccess_customPolicy(t *testing.T) {
 	})
 }
 
-// TestAccDataSourceMinioS3BucketAnonymousAccess_policyMatchesResource verifies that
-// the data source derives the same access_type as the resource and exposes a non-empty
-// policy for the public-read canned type round-trip.
-//
 // Note: exact policy string equality is intentionally not asserted. The resource's read
 // path may return struct-marshaled JSON (e.g. Version before Statement) while the data
 // source normalizes via structure.NormalizeJsonString (alphabetical key order). Both

--- a/minio/error.go
+++ b/minio/error.go
@@ -11,18 +11,15 @@ import (
 )
 
 const (
-	// ErrorSeverityFatal indicates a fatal error that prevents further execution
 	ErrorSeverityFatal = "[FATAL]"
 )
 
-// ResourceError represents an error that occurred while managing a MinIO resource
 type ResourceError struct {
 	Message  string
 	Resource string
 	Err      error
 }
 
-// Error implements the error interface for ResourceError
 func (e *ResourceError) Error() string {
 	if e.Err != nil {
 		return fmt.Sprintf("%s %s (%s): %v", ErrorSeverityFatal, e.Message, e.Resource, e.Err)
@@ -30,21 +27,7 @@ func (e *ResourceError) Error() string {
 	return fmt.Sprintf("%s %s (%s)", ErrorSeverityFatal, e.Message, e.Resource)
 }
 
-// NewResourceError creates a diagnostic error for a MinIO resource operation.
-// It handles different error types and formats them consistently:
-//   - diag.Diagnostics: appends a new diagnostic
-//   - error: creates a new diagnostic with error details
-//   - other: creates a new diagnostic with string representation
-//
-// Parameters:
-//   - msg: A descriptive message about what operation failed
-//   - resource: The name or identifier of the resource that failed
-//   - err: The underlying error (can be diag.Diagnostics, error, or other type)
-//
-// Returns:
-//   - diag.Diagnostics containing the formatted error
 func NewResourceError(msg string, resource string, err interface{}) diag.Diagnostics {
-	// Create a ResourceError for consistent error formatting
 	resErr := &ResourceError{
 		Message:  msg,
 		Resource: resource,
@@ -74,23 +57,12 @@ func NewResourceError(msg string, resource string, err interface{}) diag.Diagnos
 	}
 }
 
-// NewResourceErrorStr creates a string representation of a resource error.
-// This is useful when you need to return a string error message instead of diagnostics.
-//
-// Parameters:
-//   - msg: A descriptive message about what operation failed
-//   - resource: The name or identifier of the resource that failed
-//   - err: The underlying error (can be diag.Diagnostics, error, or other type)
-//
-// Returns:
-//   - A string containing all error messages joined with commas
 func NewResourceErrorStr(msg string, resource string, err interface{}) string {
 	diags := NewResourceError(msg, resource, err)
 	if len(diags) == 0 {
 		return ""
 	}
 
-	// Create a slice with the correct initial capacity
 	strs := make([]string, 0, len(diags))
 	for _, d := range diags {
 		if d.Summary != "" {

--- a/minio/fuzz_test.go
+++ b/minio/fuzz_test.go
@@ -5,10 +5,7 @@ import (
 	"testing"
 )
 
-// FuzzNormalizeAndCompareJSONPolicies verifies that NormalizeAndCompareJSONPolicies
-// never panics on arbitrary JSON-like input, including malformed documents.
 func FuzzNormalizeAndCompareJSONPolicies(f *testing.F) {
-	// Seed corpus: representative policy documents
 	f.Add(`{"Version":"2012-10-17","Statement":[]}`, `{"Version":"2012-10-17","Statement":[]}`)
 	f.Add(``, `{"Version":"2012-10-17","Statement":[]}`)
 	f.Add(`{}`, `{}`)
@@ -20,15 +17,11 @@ func FuzzNormalizeAndCompareJSONPolicies(f *testing.F) {
 	f.Add(`{"Version":"2012-10-17"}`, ``)
 
 	f.Fuzz(func(t *testing.T, oldPolicy, newPolicy string) {
-		// Must not panic regardless of input
 		_, _ = NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy)
 	})
 }
 
-// FuzzParseBandwidthLimit verifies that ParseBandwidthLimit never panics on
-// arbitrary bandwidth string values, including malformed ones.
 func FuzzParseBandwidthLimit(f *testing.F) {
-	// Seed corpus: valid and invalid bandwidth strings
 	f.Add("100MB")
 	f.Add("1GB")
 	f.Add("500k")
@@ -42,7 +35,6 @@ func FuzzParseBandwidthLimit(f *testing.F) {
 		target := map[string]any{
 			"bandwidth_limit": bandwidthStr,
 		}
-		// Must not panic regardless of input
 		_, _, _ = ParseBandwidthLimit(context.Background(), target)
 	})
 }

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	// MinTLSVersion is the minimum TLS version supported
 	MinTLSVersion = tls.VersionTLS12
 )
 
@@ -28,16 +27,12 @@ const (
 // instead of leaving callers with two strings that never match.
 const aistorEdition = "AIStor"
 
-// NewClient creates and configures both S3 and admin clients for MinIO
-// It handles the setup of credentials, SSL/TLS configuration, and custom transport options
 func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error) {
-	// Set up custom transport with SSL/TLS configuration
 	tr, err := config.customTransport(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure transport: %w", err)
 	}
 
-	// Initialize credentials based on API signature version
 	var minioCredentials *credentials.Credentials
 	switch config.S3APISignature {
 	case "v2":
@@ -103,7 +98,6 @@ func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error)
 		tflog.Debug(ctx, "Using STS WebIdentity credentials")
 	}
 
-	// Initialize S3 client
 	minioClient, err := minio.New(config.S3HostPort, &minio.Options{
 		Creds:     minioCredentials,
 		Secure:    config.S3SSL,
@@ -114,7 +108,6 @@ func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error)
 		return nil, fmt.Errorf("failed to create S3 client: %w", err)
 	}
 
-	// Initialize admin client
 	minioAdmin, err := madmin.NewWithOptions(config.S3HostPort, &madmin.Options{
 		Creds:     minioCredentials,
 		Secure:    config.S3SSL,
@@ -179,7 +172,6 @@ func normalizeEdition(edition string) string {
 	return edition
 }
 
-// isValidCertificate checks if the provided bytes represent a valid x509 certificate in PEM format
 func isValidCertificate(certBytes []byte) bool {
 	block, _ := pem.Decode(certBytes)
 	if block == nil {
@@ -189,12 +181,9 @@ func isValidCertificate(certBytes []byte) bool {
 	return err == nil
 }
 
-// customTransport creates and configures an HTTP transport with SSL/TLS settings
-// It handles CA certificates, client certificates, and verification settings
 func (config *S3MinioConfig) customTransport(ctx context.Context) (*http.Transport, error) {
 	timeout := time.Duration(config.RequestTimeoutSeconds) * time.Second
 
-	// If SSL is disabled, return default transport with timeout settings
 	if !config.S3SSL {
 		tr, err := minio.DefaultTransport(config.S3SSL)
 		if err != nil {
@@ -208,38 +197,31 @@ func (config *S3MinioConfig) customTransport(ctx context.Context) (*http.Transpo
 		return tr, nil
 	}
 
-	// Initialize TLS config with minimum version
 	tlsConfig := &tls.Config{
-		MinVersion: MinTLSVersion, // Minimum TLS 1.2 for security
+		MinVersion: MinTLSVersion,
 	}
 
-	// Get default transport
 	tr, err := minio.DefaultTransport(config.S3SSL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default transport: %w", err)
 	}
 
-	// Configure CA certificate if provided
 	if config.S3SSLCACertFile != "" {
 		if err := config.configureCACert(tlsConfig); err != nil {
 			return nil, err
 		}
 	}
 
-	// Configure client certificates if both cert and key are provided
 	if config.S3SSLCertFile != "" && config.S3SSLKeyFile != "" {
 		if err := config.configureClientCert(tlsConfig); err != nil {
 			return nil, err
 		}
 	}
 
-	// Configure SSL verification
 	tlsConfig.InsecureSkipVerify = config.S3SSLSkipVerify
 
-	// Set TLS config on transport
 	tr.TLSClientConfig = tlsConfig
 
-	// Apply timeout settings
 	tr.DialContext = (&net.Dialer{
 		Timeout:   timeout,
 		KeepAlive: 30 * time.Second,
@@ -251,7 +233,6 @@ func (config *S3MinioConfig) customTransport(ctx context.Context) (*http.Transpo
 	return tr, nil
 }
 
-// configureCACert loads and configures the CA certificate for TLS verification
 func (config *S3MinioConfig) configureCACert(tlsConfig *tls.Config) error {
 	caCert, err := os.ReadFile(config.S3SSLCACertFile)
 	if err != nil {
@@ -277,7 +258,6 @@ func (config *S3MinioConfig) configureCACert(tlsConfig *tls.Config) error {
 	return nil
 }
 
-// configureClientCert loads and configures client certificates for mutual TLS
 func (config *S3MinioConfig) configureClientCert(tlsConfig *tls.Config) error {
 	cert, err := tls.LoadX509KeyPair(config.S3SSLCertFile, config.S3SSLKeyFile)
 	if err != nil {

--- a/minio/payload.go
+++ b/minio/payload.go
@@ -11,7 +11,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/sse"
 )
 
-// S3MinioConfig defines variable for minio
 type S3MinioConfig struct {
 	S3HostPort        string
 	S3UserAccess      string
@@ -43,7 +42,6 @@ type S3MinioConfig struct {
 	RetryDelayMs          int
 }
 
-// S3MinioClient defines default minio
 type S3MinioClient struct {
 	S3UserAccess      string
 	S3Region          string
@@ -61,7 +59,6 @@ type S3MinioClient struct {
 	RetryDelayMs          int
 }
 
-// S3MinioBucket defines minio config
 type S3MinioBucket struct {
 	MinioClient          *minio.Client
 	MinioAdmin           *madmin.AdminClient
@@ -76,21 +73,18 @@ type S3MinioBucket struct {
 	S3CompatMode         bool
 }
 
-// S3MinioBucketPolicy defines bucket policy config
 type S3MinioBucketPolicy struct {
 	MinioClient       *minio.Client
 	MinioBucket       string
 	MinioBucketPolicy string
 }
 
-// S3MinioBucketVersioningConfiguration defines bucket versioning config
 type S3MinioBucketVersioningConfiguration struct {
 	Status           string
 	ExcludedPrefixes []string
 	ExcludeFolders   bool
 }
 
-// S3PathStyle
 type S3PathStyle int8
 
 const (
@@ -110,7 +104,6 @@ func (p S3PathStyle) String() string {
 	}
 }
 
-// S3MinioBucketReplicationConfiguration defines bucket replication rule
 type S3MinioBucketReplicationRule struct {
 	Id       string
 	Arn      string
@@ -128,7 +121,6 @@ type S3MinioBucketReplicationRule struct {
 	Target S3MinioBucketReplicationRuleTarget
 }
 
-// S3MinioBucketReplicationRuleTarget defines bucket replication rule target
 type S3MinioBucketReplicationRuleTarget struct {
 	Bucket            string
 	StorageClass      string
@@ -145,14 +137,12 @@ type S3MinioBucketReplicationRuleTarget struct {
 	SecretKey         string
 }
 
-// S3MinioBucketVersioning defines bucket versioning
 type S3MinioBucketVersioning struct {
 	MinioClient             *minio.Client
 	MinioBucket             string
 	VersioningConfiguration *S3MinioBucketVersioningConfiguration
 }
 
-// S3MinioBucketReplication defines bucket replication
 type S3MinioBucketReplication struct {
 	MinioAdmin       *madmin.AdminClient
 	MinioClient      *minio.Client
@@ -160,27 +150,23 @@ type S3MinioBucketReplication struct {
 	ReplicationRules []S3MinioBucketReplicationRule
 }
 
-// S3MinioBucketNotification
 type S3MinioBucketNotification struct {
 	MinioClient   *minio.Client
 	MinioBucket   string
 	Configuration *notification.Configuration
 }
 
-// S3MinioBucketServerSideEncryption defines bucket encryption
 type S3MinioBucketServerSideEncryption struct {
 	MinioClient   *minio.Client
 	MinioBucket   string
 	Configuration *sse.Configuration
 }
 
-// S3MinioBucketCors defines bucket CORS configuration
 type S3MinioBucketCors struct {
 	MinioClient *minio.Client
 	MinioBucket string
 }
 
-// S3MinioBucketObjectLockConfiguration defines bucket object lock configuration
 type S3MinioBucketObjectLockConfiguration struct {
 	MinioClient       *minio.Client
 	MinioBucket       string
@@ -190,7 +176,6 @@ type S3MinioBucketObjectLockConfiguration struct {
 	Unit              *minio.ValidityUnit
 }
 
-// S3MinioServiceAccountConfig defines service account config
 type S3MinioServiceAccountConfig struct {
 	MinioAdmin        *madmin.AdminClient
 	MinioTargetUser   string
@@ -206,7 +191,6 @@ type S3MinioServiceAccountConfig struct {
 	MinioExpiration   string
 }
 
-// S3MinioIAMUserConfig defines IAM config
 type S3MinioIAMUserConfig struct {
 	MinioAdmin        *madmin.AdminClient
 	MinioIAMName      string
@@ -217,7 +201,6 @@ type S3MinioIAMUserConfig struct {
 	MinioIAMTags      map[string]string
 }
 
-// S3MinioIAMGroupConfig defines IAM Group config
 type S3MinioIAMGroupConfig struct {
 	MinioAdmin        *madmin.AdminClient
 	MinioIAMName      string
@@ -225,14 +208,12 @@ type S3MinioIAMGroupConfig struct {
 	MinioForceDestroy bool
 }
 
-// S3MinioIAMGroupAttachmentConfig defines IAM Group membership config
 type S3MinioIAMGroupAttachmentConfig struct {
 	MinioAdmin    *madmin.AdminClient
 	MinioIAMUser  string
 	MinioIAMGroup string
 }
 
-// S3MinioIAMGroupMembershipConfig defines IAM Group membership config
 type S3MinioIAMGroupMembershipConfig struct {
 	MinioAdmin    *madmin.AdminClient
 	MinioIAMName  string
@@ -240,7 +221,6 @@ type S3MinioIAMGroupMembershipConfig struct {
 	MinioIAMGroup string
 }
 
-// S3MinioIAMPolicyConfig defines IAM Policy config
 type S3MinioIAMPolicyConfig struct {
 	MinioAdmin         *madmin.AdminClient
 	MinioIAMName       string
@@ -248,7 +228,6 @@ type S3MinioIAMPolicyConfig struct {
 	MinioIAMPolicy     string
 }
 
-// S3MinioIAMGroupPolicyConfig defines IAM Policy config
 type S3MinioIAMGroupPolicyConfig struct {
 	MinioAdmin         *madmin.AdminClient
 	MinioIAMName       string
@@ -257,20 +236,17 @@ type S3MinioIAMGroupPolicyConfig struct {
 	MinioIAMGroup      string
 }
 
-// S3MinioKMSKeyConfig defines service account config
 type S3MinioKMSKeyConfig struct {
 	MinioAdmin    *madmin.AdminClient
 	MinioKMSKeyID string
 }
 
-// S3MinioObjectTags defines object tags configuration
 type S3MinioObjectTags struct {
 	MinioClient    *minio.Client
 	MinioBucket    string
 	MinioObjectKey string
 }
 
-// S3MinioObjectLegalHold defines object legal hold configuration
 type S3MinioObjectLegalHold struct {
 	MinioClient    *minio.Client
 	MinioBucket    string
@@ -279,27 +255,23 @@ type S3MinioObjectLegalHold struct {
 	MinioStatus    string
 }
 
-// Princ defines policy princ
 type Princ struct {
 	AWS           set.StringSet `json:"AWS,omitempty"`
 	CanonicalUser set.StringSet `json:"CanonicalUser,omitempty"`
 }
 
-// BucketPolicy defines bucket policy
 type BucketPolicy struct {
 	Version    string             `json:",omitempty"`
 	ID         string             `json:",omitempty"`
 	Statements []policy.Statement `json:"Statement"`
 }
 
-// IAMPolicyDoc returns IAM policy
 type IAMPolicyDoc struct {
 	Version    string                `json:"Version,omitempty"`
 	ID         string                `json:"Id,omitempty"`
 	Statements []*IAMPolicyStatement `json:"Statement"`
 }
 
-// IAMPolicyStatement returns IAM policy statement
 type IAMPolicyStatement struct {
 	Sid          string
 	Effect       string      `json:",omitempty"`
@@ -311,31 +283,26 @@ type IAMPolicyStatement struct {
 	Conditions   interface{} `json:"Condition,omitempty"`
 }
 
-// IAMPolicyStatementCondition returns IAM policy condition
 type IAMPolicyStatementCondition struct {
 	Test     string `json:"-"`
 	Variable string `json:"-"`
 	Values   interface{}
 }
 
-// IAMPolicyStatementConditionSet returns IAM policy condition set
 type IAMPolicyStatementConditionSet []IAMPolicyStatementCondition
 
-// ServiceAccountStatus User status
 type ServiceAccountStatus struct {
 	AccessKey     string `json:"accessKey,omitempty"`
 	SecretKey     string `json:"secretKey,omitempty"`
 	AccountStatus string `json:"status,omitempty"`
 }
 
-// UserStatus User status
 type UserStatus struct {
 	AccessKey string               `json:"accessKey,omitempty"`
 	SecretKey string               `json:"secretKey,omitempty"`
 	Status    madmin.AccountStatus `json:"status,omitempty"`
 }
 
-// ResponseError handles error message
 type ResponseError struct {
 	Code       string `json:"Code,omitempty"`
 	Message    string `json:"Message,omitempty"`
@@ -343,7 +310,6 @@ type ResponseError struct {
 	Region     string `json:"Region,omitempty"`
 }
 
-// Resource prefix for all aws resources.
 const awsResourcePrefix = "arn:aws:s3:::"
 
 // Bucket actions granted by the `public` access type. Deliberately limited to discovery:
@@ -360,16 +326,12 @@ var downloadBucketActions = set.CreateStringSet("s3:GetBucketLocation", "s3:List
 // upload` writes.
 var uploadBucketActions = set.CreateStringSet("s3:GetBucketLocation", "s3:ListBucketMultipartUploads")
 
-// Read only object actions.
 var readOnlyObjectActions = set.CreateStringSet("s3:GetObject")
 
-// Write only object actions.
 var writeOnlyObjectActions = set.CreateStringSet("s3:AbortMultipartUpload", "s3:DeleteObject", "s3:ListMultipartUploadParts", "s3:PutObject")
 
-// Object actions granted by the `public` access type.
 var publicObjectActions = readOnlyObjectActions.Union(writeOnlyObjectActions)
 
-// S3MinioPrometheusBearerToken defines Prometheus bearer token configuration
 type S3MinioPrometheusBearerToken struct {
 	MinioAdmin     *madmin.AdminClient
 	MinioAccessKey string
@@ -379,7 +341,6 @@ type S3MinioPrometheusBearerToken struct {
 	Limit          int
 }
 
-// S3MinioPrometheusScrapeConfig defines Prometheus scrape configuration
 type S3MinioPrometheusScrapeConfig struct {
 	MinioEndpoint  string
 	MinioAccessKey string
@@ -391,7 +352,6 @@ type S3MinioPrometheusScrapeConfig struct {
 	BearerToken    string
 }
 
-// S3MinioIdpLdap defines configuration for an LDAP/Active Directory identity provider
 type S3MinioIdpLdap struct {
 	MinioAdmin         *madmin.AdminClient
 	ServerAddr         string
@@ -407,7 +367,6 @@ type S3MinioIdpLdap struct {
 	Enable             bool
 }
 
-// S3MinioIdpOpenId defines configuration for an OpenID Connect identity provider
 type S3MinioIdpOpenId struct {
 	MinioAdmin   *madmin.AdminClient
 	Name         string
@@ -424,14 +383,12 @@ type S3MinioIdpOpenId struct {
 	Enable       bool
 }
 
-// S3MinioIncompleteUploadCleanup defines incomplete upload cleanup config
 type S3MinioIncompleteUploadCleanup struct {
 	MinioClient *minio.Client
 	MinioBucket string
 	MinioPrefix string
 }
 
-// S3MinioAuditWebhook defines configuration for an audit webhook target
 type S3MinioAuditWebhook struct {
 	MinioAdmin *madmin.AdminClient
 	Name       string
@@ -444,7 +401,6 @@ type S3MinioAuditWebhook struct {
 	ClientKey  string
 }
 
-// S3MinioIAMImport defines configuration for an IAM import operation.
 type S3MinioIAMImport struct {
 	MinioAdmin *madmin.AdminClient
 	IAMData    string

--- a/minio/policy_utils.go
+++ b/minio/policy_utils.go
@@ -6,7 +6,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 )
 
-// ConditionKeyMap - map of policy condition key and value.
 type ConditionKeyMap map[string]set.StringSet
 
 // Add - adds key and value.  The value is appended If key already exists.
@@ -18,7 +17,6 @@ func (ckm ConditionKeyMap) Add(key string, value set.StringSet) {
 	}
 }
 
-// Remove - removes value of given key.  If key has empty after removal, the key is also removed.
 func (ckm ConditionKeyMap) Remove(key string, value set.StringSet) {
 	if v, ok := ckm[key]; ok {
 		if value != nil {
@@ -31,12 +29,10 @@ func (ckm ConditionKeyMap) Remove(key string, value set.StringSet) {
 	}
 }
 
-// RemoveKey - removes key and its value.
 func (ckm ConditionKeyMap) RemoveKey(key string) {
 	delete(ckm, key)
 }
 
-// CopyConditionKeyMap - returns new copy of given ConditionKeyMap.
 func CopyConditionKeyMap(condKeyMap ConditionKeyMap) ConditionKeyMap {
 	out := make(ConditionKeyMap)
 
@@ -47,7 +43,6 @@ func CopyConditionKeyMap(condKeyMap ConditionKeyMap) ConditionKeyMap {
 	return out
 }
 
-// mergeConditionKeyMap - returns a new ConditionKeyMap which contains merged key/value of given two ConditionKeyMap.
 func mergeConditionKeyMap(condKeyMap1 ConditionKeyMap, condKeyMap2 ConditionKeyMap) ConditionKeyMap {
 	out := CopyConditionKeyMap(condKeyMap1)
 
@@ -62,7 +57,6 @@ func mergeConditionKeyMap(condKeyMap1 ConditionKeyMap, condKeyMap2 ConditionKeyM
 	return out
 }
 
-// ConditionMap - map of condition and conditional values.
 type ConditionMap map[string]ConditionKeyMap
 
 // Add - adds condition key and condition value.  The value is appended if key already exists.
@@ -74,7 +68,6 @@ func (cond ConditionMap) Add(condKey string, condKeyMap ConditionKeyMap) {
 	}
 }
 
-// Remove - removes condition key and its value.
 func (cond ConditionMap) Remove(condKey string) {
 	delete(cond, condKey)
 }

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -300,7 +300,6 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_pool_status":                         dataSourceMinioPoolStatus(),
 			"minio_bucket_metadata_export":              dataSourceMinioBucketMetadataExport(),
 
-			// Notification Targets
 			"minio_notify_webhook":       dataSourceMinioNotifyWebhook(),
 			"minio_notify_amqp":          dataSourceMinioNotifyAmqp(),
 			"minio_notify_kafka":         dataSourceMinioNotifyKafka(),
@@ -314,7 +313,6 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			// S3 Bucket Operations
 			"minio_s3_bucket":                           resourceMinioBucket(),
 			"minio_s3_bucket_policy":                    resourceMinioBucketPolicy(),
 			"minio_s3_bucket_anonymous_access":          resourceMinioS3BucketAnonymousAccess(),
@@ -334,7 +332,6 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_s3_object":                           resourceMinioObject(),
 			"minio_s3_incomplete_upload_cleanup":        resourceMinioS3IncompleteUploadCleanup(),
 
-			// IAM Operations
 			"minio_iam_group":                   resourceMinioIAMGroup(),
 			"minio_iam_group_membership":        resourceMinioIAMGroupMembership(),
 			"minio_iam_user":                    resourceMinioIAMUser(),
@@ -347,23 +344,18 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_iam_user_group_membership":   resourceMinioIAMUserGroupMembership(),
 			"minio_iam_import":                  resourceMinioIAMImport(),
 
-			// LDAP Operations
 			"minio_iam_ldap_group_policy_attachment": resourceMinioIAMLDAPGroupPolicyAttachment(),
 			"minio_iam_ldap_user_policy_attachment":  resourceMinioIAMLDAPUserPolicyAttachment(),
 
-			// Identity Provider Operations
 			"minio_iam_idp_openid": resourceMinioIAMIdpOpenId(),
 			"minio_iam_idp_ldap":   resourceMinioIAMIdpLdap(),
 
-			// ILM and KMS Operations
 			"minio_ilm_policy": resourceMinioILMPolicy(),
 			"minio_ilm_tier":   resourceMinioILMTier(),
 			"minio_kms_key":    resourceMinioKMSKey(),
 
-			// AccessKey Operations
 			"minio_accesskey": resourceMinioAccessKey(),
 
-			// Server Configuration
 			"minio_config":                      resourceMinioConfig(),
 			"minio_config_restore":              resourceMinioConfigRestore(),
 			"minio_audit_webhook":               resourceMinioAuditWebhook(),
@@ -377,10 +369,8 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_audit_kafka":                 resourceMinioAuditKafka(),
 			"minio_site_replication":            resourceMinioSiteReplication(),
 
-			// Batch Job Operations
 			"minio_batch_job": resourceMinioBatchJob(),
 
-			// Notification Targets
 			"minio_notify_webhook":          resourceMinioNotifyWebhook(),
 			"minio_notify_amqp":             resourceMinioNotifyAmqp(),
 			"minio_notify_kafka":            resourceMinioNotifyKafka(),
@@ -393,14 +383,11 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"minio_notify_redis":            resourceMinioNotifyRedis(),
 			"minio_prometheus_bearer_token": resourceMinioPrometheusBearerToken(),
 
-			// Pool Management
 			"minio_pool_rebalance":    resourceMinioPoolRebalance(),
 			"minio_pool_decommission": resourceMinioPoolDecommission(),
 
-			// Bucket Metadata
 			"minio_bucket_metadata_import": resourceMinioBucketMetadataImport(),
 
-			// Service Control
 			"minio_service_action": resourceMinioServiceAction(),
 		},
 

--- a/minio/provider_test.go
+++ b/minio/provider_test.go
@@ -228,8 +228,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-// testAccEndpoint returns the endpoint (host:port) of the MinIO test instance
-// configured by the given env var prefix ("", "SECOND_", "THIRD_", ...).
 func testAccEndpoint(prefix string) string {
 	return os.Getenv(prefix + "MINIO_ENDPOINT")
 }

--- a/minio/resource_minio_accesskey.go
+++ b/minio/resource_minio_accesskey.go
@@ -56,7 +56,6 @@ func resourceMinioAccessKey() *schema.Resource {
 			hasSecretVersionChange := d.HasChange("secret_key_version") && version != ""
 			// When secret_key_version changes to non-empty value, validate secret_key availability
 			if hasSecretVersionChange {
-				// Check if secret_key is present in the configuration
 				rawConfig := d.GetRawConfig()
 				secretKeyAttr := rawConfig.GetAttr("secret_key")
 
@@ -276,7 +275,6 @@ func minioCreateAccessKey(ctx context.Context, d *schema.ResourceData, meta inte
 		return NewResourceError("waiting for access key readiness", creds.AccessKey, err)
 	}
 
-	// Attach policy if provided
 	if policy != "" {
 		err := client.S3Admin.UpdateServiceAccount(ctx, creds.AccessKey, madmin.UpdateServiceAccountReq{
 			NewPolicy: []byte(policy),
@@ -353,7 +351,6 @@ func minioReadAccessKey(ctx context.Context, d *schema.ResourceData, meta interf
 			var policyObj map[string]interface{}
 			err := json.Unmarshal([]byte(policy), &policyObj)
 			if err == nil {
-				// Check for empty or null Statement and empty Version
 				statement, hasStatement := policyObj["Statement"]
 				version, hasVersion := policyObj["Version"]
 				if hasStatement && hasVersion {

--- a/minio/resource_minio_accesskey_test.go
+++ b/minio/resource_minio_accesskey_test.go
@@ -334,7 +334,6 @@ resource "minio_accesskey" "test_policy" {
 `, rName, policy)
 }
 
-// Helper for JSON equality
 func testCheckResourceAttrJSON(resourceName, attrName, expectedJSON string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/minio/resource_minio_config.go
+++ b/minio/resource_minio_config.go
@@ -38,7 +38,6 @@ func resourceMinioConfig() *schema.Resource {
 					if v == "" {
 						errs = append(errs, fmt.Errorf("%q cannot be empty", key))
 					}
-					// Validate key format - should contain subsystem name
 					if !strings.Contains(v, "_") && v != "region" && v != "name" {
 						warns = append(warns, fmt.Sprintf("Config key %q should typically contain the subsystem (e.g., 'api', 'notify_webhook:1')", v))
 					}
@@ -62,7 +61,6 @@ func resourceMinioConfig() *schema.Resource {
 					// Parse the server's response (old) into a map
 					serverParams := parseConfigParams(old)
 
-					// Check if all user-specified parameters exist in server response with same values
 					for key, userValue := range userParams {
 						serverValue, exists := serverParams[key]
 						if !exists || serverValue != userValue {
@@ -112,7 +110,6 @@ func minioCreateConfig(ctx context.Context, d *schema.ResourceData, meta interfa
 		return NewResourceError("setting config", key, err)
 	}
 
-	// Set the ID to the key
 	d.SetId(key)
 	_ = d.Set("restart_required", restartRequired)
 
@@ -120,7 +117,6 @@ func minioCreateConfig(ctx context.Context, d *schema.ResourceData, meta interfa
 		tflog.Warn(ctx, fmt.Sprintf("Config change for %s requires MinIO server restart to take effect", key))
 	}
 
-	// Verify the config was set by reading it back
 	return minioReadConfig(ctx, d, meta)
 }
 
@@ -137,7 +133,6 @@ func minioReadConfig(ctx context.Context, d *schema.ResourceData, meta interface
 	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		configData, err = client.S3Admin.GetConfigKV(ctx, key)
 		if err != nil {
-			// Check if config key doesn't exist
 			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {
 				tflog.Warn(ctx, fmt.Sprintf("Config %s no longer exists", key))
 				d.SetId("")
@@ -158,16 +153,13 @@ func minioReadConfig(ctx context.Context, d *schema.ResourceData, meta interface
 		return NewResourceError("reading config", key, err)
 	}
 
-	// If the resource was removed
 	if d.Id() == "" {
 		return nil
 	}
 
-	// Parse the config data to extract the value
 	configStr := strings.TrimSpace(string(configData))
 	tflog.Debug(ctx, fmt.Sprintf("Raw config data for key %s: %s", key, configStr))
 
-	// Handle different config formats
 	if strings.HasPrefix(configStr, key+" ") {
 		// Format: "key subsys:target key1=value1 key2=value2" -> "key1=value1 key2=value2"
 		parts := strings.SplitN(configStr, " ", 2)
@@ -233,7 +225,6 @@ func minioDeleteConfig(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting MinIO config: %s", key))
 
-	// Check if config exists before attempting deletion
 	_, err := client.S3Admin.GetConfigKV(ctx, key)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {
@@ -283,10 +274,8 @@ func parseConfigParams(configStr string) map[string]string {
 		return params
 	}
 
-	// Split by spaces to get individual key=value pairs
 	pairs := strings.Fields(configStr)
 	for _, pair := range pairs {
-		// Split each pair by '=' to get key and value
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) == 2 {
 			params[parts[0]] = parts[1]

--- a/minio/resource_minio_config_test.go
+++ b/minio/resource_minio_config_test.go
@@ -135,7 +135,6 @@ func testAccCheckMinioConfigExists(resourceName string) resource.TestCheckFunc {
 		minioC := testAccClient()
 		configKey := rs.Primary.ID
 
-		// Try to get the config
 		_, err := minioC.S3Admin.GetConfigKV(context.Background(), configKey)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {

--- a/minio/resource_minio_iam_policy_test.go
+++ b/minio/resource_minio_iam_policy_test.go
@@ -375,13 +375,11 @@ func TestAccMinioIAMPolicy_jsonencode(t *testing.T) {
 	resourceName := "minio_iam_policy.test_jsonencode"
 	rName := acctest.RandomWithPrefix("tf-acc-jsonencode")
 
-	// Run the test in multiple phases to verify the policy remains unchanged
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckMinioIAMPolicyDestroy,
 		Steps: []resource.TestStep{
-			// Apply the policy for the first time
 			{
 				Config: testAccMinioIAMPolicyConfigJsonencode(rName),
 				Check: resource.ComposeTestCheckFunc(
@@ -408,19 +406,16 @@ func TestAccMinioIAMPolicy_jsonencode(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Verify import works correctly
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"policy"}, // Skip policy verification during import
+				ImportStateVerifyIgnore: []string{"policy"},
 			},
-			// Use a final step with a specific check for semantically equivalent policies
 			{
 				Config: testAccMinioIAMPolicyConfigJsonencode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioIAMPolicyExists(resourceName),
-					// Use the testCheckJSONResourceAttr helper that properly compares JSON content
 					func(s *terraform.State) error {
 						rs, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -428,7 +423,6 @@ func TestAccMinioIAMPolicy_jsonencode(t *testing.T) {
 						}
 
 						policyText := rs.Primary.Attributes["policy"]
-						// Verify the policy is semantically equivalent to what we expect
 						equivalent, err := awspolicy.PoliciesAreEquivalent(policyText, getExpectedJsonPolicy())
 						if err != nil {
 							return fmt.Errorf("error comparing policies: %s", err)
@@ -498,7 +492,6 @@ EOT
 `, rName)
 }
 
-// getExpectedJsonPolicy returns a normalized JSON policy string for comparison
 func getExpectedJsonPolicy() string {
 	return `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:ListBucket","s3:GetObject","s3:PutObject"],"Resource":["arn:aws:s3:::*"]}]}`
 }

--- a/minio/resource_minio_iam_user_group_membership.go
+++ b/minio/resource_minio_iam_user_group_membership.go
@@ -8,8 +8,6 @@ import (
 	"github.com/minio/madmin-go/v4"
 )
 
-// resourceMinioIAMUserGroupMembership defines the Terraform resource for attaching a single IAM user
-// to multiple IAM groups.
 func resourceMinioIAMUserGroupMembership() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: minioCreateUserGroupMembership,
@@ -37,18 +35,15 @@ func resourceMinioIAMUserGroupMembership() *schema.Resource {
 	}
 }
 
-// IAMUserGroupMembershipConfig holds the configuration needed for CRUD operations.
 type IAMUserGroupMembershipConfig struct {
 	MinioAdmin *madmin.AdminClient
 	UserName   string
 	Groups     []string
 }
 
-// iamUserGroupMembershipConfig extracts the configuration from the resource data.
 func iamUserGroupMembershipConfig(d *schema.ResourceData, meta interface{}) *IAMUserGroupMembershipConfig {
 	m := meta.(*S3MinioClient)
 
-	// Extract groups from the Set
 	groups := []string{}
 	if v, ok := d.GetOk("groups"); ok {
 		for _, g := range v.(*schema.Set).List() {
@@ -67,11 +62,9 @@ func iamUserGroupMembershipConfig(d *schema.ResourceData, meta interface{}) *IAM
 	}
 }
 
-// minioCreateUserGroupMembership creates the membership by adding the user to each specified group.
 func minioCreateUserGroupMembership(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := iamUserGroupMembershipConfig(d, meta)
 
-	// Add user to each group
 	for _, grp := range cfg.Groups {
 		err := cfg.MinioAdmin.UpdateGroupMembers(ctx, madmin.GroupAddRemove{
 			Group:   grp,
@@ -82,11 +75,8 @@ func minioCreateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	// Use user name as the resource ID
 	d.SetId(cfg.UserName)
 
-	// Reconcile: ensure the user belongs to exactly the groups defined in the resource.
-	// Remove any groups the user is a member of that are not in cfg.Groups.
 	desired := make(map[string]struct{})
 	for _, g := range cfg.Groups {
 		desired[g] = struct{}{}
@@ -114,7 +104,6 @@ func minioCreateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 	return minioReadUserGroupMembership(ctx, d, meta)
 }
 
-// minioReadUserGroupMembership reads the current groups for the user.
 func minioReadUserGroupMembership(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := iamUserGroupMembershipConfig(d, meta)
 
@@ -130,7 +119,6 @@ func minioReadUserGroupMembership(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	// Set the groups attribute to the current membership
 	if err := d.Set("groups", schema.NewSet(schema.HashString, toInterfaceSlice(userInfo.MemberOf))); err != nil {
 		return NewResourceError("setting groups attribute", cfg.UserName, err)
 	}
@@ -138,7 +126,6 @@ func minioReadUserGroupMembership(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-// minioUpdateUserGroupMembership updates the membership by reconciling desired vs actual groups.
 func minioUpdateUserGroupMembership(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	if !d.HasChange("groups") {
 		return nil
@@ -146,13 +133,11 @@ func minioUpdateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 
 	cfg := iamUserGroupMembershipConfig(d, meta)
 
-	// Desired groups from the resource
 	desired := make(map[string]struct{})
 	for _, g := range cfg.Groups {
 		desired[g] = struct{}{}
 	}
 
-	// Current groups from MinIO
 	userInfo, err := cfg.MinioAdmin.GetUserInfo(ctx, cfg.UserName)
 	if err != nil {
 		return NewResourceError("fetching current groups for user", cfg.UserName, err)
@@ -162,7 +147,6 @@ func minioUpdateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 		current[g] = struct{}{}
 	}
 
-	// Add missing groups
 	for grp := range desired {
 		if _, ok := current[grp]; !ok {
 			if err := cfg.MinioAdmin.UpdateGroupMembers(ctx, madmin.GroupAddRemove{
@@ -175,10 +159,8 @@ func minioUpdateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	// Remove extra groups
 	for grp := range current {
 		if _, ok := desired[grp]; ok {
-			// No action needed
 			continue
 		}
 		if err := cfg.MinioAdmin.UpdateGroupMembers(ctx, madmin.GroupAddRemove{
@@ -193,11 +175,9 @@ func minioUpdateUserGroupMembership(ctx context.Context, d *schema.ResourceData,
 	return minioReadUserGroupMembership(ctx, d, meta)
 }
 
-// minioDeleteUserGroupMembership removes the user from all groups managed by this resource.
 func minioDeleteUserGroupMembership(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := iamUserGroupMembershipConfig(d, meta)
 
-	// Remove user from each group listed in state
 	for _, grp := range cfg.Groups {
 		if err := cfg.MinioAdmin.UpdateGroupMembers(ctx, madmin.GroupAddRemove{
 			Group:    grp,

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -239,7 +239,6 @@ func TestAccILMPolicy_ruleStatus(t *testing.T) {
 				),
 			},
 			{
-				// Test explicitly setting status to "Disabled"
 				Config: testAccMinioILMPolicyConfigDisabledStatus(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioILMPolicyExists(resourceName, &lifecycleConfig),
@@ -247,7 +246,6 @@ func TestAccILMPolicy_ruleStatus(t *testing.T) {
 				),
 			},
 			{
-				// Test updating back to "Enabled"
 				Config: testAccMinioILMPolicyConfigEnabledStatus(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioILMPolicyExists(resourceName, &lifecycleConfig),

--- a/minio/resource_minio_notify_common.go
+++ b/minio/resource_minio_notify_common.go
@@ -180,7 +180,6 @@ func notifyBuildCfgAddInt(parts *[]string, key string, val int) {
 	}
 }
 
-// notifyCommonSchema returns schema fields shared by all notification targets.
 func notifyCommonSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
@@ -219,7 +218,6 @@ func notifyCommonSchema() map[string]*schema.Schema {
 	}
 }
 
-// mergeSchemas merges common and type-specific schemas.
 func mergeSchemas(common, specific map[string]*schema.Schema) map[string]*schema.Schema {
 	result := make(map[string]*schema.Schema, len(common)+len(specific))
 	for k, v := range common {
@@ -231,7 +229,6 @@ func mergeSchemas(common, specific map[string]*schema.Schema) map[string]*schema
 	return result
 }
 
-// notifyReadCommonFields reads queue_dir, queue_limit, and comment from config.
 func notifyReadCommonFields(cfgMap map[string]string, d *schema.ResourceData) {
 	if v, ok := cfgMap["queue_limit"]; ok {
 		if n, err := parseInt(v); err == nil {
@@ -246,7 +243,6 @@ func notifyReadCommonFields(cfgMap map[string]string, d *schema.ResourceData) {
 	}
 }
 
-// notifyBuildCommonCfg appends common fields (queue_dir, queue_limit, comment, enable).
 func notifyBuildCommonCfg(parts *[]string, d *schema.ResourceData, meta interface{}) {
 	notifyBuildCfgAddParam(parts, "queue_dir", getOptionalField(d, "queue_dir", "").(string))
 	notifyBuildCfgAddParam(parts, "comment", getOptionalField(d, "comment", "").(string))

--- a/minio/resource_minio_notify_targets_test.go
+++ b/minio/resource_minio_notify_targets_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// TestNotifyResourceRegistration verifies that all notification resource
-// constructor functions can be called without panicking.
 func TestNotifyResourceRegistration(t *testing.T) {
 	resources := map[string]func() *schema.Resource{
 		"minio_notify_amqp":          resourceMinioNotifyAmqp,
@@ -34,8 +32,6 @@ func TestNotifyResourceRegistration(t *testing.T) {
 	}
 }
 
-// TestNotifyResourceSchemas verifies that every notification resource schema
-// contains the expected common fields plus the type-specific required fields.
 func TestNotifyResourceSchemas(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -77,8 +73,6 @@ func TestNotifyResourceSchemas(t *testing.T) {
 	}
 }
 
-// TestNotifyResourceSchemaFieldTypes verifies that key schema fields have the
-// correct types and attributes (Required, Optional, Computed, Sensitive).
 func TestNotifyResourceSchemaFieldTypes(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -229,7 +223,6 @@ func TestNotifyResourceSchemaFieldTypes(t *testing.T) {
 	}
 }
 
-// TestNotifyCommonSchemaDefaults verifies the common schema field defaults.
 func TestNotifyCommonSchemaDefaults(t *testing.T) {
 	common := notifyCommonSchema()
 
@@ -267,7 +260,6 @@ func TestNotifyCommonSchemaDefaults(t *testing.T) {
 	}
 }
 
-// fieldCheck describes the expected attributes of a single schema field.
 type fieldCheck struct {
 	field         string
 	wantType      schema.ValueType

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -498,19 +498,7 @@ func minioDeleteBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 }
 
 // forceDestroyBucketObjects deletes all object versions and delete markers from
-// a bucket, enabling bucket removal.
-//
-// It uses a two-phase approach:
-//
-//  1. Bulk delete via RemoveObjects with GovernanceBypass — efficiently removes
-//     most objects in batches of up to 1000.
-//
-//  2. Per-object fallback via RemoveObject with GovernanceBypass — catches
-//     versions that the bulk API silently skips. The minio-go bulk delete
-//     swallows InvalidArgument and NoSuchVersion per-object errors
-//     (processRemoveMultiObjectsResponse), which causes locked object versions
-//     on object-lock-enabled buckets to be silently left behind.
-//
+// a bucket in two phases (bulkDeleteBucketObjects, removeRemainingObjectVersions).
 // Objects under active legal hold are never force-deleted; the function returns
 // an actionable error asking the user to remove the hold first.
 func forceDestroyBucketObjects(ctx context.Context, client *minio.Client, bucketName string) diag.Diagnostics {
@@ -528,9 +516,8 @@ func forceDestroyBucketObjects(ctx context.Context, client *minio.Client, bucket
 	return nil
 }
 
-// bulkDeleteBucketObjects is phase 1 of force destroy: it bulk-deletes objects via
-// RemoveObjects with GovernanceBypass, efficiently removing most objects in batches
-// of up to 1000.
+// bulkDeleteBucketObjects is phase 1 of force destroy: RemoveObjects with
+// GovernanceBypass, in batches of up to 1000.
 func bulkDeleteBucketObjects(ctx context.Context, client *minio.Client, bucketName string) diag.Diagnostics {
 	objectsCh := make(chan minio.ObjectInfo)
 	var listErr error
@@ -749,7 +736,6 @@ func diagnoseMissingBucket(ctx context.Context, bucketConfig *S3MinioBucket, buc
 	// NoSuchKey (bucket present, probe object just doesn't exist).
 	_, err := bucketConfig.MinioClient.StatObject(ctx, bucket, "__bucket_existence_probe__", minio.StatObjectOptions{})
 	if err == nil {
-		// Probe object somehow exists — bucket is definitely present.
 		tflog.Debug(ctx, fmt.Sprintf("Bucket [%s] confirmed via StatObject probe", bucket))
 		return true, nil
 	}
@@ -766,7 +752,6 @@ func diagnoseMissingBucket(ctx context.Context, bucketConfig *S3MinioBucket, buc
 	}
 
 	if errResp.Code == "NoSuchKey" {
-		// Probe object doesn't exist but the bucket does — bucket is present.
 		tflog.Debug(ctx, fmt.Sprintf("Bucket [%s] confirmed after existence check failure", bucket))
 		return true, nil
 	}
@@ -789,7 +774,6 @@ func isCredentialError(errResp minio.ErrorResponse) bool {
 	}
 }
 
-// isNoSuchBucketError checks if the error indicates the bucket does not exist.
 func isNoSuchBucketError(err error) bool {
 	if err == nil {
 		return false
@@ -805,7 +789,6 @@ func isNoSuchBucketError(err error) bool {
 	return strings.Contains(errStr, "NoSuchBucket") || strings.Contains(errStr, "does not exist")
 }
 
-// waitForBucketReady waits for a bucket to become available for operations.
 func waitForBucketReady(ctx context.Context, client *minio.Client, bucket string, timeout time.Duration) error {
 	return retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := client.GetBucketLocation(ctx, bucket)
@@ -815,7 +798,6 @@ func waitForBucketReady(ctx context.Context, client *minio.Client, bucket string
 
 		errResp := minio.ToErrorResponse(err)
 
-		// Fail fast on credential errors
 		if isCredentialError(errResp) {
 			return retry.NonRetryableError(fmt.Errorf("access denied while waiting for bucket %q: %w", bucket, err))
 		}
@@ -826,7 +808,6 @@ func waitForBucketReady(ctx context.Context, client *minio.Client, bucket string
 			return retry.RetryableError(fmt.Errorf("bucket %q not yet available: %w", bucket, err))
 		}
 
-		// Non-retryable for other errors
 		return retry.NonRetryableError(fmt.Errorf("error checking bucket %q availability: %w", bucket, err))
 	})
 }

--- a/minio/resource_minio_s3_bucket_anonymous_access.go
+++ b/minio/resource_minio_s3_bucket_anonymous_access.go
@@ -26,12 +26,10 @@ func encodeAnonymousAccessID(bucket string) string {
 func putAnonymousBucketPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}, bucket, policy string) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
-	// Wait for bucket to be ready for eventual consistency
 	timeout := d.Timeout(schema.TimeoutCreate)
 	if d.Id() != "" {
 		timeout = d.Timeout(schema.TimeoutUpdate)
 	}
-	// Reserve time for the actual operation
 	waitTimeout := timeout - 30*time.Second
 	if waitTimeout < 30*time.Second {
 		waitTimeout = 30 * time.Second
@@ -182,13 +180,11 @@ func minioSetAnonymousPolicy(ctx context.Context, d *schema.ResourceData, meta i
 		return NewResourceError("validating anonymous access configuration", bucketName, errors.New("policy or access_type must be specified"))
 	}
 
-	// Normalize the policy for consistent formatting
 	normalizedPolicy, err := structure.NormalizeJsonString(policy)
 	if err != nil {
 		return NewResourceError("failed to normalize policy JSON", bucketName, err)
 	}
 
-	// Set the resource ID to be unique for anonymous access resources
 	d.SetId(encodeAnonymousAccessID(bucketName))
 
 	if err := d.Set("policy", normalizedPolicy); err != nil {
@@ -302,7 +298,6 @@ func getAnonymousPolicy(d *schema.ResourceData, bucket string) (string, error) {
 
 	accessType := d.Get("access_type").(string)
 
-	// If policy is explicitly set by user, use it (it takes precedence over access_type)
 	if policyExplicitlySet {
 		policy := d.Get("policy").(string)
 		if policy != "" {
@@ -377,7 +372,6 @@ func confirmConfiguredAccessType(d *schema.ResourceData, policy string, bucketNa
 // and `public-read-write` writes the same one as `public`, so a policy written by either is
 // reported as `public`; callers that know which access type is configured confirm that first.
 func getAccessTypeFromPolicy(policy string, bucketName string) (string, error) {
-	// Generate canned policies for this specific bucket
 	publicPolicy, _ := marshalPolicy(PublicPolicy(&S3MinioBucket{MinioBucket: bucketName}))
 	readOnlyPolicy, _ := marshalPolicy(ReadOnlyPolicy(&S3MinioBucket{MinioBucket: bucketName}))
 	writeOnlyPolicy, _ := marshalPolicy(WriteOnlyPolicy(&S3MinioBucket{MinioBucket: bucketName}))

--- a/minio/resource_minio_s3_bucket_notification.go
+++ b/minio/resource_minio_s3_bucket_notification.go
@@ -126,7 +126,6 @@ func minioPutBucketNotification(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	// Add the new queues from this resource's config
 	for _, c := range bucketNotificationConfig.Configuration.QueueConfigs {
 		newConfig.AddQueue(c.Config)
 	}
@@ -347,7 +346,6 @@ func importBucketNotification(ctx context.Context, d *schema.ResourceData, meta 
 		return nil, fmt.Errorf("setting bucket during import: %w", err)
 	}
 
-	// Read the bucket's notification config to populate queue data.
 	m := meta.(*S3MinioClient)
 	notificationConfig, err := m.S3Client.GetBucketNotification(ctx, bucketName)
 	if err != nil {
@@ -383,7 +381,6 @@ func generateBucketNotificationID(bucket string, d *schema.ResourceData) string 
 	return fmt.Sprintf("%s|%s", bucket, strings.Join(queueIDs, ","))
 }
 
-// getQueueIDsFromResource extracts the queue IDs defined in the resource's queue blocks.
 func getQueueIDsFromResource(d *schema.ResourceData) []string {
 	ids := make([]string, 0)
 	for _, q := range d.Get("queue").([]interface{}) {
@@ -412,7 +409,6 @@ func getQueueIDsFromState(d *schema.ResourceData) []string {
 	return ids
 }
 
-// filterQueueConfigsByIDs returns only the queue configs whose ID is in the given set.
 func filterQueueConfigsByIDs(configs []notification.QueueConfig, ids []string) []notification.QueueConfig {
 	idSet := make(map[string]struct{}, len(ids))
 	for _, qid := range ids {

--- a/minio/resource_minio_s3_bucket_object_lock_configuration.go
+++ b/minio/resource_minio_s3_bucket_object_lock_configuration.go
@@ -142,19 +142,16 @@ func minioReadObjectLockConfiguration(ctx context.Context, d *schema.ResourceDat
 		return NewResourceError("setting object_lock_enabled", bucket, err)
 	}
 
-	// Build rule structure if we have retention configuration
 	if mode != nil && validity != nil && unit != nil {
 		defaultRetention := map[string]interface{}{
 			"mode": mode.String(),
 		}
 
-		// Safe uint to int conversion
 		validityInt := math.MaxInt
 		if *validity <= uint(math.MaxInt) {
 			validityInt = int(*validity)
 		}
 
-		// Set either days or years based on the unit
 		switch *unit {
 		case minio.Days:
 			defaultRetention["days"] = validityInt
@@ -219,7 +216,6 @@ func validateObjectLockPrerequisites(ctx context.Context, client *minio.Client, 
 		return fmt.Errorf("bucket %s does not exist", bucket)
 	}
 
-	// Object locking requires versioning
 	versioning, err := client.GetBucketVersioning(ctx, bucket)
 	if err != nil {
 		return fmt.Errorf("error checking bucket versioning: %w", err)
@@ -245,14 +241,12 @@ func validateObjectLockPrerequisites(ctx context.Context, client *minio.Client, 
 }
 
 func applyObjectLockConfiguration(ctx context.Context, d *schema.ResourceData, client *minio.Client, bucket string) error {
-	// Check if rule is configured
 	rules := d.Get("rule").([]interface{})
 	if len(rules) == 0 {
 		// No rule configured, clear any existing retention
 		return client.SetBucketObjectLockConfig(ctx, bucket, nil, nil, nil)
 	}
 
-	// Extract retention configuration from nested structure
 	rule := rules[0].(map[string]interface{})
 	defaultRetentions := rule["default_retention"].([]interface{})
 
@@ -265,7 +259,6 @@ func applyObjectLockConfiguration(ctx context.Context, d *schema.ResourceData, c
 	modeStr := retention["mode"].(string)
 	mode := minio.RetentionMode(modeStr)
 
-	// Determine validity and unit
 	var validity uint
 	var unit minio.ValidityUnit
 

--- a/minio/resource_minio_s3_bucket_policy.go
+++ b/minio/resource_minio_s3_bucket_policy.go
@@ -57,12 +57,10 @@ func minioPutBucketPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put policy: %s", bucketPolicyConfig.MinioBucket, policy))
 
-	// Wait for bucket to be ready for eventual consistency
 	timeout := d.Timeout(schema.TimeoutCreate)
 	if d.Id() != "" {
 		timeout = d.Timeout(schema.TimeoutUpdate)
 	}
-	// Reserve time for the actual operation
 	waitTimeout := timeout - 30*time.Second
 	if waitTimeout < 30*time.Second {
 		waitTimeout = 30 * time.Second
@@ -112,7 +110,6 @@ func minioReadBucketPolicy(ctx context.Context, d *schema.ResourceData, meta int
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket policy, read for bucket: %s", d.Id()))
 
-	// For new resources, wait for bucket to be ready
 	if d.IsNewResource() {
 		timeout := d.Timeout(schema.TimeoutRead)
 		if err := waitForBucketReady(ctx, bucketPolicyConfig.MinioClient, d.Id(), timeout); err != nil {

--- a/minio/resource_minio_s3_bucket_replication.go
+++ b/minio/resource_minio_s3_bucket_replication.go
@@ -62,7 +62,6 @@ func resourceMinioBucketReplication() *schema.Resource {
 	}
 }
 
-// bucketReplicationRuleResource returns the schema for a single replication rule.
 func bucketReplicationRuleResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -142,7 +141,6 @@ func bucketReplicationRuleResource() *schema.Resource {
 	}
 }
 
-// bucketReplicationTargetResource returns the schema for a replication rule target.
 func bucketReplicationTargetResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -251,7 +249,6 @@ func bucketReplicationTargetResource() *schema.Resource {
 	}
 }
 
-// validateReplicationBandwidthLimit validates the bandwidth_limit target attribute.
 func validateReplicationBandwidthLimit(i interface{}, _ cty.Path) (diags diag.Diagnostics) {
 	v, ok := i.(string)
 	if !ok {
@@ -358,7 +355,6 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket replication, read for bucket: %s", bucketName))
 
-	// First, gather the bucket replication config
 	rcfg, err := client.GetBucketReplication(ctx, bucketName)
 	if err != nil {
 		tflog.Warn(ctx, fmt.Sprintf("Unable to fetch bucket replication config for %q: %v", bucketName, err))
@@ -370,7 +366,6 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 		return ruleDiags
 	}
 
-	// Second, we read the remote bucket config
 	existingRemoteTargets, err := admclient.ListRemoteTargets(ctx, bucketName, "")
 	if err != nil {
 		tflog.Warn(ctx, fmt.Sprintf("Unable to fetch existing remote target config for %q: %v", bucketName, err))
@@ -399,9 +394,7 @@ func minioReadBucketReplication(ctx context.Context, d *schema.ResourceData, met
 // buildReplicationRuleStates converts the replication rules returned by MinIO into
 // the state representation, preserving the order they have in the configuration.
 func buildReplicationRuleStates(ctx context.Context, bucketName string, bucketReplicationConfig *S3MinioBucketReplication, rcfg replication.Config) (rules []map[string]interface{}, ruleArnMap map[string]int, diags diag.Diagnostics) {
-	// Reverse index to store rule definition read from Minio to macth the order they have in the IaC. This prevent Terrfaform from try to re-order rule each time
 	rulePriorityMap := map[int]int{}
-	// Reverse index to store arn and index in the rule set. This is used to match bucket config and remote target order
 	ruleArnMap = map[string]int{}
 
 	if bucketReplicationConfig.ReplicationRules != nil {
@@ -514,8 +507,6 @@ func applyRemoteTargetsToRules(ctx context.Context, bucketName string, bucketRep
 		target["health_check_period"] = shortDur(remoteTarget.HealthCheckDuration)
 		var bwUint64 uint64
 		if remoteTarget.BandwidthLimit < 0 {
-			// Bandwidth limit shouldn't be negative, but handle defensively.
-			// Setting to 0 as a safe default.
 			tflog.Warn(ctx, fmt.Sprintf("Received negative bandwidth limit (%d) from MinIO, treating as 0", remoteTarget.BandwidthLimit))
 			bwUint64 = 0
 		} else {
@@ -668,7 +659,6 @@ func convertBucketReplicationConfig(ctx context.Context, bucketReplicationConfig
 	return
 }
 
-// buildBucketReplicationTarget builds the madmin remote target definition for a rule.
 func buildBucketReplicationTarget(rule S3MinioBucketReplicationRule, tgtBucket string) *madmin.BucketTarget {
 	creds := &madmin.Credentials{AccessKey: rule.Target.AccessKey, SecretKey: rule.Target.SecretKey}
 	return &madmin.BucketTarget{
@@ -687,7 +677,6 @@ func buildBucketReplicationTarget(rule S3MinioBucketReplicationRule, tgtBucket s
 	}
 }
 
-// ensureRemoteTarget creates or updates the remote target for a rule and returns its ARN.
 func ensureRemoteTarget(ctx context.Context, admclient *madmin.AdminClient, bucket string, rule S3MinioBucketReplicationRule, bktTarget *madmin.BucketTarget) (arn string, err error) {
 	targets, _ := admclient.ListRemoteTargets(ctx, bucket, string(madmin.ReplicationService))
 	tflog.Debug(ctx, fmt.Sprintf("Existing remote targets %q: %v", bucket, targets))
@@ -759,7 +748,6 @@ func ensureRemoteTarget(ctx context.Context, admclient *madmin.AdminClient, buck
 	return
 }
 
-// buildReplicationOptions builds the replication rule options for a target ARN.
 func buildReplicationOptions(rule S3MinioBucketReplicationRule, arn string) (replication.Options, error) {
 	tagList := []string{}
 	for k, v := range rule.Tags {
@@ -801,7 +789,6 @@ func getBucketReplicationConfig(ctx context.Context, v []interface{}, d *schema.
 	return
 }
 
-// extractBucketReplicationRule decodes a single rule from the resource data.
 func extractBucketReplicationRule(ctx context.Context, i int, ruleCount int, rule interface{}, d *schema.ResourceData) (result S3MinioBucketReplicationRule, errs diag.Diagnostics) {
 	var ok bool
 	tfMap, ok := rule.(map[string]interface{})
@@ -907,11 +894,11 @@ func extractBucketReplicationRule(ctx context.Context, i int, ruleCount int, rul
 		var bwLimit int64
 		if bandwidth > uint64(math.MaxInt64) {
 			tflog.Warn(ctx, fmt.Sprintf("Configured bandwidth limit (%d) exceeds maximum supported value (%d), clamping.", bandwidth, int64(math.MaxInt64)))
-			bwLimit = math.MaxInt64 // Clamp to max int64 if overflow would occur
+			bwLimit = math.MaxInt64
 		} else {
 			bwLimit = int64(bandwidth)
 		}
-		result.Target.BandwidthLimit = bwLimit // Safe conversion
+		result.Target.BandwidthLimit = bwLimit
 	}
 
 	var healthcheckDuration string
@@ -964,7 +951,6 @@ func resolveReplicationTargetSync(d *schema.ResourceData, i int, target map[stri
 						if !syncAttr.IsNull() && syncAttr.IsKnown() {
 							return syncAttr.True()
 						}
-						// Fall back to deprecated "syncronous" if "synchronous" not set
 						syncronousAttr := targetVal.GetAttr("syncronous")
 						if !syncronousAttr.IsNull() && syncronousAttr.IsKnown() {
 							return syncronousAttr.True()

--- a/minio/resource_minio_s3_bucket_replication_test.go
+++ b/minio/resource_minio_s3_bucket_replication_test.go
@@ -1463,7 +1463,7 @@ func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
 					"rule.2.target.0.secret_key",
 					"resync_version",
 					"last_resync_id",
-					// Prorities are ignored in this test case, as it gets automatically generated and thus mismatch
+					// Priorities are ignored here: they are auto-generated and thus mismatch
 					"rule.0.priority",
 					"rule.1.priority",
 					"rule.2.priority",
@@ -1480,7 +1480,7 @@ func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
 					"rule.2.target.0.secret_key",
 					"resync_version",
 					"last_resync_id",
-					// Prorities are ignored in this test case, as it gets automatically generated and thus mismatch
+					// Priorities are ignored here: they are auto-generated and thus mismatch
 					"rule.0.priority",
 					"rule.1.priority",
 					"rule.2.priority",
@@ -1497,7 +1497,7 @@ func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
 					"rule.2.target.0.secret_key",
 					"resync_version",
 					"last_resync_id",
-					// Prorities are ignored in this test case, as it gets automatically generated and thus mismatch
+					// Priorities are ignored here: they are auto-generated and thus mismatch
 					"rule.0.priority",
 					"rule.1.priority",
 					"rule.2.priority",
@@ -1514,7 +1514,7 @@ func TestAccS3BucketReplication_twoway_complex(t *testing.T) {
 					"rule.2.target.0.secret_key",
 					"resync_version",
 					"last_resync_id",
-					// Prorities are ignored in this test case, as it gets automatically generated and thus mismatch
+					// Priorities are ignored here: they are auto-generated and thus mismatch
 					"rule.0.priority",
 					"rule.1.priority",
 					"rule.2.priority",
@@ -1711,17 +1711,6 @@ func testAccCheckBucketHasReplication(n string, config []S3MinioBucketReplicatio
 			return fmt.Errorf("non-equivalent status error:\n\nexpected: %d\n\ngot: %d", len(actualConfig.Rules), len(config))
 		}
 
-		// Check computed fields
-		// for i, rule := range config {
-		// 	if id, ok := rs.Primary.Attributes[fmt.Sprintf("rule.%d.id", i)]; !ok || len(id) != 20 {
-		// 		return fmt.Errorf("Rule#%d doesn't have a valid ID: %q", i, id)
-		// 	}
-		// 	if arn, ok := rs.Primary.Attributes[fmt.Sprintf("rule.%d.arn", i)]; !ok || len(arn) != len(fmt.Sprintf("arn:minio:replication::xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:%s", rule.Target.Bucket)) {
-		// 		return fmt.Errorf("Rule#%d doesn't have a valid ARN:\n\nexpected: arn:minio:replication::xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:%s\n\ngot: %v", i, rule.Target.Bucket, arn)
-		// 	}
-		// }
-
-		// Check bucket replication
 		actualReplicationConfigByPriority := map[int]replication.Rule{}
 		for _, rule := range actualConfig.Rules {
 			actualReplicationConfigByPriority[rule.Priority] = rule
@@ -1781,7 +1770,6 @@ func testAccCheckBucketHasReplication(n string, config []S3MinioBucketReplicatio
 			}
 		}
 
-		// Check remote target
 		actualTargets, err := minioadm.ListRemoteTargets(context.Background(), rs.Primary.ID, "")
 		if err != nil {
 			return fmt.Errorf("error on ListRemoteTargets: %v", err)

--- a/minio/resource_minio_s3_bucket_retention.go
+++ b/minio/resource_minio_s3_bucket_retention.go
@@ -89,7 +89,6 @@ func validateValidityPeriod(v interface{}, p cty.Path) diag.Diagnostics {
 }
 
 func validateBucketObjectLock(ctx context.Context, client *minio.Client, bucket string) error {
-	// Check if bucket exists
 	exists, err := client.BucketExists(ctx, bucket)
 	if err != nil {
 		return fmt.Errorf("error checking bucket existence: %w", err)
@@ -98,7 +97,6 @@ func validateBucketObjectLock(ctx context.Context, client *minio.Client, bucket 
 		return fmt.Errorf("bucket %s does not exist", bucket)
 	}
 
-	// Check if versioning is enabled (required for object locking)
 	versioning, err := client.GetBucketVersioning(ctx, bucket)
 	if err != nil {
 		return fmt.Errorf("error checking bucket versioning: %w", err)
@@ -108,7 +106,6 @@ func validateBucketObjectLock(ctx context.Context, client *minio.Client, bucket 
 		return fmt.Errorf("bucket %s does not have versioning enabled. Object locking requires versioning", bucket)
 	}
 
-	// Check if object lock is enabled
 	objectLock, _, _, _, err := client.GetObjectLockConfig(ctx, bucket)
 	if err != nil {
 		if strings.Contains(err.Error(), "Object Lock configuration does not exist") {
@@ -129,7 +126,6 @@ func minioCreateRetention(ctx context.Context, d *schema.ResourceData, meta inte
 	bucket := d.Get("bucket").(string)
 	var diags diag.Diagnostics
 
-	// Validate bucket object lock status before proceeding
 	if err := validateBucketObjectLock(ctx, client, bucket); err != nil {
 		return NewResourceError("validating bucket object lock", bucket, err)
 	}
@@ -166,7 +162,6 @@ func minioCreateRetention(ctx context.Context, d *schema.ResourceData, meta inte
 func minioReadRetention(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*S3MinioClient).S3Client
 
-	// First check if bucket still exists
 	exists, err := client.BucketExists(ctx, d.Id())
 	if err != nil {
 		return NewResourceError("checking bucket existence", d.Id(), err)
@@ -178,7 +173,6 @@ func minioReadRetention(ctx context.Context, d *schema.ResourceData, meta interf
 
 	mode, validity, unit, err := client.GetBucketObjectLockConfig(ctx, d.Id())
 	if err != nil {
-		// Check if the error indicates the retention config is gone
 		if strings.Contains(err.Error(), "Object Lock configuration does not exist") {
 			d.SetId("")
 			return nil
@@ -215,7 +209,6 @@ func minioUpdateRetention(ctx context.Context, d *schema.ResourceData, meta inte
 	client := meta.(*S3MinioClient).S3Client
 	bucket := d.Id()
 
-	// Validate bucket object lock status before proceeding
 	if err := validateBucketObjectLock(ctx, client, bucket); err != nil {
 		return NewResourceError("validating bucket object lock", bucket, err)
 	}

--- a/minio/resource_minio_s3_bucket_retention_test.go
+++ b/minio/resource_minio_s3_bucket_retention_test.go
@@ -123,7 +123,6 @@ func testAccCheckMinioBucketRetentionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Try to get retention config
 		mode, _, _, err := client.GetBucketObjectLockConfig(context.Background(), rs.Primary.ID)
 		if err == nil && mode != nil {
 			return fmt.Errorf("bucket retention still exists")
@@ -142,13 +141,11 @@ func testAccCheckMinioBucketRetentionDisappears(n string) resource.TestCheckFunc
 
 		client := testAccClient().S3Client
 
-		// Clear the retention configuration
 		err := client.SetBucketObjectLockConfig(context.Background(), rs.Primary.ID, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("error clearing bucket retention: %w", err)
 		}
 
-		// Force a read of the configuration to update state
 		mode, _, _, err := client.GetBucketObjectLockConfig(context.Background(), rs.Primary.ID)
 		if err == nil && mode != nil {
 			return fmt.Errorf("bucket retention still exists after clearing")

--- a/minio/resource_minio_s3_bucket_versioning.go
+++ b/minio/resource_minio_s3_bucket_versioning.go
@@ -80,12 +80,10 @@ func minioPutBucketVersioning(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put versioning configuration: %v", bucketVersioningConfig.MinioBucket, versioningConfig))
 
-	// Wait for bucket to be ready for eventual consistency
 	timeout := d.Timeout(schema.TimeoutCreate)
 	if d.Id() != "" {
 		timeout = d.Timeout(schema.TimeoutUpdate)
 	}
-	// Reserve time for the actual operation
 	waitTimeout := timeout - 30*time.Second
 	if waitTimeout < 30*time.Second {
 		waitTimeout = 30 * time.Second
@@ -139,7 +137,6 @@ func minioReadBucketVersioning(ctx context.Context, d *schema.ResourceData, meta
 
 	tflog.Debug(ctx, fmt.Sprintf("S3 bucket versioning, read for bucket: %s", d.Id()))
 
-	// For new resources, wait for bucket to be ready
 	if d.IsNewResource() {
 		timeout := d.Timeout(schema.TimeoutRead)
 		if err := waitForBucketReady(ctx, bucketVersioningConfig.MinioClient, d.Id(), timeout); err != nil {
@@ -151,7 +148,6 @@ func minioReadBucketVersioning(ctx context.Context, d *schema.ResourceData, meta
 			return NewResourceError("error waiting for bucket to be ready", d.Id(), err)
 		}
 	} else {
-		// For existing resources, check if bucket exists
 		exists, err := bucketVersioningConfig.MinioClient.BucketExists(ctx, d.Id())
 		if err != nil {
 			return NewResourceError("checking bucket existence", d.Id(), err)

--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -359,7 +359,6 @@ func minioDeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		return NewResourceError("deleting service account", d.Id(), err)
 	}
 
-	// Actively set resource as deleted
 	d.SetId("")
 
 	return nil

--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -478,7 +478,6 @@ func testAccCheckMinioServiceAccountDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Try to get service account
 		_, err := minioIam.GetUserInfo(context.Background(), rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("service account still exists")
@@ -503,7 +502,6 @@ func testAccCheckMinioServiceAccountCanLogIn(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
 
-		// Check if we can log in
 		cfg := &S3MinioConfig{
 			S3APISignature: "v4",
 			S3HostPort:     os.Getenv("MINIO_ENDPOINT"),

--- a/minio/tagging_helpers.go
+++ b/minio/tagging_helpers.go
@@ -8,9 +8,6 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
-// shouldSkipBucketTagging returns true when tagging operations should be skipped
-// for the given bucket configuration because tagging is disabled via the provider
-// flag. Returns false if the config object is nil.
 func shouldSkipBucketTagging(cfg *S3MinioBucket) bool {
 	if cfg == nil {
 		return false

--- a/minio/utils.go
+++ b/minio/utils.go
@@ -37,7 +37,6 @@ func tagsSchema() *schema.Schema {
 	}
 }
 
-// generateSecretAccessKey - generate random base64 numeric value from a random seed.
 func generateSecretAccessKey() (string, error) {
 	rb := make([]byte, minioSecretIDLength)
 	if _, e := rand.Read(rb); e != nil {
@@ -47,7 +46,6 @@ func generateSecretAccessKey() (string, error) {
 	return string(Encode(rb)), nil
 }
 
-// Encode queues message
 func Encode(value []byte) []byte {
 	length := len(value)
 	encoded := make([]byte, base64.URLEncoding.EncodedLen(length))
@@ -55,7 +53,6 @@ func Encode(value []byte) []byte {
 	return encoded
 }
 
-// getStringList get array of strings
 func getStringList(listString []interface{}) []string {
 	var result []string
 	for _, v := range listString {
@@ -66,7 +63,6 @@ func getStringList(listString []interface{}) []string {
 	return result
 }
 
-// Contains check that an array has the given element
 func Contains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {
@@ -104,12 +100,9 @@ func HashcodeString(s string) int {
 	return 0
 }
 
-// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
-// serialize changes across arbitrary collaborators that share knowledge of the
-// keys they must serialize on.
-//
-// The initial use case is to let aws_security_group_rule resources serialize
-// their access to individual security groups based on SG ID.
+// MutexKV is a simple key/value store for arbitrary mutexes, used to serialize
+// changes across collaborators that share knowledge of the keys they must
+// serialize on.
 type MutexKV struct {
 	lock  sync.Mutex
 	store map[string]*sync.Mutex
@@ -138,7 +131,6 @@ func (m *MutexKV) get(key string) *sync.Mutex {
 	return mutex
 }
 
-// Returns a properly initialized MutexKV
 func NewMutexKV() *MutexKV {
 	return &MutexKV{
 		store: make(map[string]*sync.Mutex),
@@ -156,12 +148,10 @@ func shortDur(d time.Duration) string {
 	return s
 }
 
-// NormalizeAndCompareJSONPolicies compares two policy JSON strings and returns the appropriate one to use.
-// It chooses the old policy if the policies are equivalent, otherwise returns the new one.
-// It also normalizes the chosen policy to ensure consistent formatting.
-// This function is used to prevent unnecessary updates when policies are semantically equivalent.
+// NormalizeAndCompareJSONPolicies returns the policy to keep, normalized: the
+// old one when the two are semantically equivalent (preventing unnecessary
+// updates), the new one otherwise.
 func NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy string) (string, error) {
-	// Handle empty policies
 	if strings.TrimSpace(newPolicy) == "" {
 		return "", nil
 	}
@@ -171,7 +161,6 @@ func NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy string) (string, error
 	}
 
 	if strings.TrimSpace(oldPolicy) == "" || strings.TrimSpace(oldPolicy) == "{}" {
-		// If old policy is empty, use the new one but normalize it first
 		normalizedPolicy, err := structure.NormalizeJsonString(newPolicy)
 		if err != nil {
 			return "", err
@@ -179,14 +168,12 @@ func NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy string) (string, error
 		return normalizedPolicy, nil
 	}
 
-	// Check if policies are equivalent
 	equivalent, err := awspolicy.PoliciesAreEquivalent(oldPolicy, newPolicy)
 	if err != nil {
 		return "", err
 	}
 
 	if equivalent {
-		// If policies are equivalent, prefer the existing one for state consistency
 		normalizedPolicy, err := structure.NormalizeJsonString(oldPolicy)
 		if err != nil {
 			return "", err
@@ -194,7 +181,6 @@ func NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy string) (string, error
 		return normalizedPolicy, nil
 	}
 
-	// Policies are different, use the new one but normalize it
 	normalizedPolicy, err := structure.NormalizeJsonString(newPolicy)
 	if err != nil {
 		return "", err
@@ -202,7 +188,6 @@ func NormalizeAndCompareJSONPolicies(oldPolicy, newPolicy string) (string, error
 	return normalizedPolicy, nil
 }
 
-// SafeUint64ToInt64 converts a uint64 to int64, returning MaxInt64 if the value exceeds it.
 func SafeUint64ToInt64(val uint64) (int64, bool) {
 	if val > uint64(math.MaxInt64) {
 		return math.MaxInt64, false
@@ -253,7 +238,6 @@ func ParseBandwidthLimit(ctx context.Context, target map[string]any) (uint64, bo
 		return 0, false, errs
 	}
 
-	// Check if bandwidth exceeds maximum int64 value
 	if bandwidth > uint64(math.MaxInt64) {
 		tflog.Warn(ctx, "Configured bandwidth limit exceeds maximum supported value, clamping", map[string]interface{}{"configured": humanize.Bytes(bandwidth), "max": humanize.Bytes(uint64(math.MaxInt64))})
 	}
@@ -318,8 +302,6 @@ func isLifecycleNotFoundError(err error) bool {
 		strings.Contains(msg, "The lifecycle configuration does not exist")
 }
 
-// isS3CompatNotSupported returns true if the error indicates an unsupported
-// S3 feature and S3 compat mode is enabled on the client.
 func isS3CompatNotSupported(client *S3MinioClient, err error) bool {
 	if !client.S3CompatMode || err == nil {
 		return false

--- a/minio/utils_test.go
+++ b/minio/utils_test.go
@@ -78,7 +78,6 @@ func TestSafeUint64ToInt64(t *testing.T) {
 }
 
 func TestSafeUint64ToInt64_NoNegative(t *testing.T) {
-	// Ensure we never return negative values
 	testValues := []uint64{
 		0,
 		1,


### PR DESCRIPTION
### Type of Change
- [x] Refactoring (no functional changes, code improvement)
- [x] Documentation update

### What does this PR do?

While developing this provider, many comment lines accumulated that restate the code right below them; those go stale the moment the code moves. This PR removes them and adds an explicit `## Comment Hygiene` section to `AGENTS.md` (plus one hard guardrail) so future contributions hold the same bar.

**Removed:**
- doc comments that parrot the name (`BucketConfig creates a new configuration for MinIO buckets.`, `Encode queues message`, ~70 of them in `payload.go`/`check_config.go`)
- step narrations (`// Initialize S3 client`, `// Set the ID to the key`, `// Parse the config`)
- section markers in the `provider.go` maps, where the resource names already group themselves (`minio_iam_*`, `minio_notify_*`, ...)
- one commented-out code block in the replication test, and the stale `aws_security_group_rule` sentence carried over from the AWS provider in the `MutexKV` doc

**Trimmed, keeping only the why:** the two-phase force-destroy docs in `resource_minio_s3_bucket.go`, `NormalizeAndCompareJSONPolicies`, and two data-source test docs.

**Kept:** every non-obvious *why* - minio-go workarounds (bulk delete swallowing per-object errors, IAM cache resurrection, multi-drive versioning loss), eventual-consistency handling, the accesskey sensitivity-marker decisions, edge-case contracts, issue references (#348, #608, #941, #1014, #1071, #1089), and the `//#nosec` linter directives.

### How was this change tested?

1. Comment-only proof: stripping all comments from `main` and from this branch yields byte-identical token streams for all 35 changed Go files.
2. `go build ./...`, `go vet ./minio/...`, `gofmt -s -l` (clean), and `go test ./minio/...` (unit suite; acceptance tests need `TF_ACC`) all pass.

### Where to start

The whole diff is mechanical; the only judgment calls are the trimmed (not deleted) docs in `minio/resource_minio_s3_bucket.go` and `minio/utils.go`, and the new `AGENTS.md` section.

### Related Issues

None; requested as repository hygiene.
