### PR TITLE
fix: bound config_history and license_info reads on unsupported servers

### DIFF
--- a/minio/data_source_minio_config_history.go
+++ b/minio/data_source_minio_config_history.go
@@ -2,11 +2,12 @@ package minio
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -58,9 +59,13 @@ func dataSourceMinioConfigHistoryRead(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Debug(ctx, fmt.Sprintf("Listing config history with limit: %d", limit))
 
-	history, err := admin.ListConfigHistoryKV(ctx, limit)
+	readCtx, cancel := context.WithTimeout(ctx, unsupportedAdminAPITimeout)
+	defer cancel()
+
+	history, err := admin.ListConfigHistoryKV(readCtx, limit)
 	if err != nil {
-		if strings.Contains(err.Error(), "admin' API is not supported") ||
+		if errors.Is(err, context.DeadlineExceeded) ||
+			strings.Contains(err.Error(), "admin' API is not supported") ||
 			strings.Contains(err.Error(), "mode-server-xl") {
 			tflog.Debug(ctx, "Config history API not available (Enterprise feature)")
 			d.SetId("config_history")

--- a/minio/data_source_minio_config_history_test.go
+++ b/minio/data_source_minio_config_history_test.go
@@ -1,9 +1,19 @@
 package minio
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/madmin-go/v4"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func TestAccDataSourceMinioConfigHistory_basic(t *testing.T) {
@@ -27,4 +37,35 @@ func testAccConfigHistoryConfig_basic() string {
 	return `
 data "minio_config_history" "test" {}
 `
+}
+
+func TestDataSourceConfigHistory_unsupportedServerIsBounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"Code":"XMinioAdminNotSupported","Message":"This 'admin' API is not supported by server in 'mode-server-xl'"}`)
+	}))
+	defer srv.Close()
+
+	adminClient, err := madmin.NewWithOptions(strings.TrimPrefix(srv.URL, "http://"), &madmin.Options{
+		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("creating admin client: %v", err)
+	}
+
+	d := schema.TestResourceDataRaw(t, dataSourceMinioConfigHistory().Schema, map[string]interface{}{})
+	start := time.Now()
+	diags := dataSourceMinioConfigHistoryRead(context.Background(), d, &S3MinioClient{S3Admin: adminClient})
+	elapsed := time.Since(start)
+
+	if elapsed > 30*time.Second {
+		t.Fatalf("read took %s; the unsupported-API deadline is not bounding the retry loop", elapsed)
+	}
+	if len(diags) != 1 || diags[0].Severity != diag.Warning {
+		t.Fatalf("expected exactly one warning diagnostic, got %+v", diags)
+	}
+	if d.Id() != "config_history" {
+		t.Errorf("expected id %q, got %q", "config_history", d.Id())
+	}
 }

--- a/minio/data_source_minio_license_info.go
+++ b/minio/data_source_minio_license_info.go
@@ -2,11 +2,14 @@ package minio
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+const unsupportedAdminAPITimeout = 10 * time.Second
 
 func dataSourceMinioLicenseInfo() *schema.Resource {
 	return &schema.Resource{
@@ -28,7 +31,10 @@ func dataSourceMinioLicenseInfoRead(ctx context.Context, d *schema.ResourceData,
 
 	tflog.Debug(ctx, "Reading license info")
 
-	info, err := admin.GetLicenseInfo(ctx)
+	readCtx, cancel := context.WithTimeout(ctx, unsupportedAdminAPITimeout)
+	defer cancel()
+
+	info, err := admin.GetLicenseInfo(readCtx)
 	if err != nil {
 		// Servers without a license subsystem (community MinIO) report the
 		// unlicensed state instead of failing the read.

--- a/minio/data_source_minio_license_info_test.go
+++ b/minio/data_source_minio_license_info_test.go
@@ -1,9 +1,18 @@
 package minio
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/minio/madmin-go/v4"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func TestAccDataSourceMinioLicenseInfo_basic(t *testing.T) {
@@ -25,4 +34,35 @@ func TestAccDataSourceMinioLicenseInfo_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestDataSourceLicenseInfo_unsupportedServerIsBounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"Code":"XMinioAdminNotSupported","Message":"This 'admin' API is not supported by server in 'mode-server-xl'"}`)
+	}))
+	defer srv.Close()
+
+	adminClient, err := madmin.NewWithOptions(strings.TrimPrefix(srv.URL, "http://"), &madmin.Options{
+		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("creating admin client: %v", err)
+	}
+
+	d := schema.TestResourceDataRaw(t, dataSourceMinioLicenseInfo().Schema, map[string]interface{}{})
+	start := time.Now()
+	diags := dataSourceMinioLicenseInfoRead(context.Background(), d, &S3MinioClient{S3Admin: adminClient})
+	elapsed := time.Since(start)
+
+	if elapsed > 30*time.Second {
+		t.Fatalf("read took %s; the unsupported-API deadline is not bounding the retry loop", elapsed)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected the unlicensed fallback to succeed, got %+v", diags)
+	}
+	if d.Id() != "unlicensed" {
+		t.Errorf("expected id %q, got %q", "unlicensed", d.Id())
+	}
 }


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

Implements #1117.

Root cause, measured with stub servers that reproduce the two failure modes:

1. Community MinIO does not serve `list-config-history-kv` and `license-info`. madmin-go treats the failure as transient and retries **ten times with exponential backoff** before returning.
2. Measured cost of one call through the provider's transport (`ResponseHeaderTimeout` 30s):
   - server answers an instant permanent `503` ("This 'admin' API is not supported by server in 'mode-server-xl'"): **94.5s** (jitter reaches ~3 minutes)
   - server accepts the request and never answers: **415.9s** (10 × 30s header timeout plus backoff)
3. The ~460s observed per test in CI matches one hang-mode read, or multiple 503-mode reads across plan and apply. Both tests then gate the wall clock of every CI run.

The fix:

- Both reads run under a **10-second context deadline** (`unsupportedAdminAPITimeout`). The deadline cancels madmin's retry loop in both failure modes.
- The config history fallback treats `context.DeadlineExceeded` as the unsupported case, next to the existing error-string matches. The license fallback already treats any error as unlicensed.
- Servers that support these APIs answer in milliseconds and never hit the deadline.

### How was this change tested?

- Two new tests run each read against a stub that answers with the exact 503 the community server produces, and assert the read returns within the deadline and takes the graceful path (warning + empty entries; `unlicensed`). Both complete in 10.0s, against 94.5s and 415.9s measured for one unbounded call.
- Full unit suite passes. `go vet` and `gofmt` clean.
- Expected CI effect: `TestAccDataSourceMinioConfigHistory_basic` and `TestAccDataSourceMinioLicenseInfo_basic` drop from ~460s to under 30s, which the acceptance criterion in #1117 requires.

A note for a possible upstream report: retrying `XMinioAdminNotSupported` responses is arguably a madmin-go defect, since the condition is permanent. This PR bounds the damage on the provider side either way.

### Related Issues

- Closes #1117