### PR TITLE
test: make iam_import trailing plans deterministic

### DIFF
--- a/minio/resource_minio_iam_import_test.go
+++ b/minio/resource_minio_iam_import_test.go
@@ -28,13 +28,6 @@ func TestAccResourceMinioIAMImport_roundTrip(t *testing.T) {
 					resource.TestCheckResourceAttrSet(importName, "id"),
 					resource.TestCheckResourceAttrSet(importName, "sha256"),
 				),
-				// MinIO's zip export embeds non-deterministic metadata, so
-				// chaining data.minio_iam_export -> minio_iam_import in the
-				// same apply produces different bytes on each refresh. The
-				// import is idempotent server-side; users wanting stable
-				// plans should put export and import in separate states or
-				// pin iam_data via lifecycle.ignore_changes.
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -60,6 +53,10 @@ data "minio_iam_export" "snapshot" {
 
 resource "minio_iam_import" "restore" {
   iam_data = data.minio_iam_export.snapshot.iam_data
+
+  lifecycle {
+    ignore_changes = [iam_data]
+  }
 }
 `, policyName)
 }
@@ -79,15 +76,14 @@ func TestAccResourceMinioIAMImport_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet(importName, "id"),
 					resource.TestCheckResourceAttrSet(importName, "sha256"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccIAMImportTwoPoliciesConfig(policyA, policyB),
+				Taint:  []string{importName},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(importName, "id"),
 					resource.TestCheckResourceAttrSet(importName, "sha256"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -113,6 +109,10 @@ data "minio_iam_export" "snapshot" {
 
 resource "minio_iam_import" "restore" {
   iam_data = data.minio_iam_export.snapshot.iam_data
+
+  lifecycle {
+    ignore_changes = [iam_data]
+  }
 }
 `, policyA)
 }
@@ -149,6 +149,10 @@ data "minio_iam_export" "snapshot" {
 
 resource "minio_iam_import" "restore" {
   iam_data = data.minio_iam_export.snapshot.iam_data
+
+  lifecycle {
+    ignore_changes = [iam_data]
+  }
 }
 `, policyA, policyB)
 }


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

`TestAccResourceMinioIAMImport_roundTrip` failed intermittently on `main` with `Expected a non-empty plan, but got an empty plan` (attempt 1 of runs 32979972304 and 32973023371; both passed on re-run).

Root cause: the steps set `ExpectNonEmptyPlan: true` on the assumption that re-reading `minio_iam_export` always yields different zip bytes. Zip metadata timestamps have one-second granularity, so when the apply-time export and the refresh-time export land in the same second, the bytes are identical, the trailing plan is empty, and the step fails. The SDK cannot accept both outcomes, so each step must be deterministic one way.

The fix makes the trailing plans deterministically empty:

- All three test configurations pin `iam_data` with `lifecycle.ignore_changes`, which is the stable-plan remedy the resource already documents for users.
- `ExpectNonEmptyPlan` is dropped from all three steps.
- The update test keeps exercising re-import of a changed snapshot by tainting the resource in its second step; create and update share the same apply function in this resource, so the covered path is unchanged.

### How was this change tested?

- `go vet`, `gofmt` and the unit suite pass. The acceptance behavior is validated by this PR's own CI run: the two tests now hold in both timing outcomes, where before they depended on the exports straddling a second boundary.