### PR TITLE
fix: honour the request timeout, retry and delay environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ History older than 3.39.0 lives in the
   A value of 0 or less falls back to the default. This was already true for
   `max_retries` and `retry_delay_ms`; `request_timeout_seconds` now behaves the
   same way, where before a non-positive value reached the HTTP transport and
-  every call failed with a misleading `i/o timeout`.
+  every call failed with a misleading `i/o timeout`. `minio_health_status` used
+  its own fallback of 10 seconds in that case, and now uses 30 as well, so one
+  value applies wherever the attribute is read.
 
 - The description of `retry_delay_ms` said "base delay in milliseconds between
   retries". The value is not the delay: it caps the wait at 20 times its value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ History older than 3.39.0 lives in the
   unchanged; the provider now speaks protocol 6, which Terraform 1.0 and later
   already negotiate.
 
+### Fixed
+
+- `MINIO_REQUEST_TIMEOUT_SECONDS`, `MINIO_MAX_RETRIES` and `MINIO_RETRY_DELAY_MS`
+  now set `request_timeout_seconds`, `max_retries` and `retry_delay_ms`. The
+  three attributes declared a static default next to the environment lookup,
+  and the static default won, so the variables had never taken effect even
+  though the provider documentation offered them. A deployment that already
+  sets one of these variables will see the value applied after this upgrade,
+  where before it silently used 30, 6 and 1000. An explicit value in the
+  provider block still wins over the environment
+  ([#1149](https://github.com/aminueza/terraform-provider-minio/issues/1149)).
+
 ## [3.41.1] - 2026-09-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,34 +37,21 @@ History older than 3.39.0 lives in the
 
 - `MINIO_REQUEST_TIMEOUT_SECONDS`, `MINIO_MAX_RETRIES` and `MINIO_RETRY_DELAY_MS`
   now set `request_timeout_seconds`, `max_retries` and `retry_delay_ms`. The
-  three attributes declared a static default next to the environment lookup,
-  and the static default won, so the variables had never taken effect even
-  though the provider documentation offered them. A deployment that already
-  sets one of these variables will see the value applied after this upgrade,
-  where before it silently used 30, 6 and 1000. An explicit value in the
-  provider block still wins over the environment
+  three attributes declared a static default beside the environment lookup, and
+  the static default won, so the variables never took effect. A deployment that
+  already sets one of them gets the value it asked for after this upgrade, where
+  before it got 30, 6 and 1000
   ([#1149](https://github.com/aminueza/terraform-provider-minio/issues/1149)).
-
-  Two consequences of the variables becoming live:
-
-  A value that is not a whole number now stops every command that loads the
+- A value that is not a whole number now stops every command that loads the
   provider, `destroy` included, instead of being ignored. The error names the
-  variable and the value, for example
-  `MINIO_MAX_RETRIES must be a whole number, got "abc"`. Correct or unset the
-  variable to recover.
-
-  A value of 0 or less falls back to the default. This was already true for
-  `max_retries` and `retry_delay_ms`; `request_timeout_seconds` now behaves the
-  same way, where before a non-positive value reached the HTTP transport and
-  every call failed with a misleading `i/o timeout`. `minio_health_status` used
-  its own fallback of 10 seconds in that case, and now uses 30 as well, so one
-  value applies wherever the attribute is read.
-
-- The description of `retry_delay_ms` said "base delay in milliseconds between
-  retries". The value is not the delay: it caps the wait at 20 times its value
-  in milliseconds, and the wait itself is random and doubles with each attempt.
-  The default of 1000 caps the wait at 20 seconds. The description and the
-  provider documentation now state this. The retry behaviour is unchanged.
+  variable: `MINIO_MAX_RETRIES must be a whole number, got "abc"`.
+- `request_timeout_seconds` of 0 or less falls back to 30. It used to reach the
+  HTTP transport, where every call then failed with a misleading `i/o timeout`.
+  `minio_health_status` fell back to 10 seconds in that case and now uses 30 too.
+- `retry_delay_ms` is not the base delay between retries, as its description
+  said. It caps the wait at 20 times its value in milliseconds, and the wait
+  itself is random and doubles with each attempt. The description and the
+  documentation now say so. The retry behaviour is unchanged.
 
 ## [3.41.1] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ History older than 3.39.0 lives in the
   provider block still wins over the environment
   ([#1149](https://github.com/aminueza/terraform-provider-minio/issues/1149)).
 
+  Two consequences of the variables becoming live:
+
+  A value that is not a whole number now stops every command that loads the
+  provider, `destroy` included, instead of being ignored. The error names the
+  variable and the value, for example
+  `MINIO_MAX_RETRIES must be a whole number, got "abc"`. Correct or unset the
+  variable to recover.
+
+  A value of 0 or less falls back to the default. This was already true for
+  `max_retries` and `retry_delay_ms`; `request_timeout_seconds` now behaves the
+  same way, where before a non-positive value reached the HTTP transport and
+  every call failed with a misleading `i/o timeout`.
+
+- The description of `retry_delay_ms` said "base delay in milliseconds between
+  retries". The value is not the delay: it caps the wait at 20 times its value
+  in milliseconds, and the wait itself is random and doubles with each attempt.
+  The default of 1000 caps the wait at 20 seconds. The description and the
+  provider documentation now state this. The retry behaviour is unchanged.
+
 ## [3.41.1] - 2026-09-03
 
 ### Changed

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,11 +113,11 @@ The following arguments are supported in the `provider` block:
 
 * `s3_compat_mode` - (Optional) Enable S3 compatibility mode for non-MinIO backends. Gracefully handles unsupported features instead of erroring (default: `false`). Can be sourced from `MINIO_S3_COMPAT_MODE`. See [S3 Compatibility Mode](#s3-compatibility-mode) below.
 
-* `request_timeout_seconds` - (Optional) Global HTTP request timeout in seconds for all MinIO API calls (default: `30`). Can be sourced from `MINIO_REQUEST_TIMEOUT_SECONDS`.
+* `request_timeout_seconds` - (Optional) Global HTTP request timeout in seconds for all MinIO API calls. A value of 0 or less falls back to the default of `30`. Can be sourced from `MINIO_REQUEST_TIMEOUT_SECONDS`.
 
-* `max_retries` - (Optional) Maximum number of retries for failed operations (default: `6`). Can be sourced from `MINIO_MAX_RETRIES`.
+* `max_retries` - (Optional) Maximum number of attempts for operations that retry. A value of 0 or less falls back to the default of `6`. Can be sourced from `MINIO_MAX_RETRIES`.
 
-* `retry_delay_ms` - (Optional) Base delay in milliseconds between retries, used with exponential backoff (default: `1000`). Can be sourced from `MINIO_RETRY_DELAY_MS`.
+* `retry_delay_ms` - (Optional) Upper bound on the wait between retries, as one twentieth of that bound in milliseconds. The wait itself is random and doubles with each attempt. The default of `1000` caps the wait at 20 seconds. A value of 0 or less falls back to the default. Can be sourced from `MINIO_RETRY_DELAY_MS`.
 
 * `assume_role` - (Optional) Configuration block for STS AssumeRole. See [Assume Role](#assume-role) below.
 

--- a/minio/check_config_test.go
+++ b/minio/check_config_test.go
@@ -1,0 +1,89 @@
+package minio
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var retryTuningAttributes = []struct {
+	attribute   string
+	envKey      string
+	builtIn     int
+	envValue    int
+	configValue int
+}{
+	{"request_timeout_seconds", "MINIO_REQUEST_TIMEOUT_SECONDS", 30, 45, 12},
+	{"max_retries", "MINIO_MAX_RETRIES", 6, 9, 2},
+	{"retry_delay_ms", "MINIO_RETRY_DELAY_MS", 1000, 250, 75},
+}
+
+func retryTuning(config *S3MinioConfig) map[string]int {
+	return map[string]int{
+		"request_timeout_seconds": config.RequestTimeoutSeconds,
+		"max_retries":             config.MaxRetries,
+		"retry_delay_ms":          config.RetryDelayMs,
+	}
+}
+
+func clearRetryTuningEnvironment(t *testing.T) {
+	t.Helper()
+	for _, tc := range retryTuningAttributes {
+		t.Setenv(tc.envKey, "")
+	}
+}
+
+func TestNewConfigUsesTheBuiltInRetryDefaults(t *testing.T) {
+	clearRetryTuningEnvironment(t)
+
+	config := NewConfig(schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{}))
+
+	for _, tc := range retryTuningAttributes {
+		if got := retryTuning(config)[tc.attribute]; got != tc.builtIn {
+			t.Errorf("%s = %d, want the built-in default %d", tc.attribute, got, tc.builtIn)
+		}
+	}
+}
+
+func TestNewConfigReadsTheRetryEnvironmentVariables(t *testing.T) {
+	for _, tc := range retryTuningAttributes {
+		t.Setenv(tc.envKey, strconv.Itoa(tc.envValue))
+	}
+
+	config := NewConfig(schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{}))
+
+	for _, tc := range retryTuningAttributes {
+		if got := retryTuning(config)[tc.attribute]; got != tc.envValue {
+			t.Errorf("%s = %d, want %d from %s", tc.attribute, got, tc.envValue, tc.envKey)
+		}
+	}
+}
+
+func TestNewConfigPrefersTheConfigurationOverTheRetryEnvironment(t *testing.T) {
+	raw := map[string]interface{}{}
+	for _, tc := range retryTuningAttributes {
+		t.Setenv(tc.envKey, strconv.Itoa(tc.envValue))
+		raw[tc.attribute] = tc.configValue
+	}
+
+	config := NewConfig(schema.TestResourceDataRaw(t, Provider().Schema, raw))
+
+	for _, tc := range retryTuningAttributes {
+		if got := retryTuning(config)[tc.attribute]; got != tc.configValue {
+			t.Errorf("%s = %d, want the configured value %d", tc.attribute, got, tc.configValue)
+		}
+	}
+}
+
+func TestProviderRetryAttributesDeclareNoStaticDefault(t *testing.T) {
+	for _, tc := range retryTuningAttributes {
+		attribute := Provider().Schema[tc.attribute]
+		if attribute.Default != nil {
+			t.Errorf("%s declares Default %v: DefaultValue returns Default without ever calling DefaultFunc, so %s would be ignored", tc.attribute, attribute.Default, tc.envKey)
+		}
+		if attribute.DefaultFunc == nil {
+			t.Errorf("%s declares no DefaultFunc, so %s cannot be read", tc.attribute, tc.envKey)
+		}
+	}
+}

--- a/minio/check_config_test.go
+++ b/minio/check_config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -101,6 +103,18 @@ func TestEnvDefaultIntRejectsAValueThatIsNotAWholeNumber(t *testing.T) {
 	}
 }
 
+func TestEnvDefaultIntSaysWhenAWholeNumberIsOutOfRange(t *testing.T) {
+	t.Setenv("MINIO_PROBE_INT", "99999999999999999999")
+
+	_, err := envDefaultInt("MINIO_PROBE_INT", 7)()
+	if err == nil {
+		t.Fatal("a value beyond the integer range must be reported")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("the error is %q: the value is a whole number, so the message must say the range is the problem", err)
+	}
+}
+
 func TestEnvDefaultIntReadsAWholeNumber(t *testing.T) {
 	t.Setenv("MINIO_PROBE_INT", "-3")
 
@@ -121,7 +135,21 @@ func TestNonPositiveRetryTuningFallsBackForBothHalves(t *testing.T) {
 		"max_retries":             0,
 		"retry_delay_ms":          0,
 	}))
-	frameworkConfigured := &S3MinioConfig{RequestTimeoutSeconds: 0, MaxRetries: 0, RetryDelayMs: 0}
+
+	model := nullFrameworkModel()
+	model.RequestTimeoutSeconds = types.Int64Value(0)
+	model.MaxRetries = types.Int64Value(0)
+	model.RetryDelayMs = types.Int64Value(0)
+
+	var diags diag.Diagnostics
+	frameworkConfigured := frameworkConfig(context.Background(), model, &diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if sdkConfig.RequestTimeoutSeconds == frameworkConfigured.RequestTimeoutSeconds {
+		t.Fatalf("both halves resolved request_timeout_seconds to %d: this test exists because they disagree, GetOk replacing 0 on the SDKv2 side only", sdkConfig.RequestTimeoutSeconds)
+	}
 
 	for _, tc := range []struct {
 		half   string

--- a/minio/check_config_test.go
+++ b/minio/check_config_test.go
@@ -1,8 +1,11 @@
 package minio
 
 import (
+	"context"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -72,6 +75,75 @@ func TestNewConfigPrefersTheConfigurationOverTheRetryEnvironment(t *testing.T) {
 	for _, tc := range retryTuningAttributes {
 		if got := retryTuning(config)[tc.attribute]; got != tc.configValue {
 			t.Errorf("%s = %d, want the configured value %d", tc.attribute, got, tc.configValue)
+		}
+	}
+}
+
+func TestEnvDefaultIntRejectsAValueThatIsNotAWholeNumber(t *testing.T) {
+	for _, raw := range []string{"abc", " 9", "1.5", ""} {
+		t.Setenv("MINIO_PROBE_INT", raw)
+
+		value, err := envDefaultInt("MINIO_PROBE_INT", 7)()
+
+		if raw == "" {
+			if err != nil || value != 7 {
+				t.Errorf("an unset variable gave (%v, %v), want the fallback 7 and no error", value, err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("%q gave %v, want an error", raw, value)
+			continue
+		}
+		if !strings.Contains(err.Error(), "MINIO_PROBE_INT") || !strings.Contains(err.Error(), raw) {
+			t.Errorf("the error for %q is %q: it must name the variable and the value so the operator can find the typo", raw, err)
+		}
+	}
+}
+
+func TestEnvDefaultIntReadsAWholeNumber(t *testing.T) {
+	t.Setenv("MINIO_PROBE_INT", "-3")
+
+	value, err := envDefaultInt("MINIO_PROBE_INT", 7)()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if value != -3 {
+		t.Errorf("value = %v, want -3: the fallback for a non-positive value belongs to the consumer, not to the parser", value)
+	}
+}
+
+func TestNonPositiveRetryTuningFallsBackForBothHalves(t *testing.T) {
+	clearRetryTuningEnvironment(t)
+
+	sdkConfig := NewConfig(schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
+		"request_timeout_seconds": 0,
+		"max_retries":             0,
+		"retry_delay_ms":          0,
+	}))
+	frameworkConfigured := &S3MinioConfig{RequestTimeoutSeconds: 0, MaxRetries: 0, RetryDelayMs: 0}
+
+	for _, tc := range []struct {
+		half   string
+		config *S3MinioConfig
+	}{
+		{"SDKv2", sdkConfig},
+		{"framework", frameworkConfigured},
+	} {
+		transport, err := tc.config.customTransport(context.Background())
+		if err != nil {
+			t.Fatalf("building the %s transport: %s", tc.half, err)
+		}
+		if transport.ResponseHeaderTimeout != defaultRequestTimeoutSeconds*time.Second {
+			t.Errorf("%s half times out after %v, want the default %ds", tc.half, transport.ResponseHeaderTimeout, defaultRequestTimeoutSeconds)
+		}
+
+		retry := getRetryConfig(&S3MinioClient{MaxRetries: tc.config.MaxRetries, RetryDelayMs: tc.config.RetryDelayMs})
+		if retry.MaxRetries != defaultMaxRetries {
+			t.Errorf("%s half retries %d times, want the default %d", tc.half, retry.MaxRetries, defaultMaxRetries)
+		}
+		if retry.MaxBackoff != time.Duration(defaultRetryDelayMs*20)*time.Millisecond {
+			t.Errorf("%s half caps the backoff at %v, want the default", tc.half, retry.MaxBackoff)
 		}
 	}
 }

--- a/minio/data_source_minio_health_status.go
+++ b/minio/data_source_minio_health_status.go
@@ -63,10 +63,11 @@ func dataSourceMinioHealthStatusRead(ctx context.Context, d *schema.ResourceData
 
 	tflog.Debug(ctx, fmt.Sprintf("Checking MinIO health at %s", baseURL))
 
-	timeout := 10 * time.Second
-	if m.RequestTimeoutSeconds > 0 {
-		timeout = time.Duration(m.RequestTimeoutSeconds) * time.Second
+	seconds := m.RequestTimeoutSeconds
+	if seconds <= 0 {
+		seconds = defaultRequestTimeoutSeconds
 	}
+	timeout := time.Duration(seconds) * time.Second
 	client := &http.Client{
 		Timeout: timeout,
 	}

--- a/minio/framework_config.go
+++ b/minio/framework_config.go
@@ -77,9 +77,9 @@ func frameworkConfig(ctx context.Context, model frameworkProviderModel, diags *d
 		SkipBucketTagging:     frameworkBool(model.SkipBucketTagging, []string{"MINIO_SKIP_BUCKET_TAGGING"}, false),
 		S3CompatMode:          frameworkBool(model.S3CompatMode, []string{"MINIO_S3_COMPAT_MODE"}, false),
 		Edition:               frameworkString(model.MinioEdition, []string{"MINIO_EDITION"}, ""),
-		RequestTimeoutSeconds: frameworkInt(model.RequestTimeoutSeconds, nil, 30),
-		MaxRetries:            frameworkInt(model.MaxRetries, nil, 6),
-		RetryDelayMs:          frameworkInt(model.RetryDelayMs, nil, 1000),
+		RequestTimeoutSeconds: frameworkInt(model.RequestTimeoutSeconds, []string{"MINIO_REQUEST_TIMEOUT_SECONDS"}, 30),
+		MaxRetries:            frameworkInt(model.MaxRetries, []string{"MINIO_MAX_RETRIES"}, 6),
+		RetryDelayMs:          frameworkInt(model.RetryDelayMs, []string{"MINIO_RETRY_DELAY_MS"}, 1000),
 	}
 
 	if !model.AssumeRole.IsNull() && !model.AssumeRole.IsUnknown() {

--- a/minio/framework_config.go
+++ b/minio/framework_config.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -47,6 +48,13 @@ func frameworkInt(v types.Int64, envKeys []string, fallback int, diags *diag.Dia
 			continue
 		}
 		parsed, err := strconv.Atoi(env)
+		if errors.Is(err, strconv.ErrRange) {
+			diags.AddError(
+				"Invalid "+key,
+				fmt.Sprintf("%s is out of range, got %q.", key, env),
+			)
+			return fallback
+		}
 		if err != nil {
 			diags.AddError(
 				"Invalid "+key,

--- a/minio/framework_config.go
+++ b/minio/framework_config.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -36,17 +37,24 @@ func frameworkBool(v types.Bool, envKeys []string, fallback bool) bool {
 	return fallback
 }
 
-func frameworkInt(v types.Int64, envKeys []string, fallback int) int {
+func frameworkInt(v types.Int64, envKeys []string, fallback int, diags *diag.Diagnostics) int {
 	if !v.IsNull() && !v.IsUnknown() {
 		return int(v.ValueInt64())
 	}
 	for _, key := range envKeys {
-		if env := os.Getenv(key); env != "" {
-			parsed, err := strconv.Atoi(env)
-			if err == nil {
-				return parsed
-			}
+		env := os.Getenv(key)
+		if env == "" {
+			continue
 		}
+		parsed, err := strconv.Atoi(env)
+		if err != nil {
+			diags.AddError(
+				"Invalid "+key,
+				fmt.Sprintf("%s must be a whole number, got %q.", key, env),
+			)
+			return fallback
+		}
+		return parsed
 	}
 	return fallback
 }
@@ -77,9 +85,9 @@ func frameworkConfig(ctx context.Context, model frameworkProviderModel, diags *d
 		SkipBucketTagging:     frameworkBool(model.SkipBucketTagging, []string{"MINIO_SKIP_BUCKET_TAGGING"}, false),
 		S3CompatMode:          frameworkBool(model.S3CompatMode, []string{"MINIO_S3_COMPAT_MODE"}, false),
 		Edition:               frameworkString(model.MinioEdition, []string{"MINIO_EDITION"}, ""),
-		RequestTimeoutSeconds: frameworkInt(model.RequestTimeoutSeconds, []string{"MINIO_REQUEST_TIMEOUT_SECONDS"}, 30),
-		MaxRetries:            frameworkInt(model.MaxRetries, []string{"MINIO_MAX_RETRIES"}, 6),
-		RetryDelayMs:          frameworkInt(model.RetryDelayMs, []string{"MINIO_RETRY_DELAY_MS"}, 1000),
+		RequestTimeoutSeconds: frameworkInt(model.RequestTimeoutSeconds, []string{"MINIO_REQUEST_TIMEOUT_SECONDS"}, defaultRequestTimeoutSeconds, diags),
+		MaxRetries:            frameworkInt(model.MaxRetries, []string{"MINIO_MAX_RETRIES"}, defaultMaxRetries, diags),
+		RetryDelayMs:          frameworkInt(model.RetryDelayMs, []string{"MINIO_RETRY_DELAY_MS"}, defaultRetryDelayMs, diags),
 	}
 
 	if !model.AssumeRole.IsNull() && !model.AssumeRole.IsUnknown() {
@@ -92,7 +100,7 @@ func frameworkConfig(ctx context.Context, model frameworkProviderModel, diags *d
 			block := blocks[0]
 			config.AssumeRoleARN = frameworkString(block.RoleARN, []string{"MINIO_ASSUME_ROLE_ARN"}, "")
 			config.AssumeRoleSessionName = frameworkString(block.SessionName, nil, "terraform")
-			config.AssumeRoleDuration = frameworkInt(block.DurationSeconds, nil, 3600)
+			config.AssumeRoleDuration = frameworkInt(block.DurationSeconds, nil, 3600, diags)
 			config.AssumeRolePolicy = frameworkString(block.Policy, nil, "")
 			config.AssumeRoleExternalID = frameworkString(block.ExternalID, nil, "")
 		}
@@ -108,7 +116,7 @@ func frameworkConfig(ctx context.Context, model frameworkProviderModel, diags *d
 			block := blocks[0]
 			config.WebIdentityToken = frameworkString(block.WebIdentityToken, []string{"MINIO_WEB_IDENTITY_TOKEN"}, "")
 			config.WebIdentityTokenFile = frameworkString(block.WebIdentityTokenFile, []string{"MINIO_WEB_IDENTITY_TOKEN_FILE"}, "")
-			config.WebIdentityDuration = frameworkInt(block.DurationSeconds, nil, 3600)
+			config.WebIdentityDuration = frameworkInt(block.DurationSeconds, nil, 3600, diags)
 		}
 	}
 

--- a/minio/framework_config_test.go
+++ b/minio/framework_config_test.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func nullFrameworkModel() frameworkProviderModel {
@@ -250,10 +252,10 @@ func TestFrameworkConfigAssumeRoleDefaults(t *testing.T) {
 	}
 }
 
-func TestFrameworkConfigIgnoresTheEnvVarsTheSDKIgnores(t *testing.T) {
-	t.Setenv("MINIO_REQUEST_TIMEOUT_SECONDS", "45")
-	t.Setenv("MINIO_MAX_RETRIES", "9")
-	t.Setenv("MINIO_RETRY_DELAY_MS", "250")
+func TestFrameworkConfigResolvesRetryTuningLikeTheSDK(t *testing.T) {
+	for _, tc := range retryTuningAttributes {
+		t.Setenv(tc.envKey, strconv.Itoa(tc.envValue))
+	}
 
 	var diags diag.Diagnostics
 	config := frameworkConfig(context.Background(), nullFrameworkModel(), &diags)
@@ -261,21 +263,38 @@ func TestFrameworkConfigIgnoresTheEnvVarsTheSDKIgnores(t *testing.T) {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 
-	sdkProvider := Provider()
-	for _, tc := range []struct {
-		attribute string
-		got       int
-	}{
-		{"request_timeout_seconds", config.RequestTimeoutSeconds},
-		{"max_retries", config.MaxRetries},
-		{"retry_delay_ms", config.RetryDelayMs},
-	} {
-		want, err := sdkProvider.Schema[tc.attribute].DefaultValue()
-		if err != nil {
-			t.Fatalf("reading the SDKv2 default for %s: %s", tc.attribute, err)
+	sdkConfig := NewConfig(schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{}))
+
+	for _, tc := range retryTuningAttributes {
+		got := retryTuning(config)[tc.attribute]
+		if got != tc.envValue {
+			t.Errorf("%s = %d, want %d from %s", tc.attribute, got, tc.envValue, tc.envKey)
 		}
-		if tc.got != want.(int) {
-			t.Errorf("%s = %d, want %v: the framework half must resolve this attribute exactly as the SDKv2 half does", tc.attribute, tc.got, want)
+		if want := retryTuning(sdkConfig)[tc.attribute]; got != want {
+			t.Errorf("%s = %d in the framework half and %d in the SDKv2 half: both must resolve this attribute the same way", tc.attribute, got, want)
+		}
+	}
+}
+
+func TestFrameworkConfigPrefersTheConfigurationOverTheRetryEnvironment(t *testing.T) {
+	for _, tc := range retryTuningAttributes {
+		t.Setenv(tc.envKey, strconv.Itoa(tc.envValue))
+	}
+
+	model := nullFrameworkModel()
+	model.RequestTimeoutSeconds = types.Int64Value(12)
+	model.MaxRetries = types.Int64Value(2)
+	model.RetryDelayMs = types.Int64Value(75)
+
+	var diags diag.Diagnostics
+	config := frameworkConfig(context.Background(), model, &diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	for _, tc := range retryTuningAttributes {
+		if got := retryTuning(config)[tc.attribute]; got != tc.configValue {
+			t.Errorf("%s = %d, want the configured value %d", tc.attribute, got, tc.configValue)
 		}
 	}
 }

--- a/minio/framework_config_test.go
+++ b/minio/framework_config_test.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -297,6 +298,24 @@ func TestFrameworkConfigPrefersTheConfigurationOverTheRetryEnvironment(t *testin
 			t.Errorf("%s = %d, want the configured value %d", tc.attribute, got, tc.configValue)
 		}
 	}
+}
+
+func TestFrameworkConfigRejectsARetryValueThatIsNotAWholeNumber(t *testing.T) {
+	clearRetryTuningEnvironment(t)
+	t.Setenv("MINIO_MAX_RETRIES", "abc")
+
+	var diags diag.Diagnostics
+	frameworkConfig(context.Background(), nullFrameworkModel(), &diags)
+
+	if !diags.HasError() {
+		t.Fatal("an unparsable MINIO_MAX_RETRIES must be reported, not silently replaced by the default")
+	}
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Summary(), "MINIO_MAX_RETRIES") && strings.Contains(d.Detail(), `"abc"`) {
+			return
+		}
+	}
+	t.Errorf("no diagnostic names the variable and the value: %v", diags)
 }
 
 func TestFrameworkProviderConfigurePassesConfigToEphemeralResources(t *testing.T) {

--- a/minio/framework_provider.go
+++ b/minio/framework_provider.go
@@ -102,15 +102,15 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			},
 			"request_timeout_seconds": schema.Int64Attribute{
 				Optional:    true,
-				Description: "Global HTTP request timeout in seconds for all MinIO API calls (default: 30)",
+				Description: "Global HTTP request timeout in seconds for all MinIO API calls. A value of 0 or less falls back to the default of 30.",
 			},
 			"max_retries": schema.Int64Attribute{
 				Optional:    true,
-				Description: "Maximum number of retries for failed operations (default: 6)",
+				Description: "Maximum number of attempts for operations that retry. A value of 0 or less falls back to the default of 6.",
 			},
 			"retry_delay_ms": schema.Int64Attribute{
 				Optional:    true,
-				Description: "Base delay in milliseconds between retries, used with exponential backoff (default: 1000)",
+				Description: "Upper bound on the wait between retries, as one twentieth of that bound in milliseconds. The wait itself is random and doubles with each attempt. The default of 1000 caps the wait at 20 seconds. A value of 0 or less falls back to the default.",
 			},
 		},
 		Blocks: map[string]schema.Block{

--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -27,6 +27,12 @@ const (
 // instead of leaving callers with two strings that never match.
 const aistorEdition = "AIStor"
 
+const (
+	defaultRequestTimeoutSeconds = 30
+	defaultMaxRetries            = 6
+	defaultRetryDelayMs          = 1000
+)
+
 func (config *S3MinioConfig) NewClient(ctx context.Context) (interface{}, error) {
 	tr, err := config.customTransport(ctx)
 	if err != nil {
@@ -182,7 +188,11 @@ func isValidCertificate(certBytes []byte) bool {
 }
 
 func (config *S3MinioConfig) customTransport(ctx context.Context) (*http.Transport, error) {
-	timeout := time.Duration(config.RequestTimeoutSeconds) * time.Second
+	seconds := config.RequestTimeoutSeconds
+	if seconds <= 0 {
+		seconds = defaultRequestTimeoutSeconds
+	}
+	timeout := time.Duration(seconds) * time.Second
 
 	if !config.S3SSL {
 		tr, err := minio.DefaultTransport(config.S3SSL)

--- a/minio/new_client_test.go
+++ b/minio/new_client_test.go
@@ -36,18 +36,20 @@ func TestCustomTransport_CustomTimeout(t *testing.T) {
 	}
 }
 
-func TestCustomTransport_ZeroTimeout(t *testing.T) {
-	config := &S3MinioConfig{
-		RequestTimeoutSeconds: 0,
-	}
+func TestCustomTransport_NonPositiveTimeoutFallsBackToTheDefault(t *testing.T) {
+	for _, seconds := range []int{0, -1} {
+		config := &S3MinioConfig{
+			RequestTimeoutSeconds: seconds,
+		}
 
-	tr, err := config.customTransport(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+		tr, err := config.customTransport(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
 
-	if tr.ResponseHeaderTimeout != 0 {
-		t.Errorf("expected ResponseHeaderTimeout 0, got %v", tr.ResponseHeaderTimeout)
+		if tr.ResponseHeaderTimeout != defaultRequestTimeoutSeconds*time.Second {
+			t.Errorf("RequestTimeoutSeconds %d gives ResponseHeaderTimeout %v, want the default %ds", seconds, tr.ResponseHeaderTimeout, defaultRequestTimeoutSeconds)
+		}
 	}
 }
 

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -167,21 +167,18 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"request_timeout_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     30,
 				Description: "Global HTTP request timeout in seconds for all MinIO API calls (default: 30)",
 				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_REQUEST_TIMEOUT_SECONDS", 30),
 			},
 			"max_retries": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     6,
 				Description: "Maximum number of retries for failed operations (default: 6)",
 				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_MAX_RETRIES", 6),
 			},
 			"retry_delay_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     1000,
 				Description: "Base delay in milliseconds between retries, used with exponential backoff (default: 1000)",
 				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_RETRY_DELAY_MS", 1000),
 			},

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -3,6 +3,8 @@ package minio
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -167,20 +169,20 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 			"request_timeout_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "Global HTTP request timeout in seconds for all MinIO API calls (default: 30)",
-				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_REQUEST_TIMEOUT_SECONDS", 30),
+				Description: "Global HTTP request timeout in seconds for all MinIO API calls. A value of 0 or less falls back to the default of 30.",
+				DefaultFunc: envDefaultInt(prefix+"MINIO_REQUEST_TIMEOUT_SECONDS", defaultRequestTimeoutSeconds),
 			},
 			"max_retries": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "Maximum number of retries for failed operations (default: 6)",
-				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_MAX_RETRIES", 6),
+				Description: "Maximum number of attempts for operations that retry. A value of 0 or less falls back to the default of 6.",
+				DefaultFunc: envDefaultInt(prefix+"MINIO_MAX_RETRIES", defaultMaxRetries),
 			},
 			"retry_delay_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "Base delay in milliseconds between retries, used with exponential backoff (default: 1000)",
-				DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_RETRY_DELAY_MS", 1000),
+				Description: "Upper bound on the wait between retries, as one twentieth of that bound in milliseconds. The wait itself is random and doubles with each attempt. The default of 1000 caps the wait at 20 seconds. A value of 0 or less falls back to the default.",
+				DefaultFunc: envDefaultInt(prefix+"MINIO_RETRY_DELAY_MS", defaultRetryDelayMs),
 			},
 			"assume_role": {
 				Type:        schema.TypeList,
@@ -392,6 +394,20 @@ func newProvider(envVarPrefix ...string) *schema.Provider {
 	}
 
 	return p
+}
+
+func envDefaultInt(key string, fallback int) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		raw := os.Getenv(key)
+		if raw == "" {
+			return fallback, nil
+		}
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s must be a whole number, got %q", key, raw)
+		}
+		return value, nil
+	}
 }
 
 func validateAPIVersion(v interface{}, k string) (ws []string, errors []error) {

--- a/minio/provider.go
+++ b/minio/provider.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -403,6 +404,9 @@ func envDefaultInt(key string, fallback int) schema.SchemaDefaultFunc {
 			return fallback, nil
 		}
 		value, err := strconv.Atoi(raw)
+		if errors.Is(err, strconv.ErrRange) {
+			return nil, fmt.Errorf("%s is out of range, got %q", key, raw)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("%s must be a whole number, got %q", key, raw)
 		}

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -33,8 +33,8 @@ type RetryConfig struct {
 }
 
 func getRetryConfig(client *S3MinioClient) RetryConfig {
-	maxRetries := 6
-	backoffBaseMs := 1000
+	maxRetries := defaultMaxRetries
+	backoffBaseMs := defaultRetryDelayMs
 	if client != nil {
 		if client.MaxRetries > 0 {
 			maxRetries = client.MaxRetries

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -113,11 +113,11 @@ The following arguments are supported in the `provider` block:
 
 * `s3_compat_mode` - (Optional) Enable S3 compatibility mode for non-MinIO backends. Gracefully handles unsupported features instead of erroring (default: `false`). Can be sourced from `MINIO_S3_COMPAT_MODE`. See [S3 Compatibility Mode](#s3-compatibility-mode) below.
 
-* `request_timeout_seconds` - (Optional) Global HTTP request timeout in seconds for all MinIO API calls (default: `30`). Can be sourced from `MINIO_REQUEST_TIMEOUT_SECONDS`.
+* `request_timeout_seconds` - (Optional) Global HTTP request timeout in seconds for all MinIO API calls. A value of 0 or less falls back to the default of `30`. Can be sourced from `MINIO_REQUEST_TIMEOUT_SECONDS`.
 
-* `max_retries` - (Optional) Maximum number of retries for failed operations (default: `6`). Can be sourced from `MINIO_MAX_RETRIES`.
+* `max_retries` - (Optional) Maximum number of attempts for operations that retry. A value of 0 or less falls back to the default of `6`. Can be sourced from `MINIO_MAX_RETRIES`.
 
-* `retry_delay_ms` - (Optional) Base delay in milliseconds between retries, used with exponential backoff (default: `1000`). Can be sourced from `MINIO_RETRY_DELAY_MS`.
+* `retry_delay_ms` - (Optional) Upper bound on the wait between retries, as one twentieth of that bound in milliseconds. The wait itself is random and doubles with each attempt. The default of `1000` caps the wait at 20 seconds. A value of 0 or less falls back to the default. Can be sourced from `MINIO_RETRY_DELAY_MS`.
 
 * `assume_role` - (Optional) Configuration block for STS AssumeRole. See [Assume Role](#assume-role) below.
 


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

Fixes #1149.

`request_timeout_seconds`, `max_retries` and `retry_delay_ms` declared both `Default` and `DefaultFunc`:

```go
"max_retries": {
    Type:        schema.TypeInt,
    Optional:    true,
    Default:     6,
    Description: "Maximum number of retries for failed operations (default: 6)",
    DefaultFunc: schema.EnvDefaultFunc(prefix+"MINIO_MAX_RETRIES", 6),
},
```

`Schema.DefaultValue()` returns `Default` when it is set and never calls `DefaultFunc`. `MINIO_REQUEST_TIMEOUT_SECONDS`, `MINIO_MAX_RETRIES` and `MINIO_RETRY_DELAY_MS` therefore had no effect. A user who set `MINIO_MAX_RETRIES=10` still got 6.

The fix drops the static default and keeps the environment lookup, which already carries the same fallback value.

`minio/framework_config.go` reproduced the defect on purpose, so both halves of the muxed provider would resolve the attributes identically (#1147). With the SDKv2 half corrected, the framework half reads the three variables as well.

### What making the variables live exposed

Three defects were unreachable while the variables were inert. They are fixed here, because this is the change that makes them reachable.

**An invalid value gave an error that named nothing.** `EnvDefaultFunc` hands the raw string to the SDK, which rejects it inside the config decoder: `error setting default for "max_retries": a number is required`, with no mention of the variable. `MINIO_RETRY_DELAY_MS=1.5` did not even name the attribute. The failure happens before `Configure`, so every command that loads the provider stops, `destroy` and `validate` included, and a pipeline with a typo cannot tear down its own infrastructure.

`envDefaultInt` now parses the value and reports `MINIO_MAX_RETRIES must be a whole number, got "abc"`. A value that is a whole number but beyond the integer range gets its own message, `MINIO_MAX_RETRIES is out of range, got "99999999999999999999"`, since "must be a whole number" would be wrong there. The command still stops, which is the right outcome for a value the operator meant to apply, but the message says what to fix. The framework half raises the same diagnostics.

**A non-positive timeout broke every call with a misleading error.** `customTransport` used `RequestTimeoutSeconds` with no guard, so `MINIO_REQUEST_TIMEOUT_SECONDS=-1` failed with `dial tcp: i/o timeout`, which reads as a network fault. It now falls back to the default, as `getRetryConfig` already did. `minio_health_status` had its own fallback of 10 seconds for the same case and now uses the same 30, so one value applies wherever the attribute is read.

This also settles a divergence between the two halves. `getOptionalField` uses `GetOk`, which treats 0 as absent, so the SDKv2 half turned 0 into 30, 6 and 1000 while the framework half passed 0 through. Both halves now reach the same effective behaviour, and the attribute descriptions say that 0 or less falls back to the default.

**`retry_delay_ms` was not the delay.** The description said "Base delay in milliseconds between retries, used with exponential backoff". `getRetryConfig` uses the value only as `MaxBackoff`, at 20 times its value in milliseconds; the wait itself is `jitter × 2^i` seconds. The default of 1000 caps the wait at 20 seconds. The description, `templates/index.md.tmpl` and `docs/index.md` now state that. The retry behaviour is unchanged: treating the value as a base delay would change the behaviour for everyone and belongs in its own change.

`max_retries` is described as attempts rather than retries, which is what the loop counts.

The three default values now come from one set of constants, instead of being repeated in the schema, in the framework half, in `getRetryConfig` and in `minio_health_status`.

### Behaviour change

A deployment that already sets one of these variables will see the value applied after this upgrade, where before it silently used 30, 6 and 1000. An invalid value now stops the run instead of being ignored. Both are in the CHANGELOG.

Precedence is unchanged for everyone else: an explicit value in the provider block wins over the environment, and the environment wins over the built-in default.

### How was this change tested?

`minio/check_config_test.go` covers the SDKv2 half at all three precedence levels for all three attributes, through `NewConfig` with a `ResourceData` built from the real provider schema. It also covers `envDefaultInt` for an unset value, a valid one, three invalid ones and an out-of-range one, asserting each error names both the variable and the value. `TestProviderRetryAttributesDeclareNoStaticDefault` fails if either attribute regains a static `Default` or loses its `DefaultFunc`.

`TestNonPositiveRetryTuningFallsBackForBothHalves` takes a configuration of zeros through `NewConfig` and through `frameworkConfig`, asserts first that the two halves really do resolve it differently, and then that both reach the same transport timeout and the same retry configuration.

In `minio/framework_config_test.go`, `TestFrameworkConfigResolvesRetryTuningLikeTheSDK` asserts the framework half reads the variables and agrees number for number with the SDKv2 half. `TestFrameworkConfigRejectsARetryValueThatIsNotAWholeNumber` asserts the diagnostic.

`TestCustomTransport_ZeroTimeout` asserted that 0 meant no timeout at the transport level, which was unreachable through the provider and is the divergence above. It is replaced by `TestCustomTransport_NonPositiveTimeoutFallsBackToTheDefault`, covering 0 and -1.

Verified against the old behaviour: with `Default: 6` restored and the framework call reverted, three of the new tests fail with the old values (`max_retries = 6, want 9 from MINIO_MAX_RETRIES`).

`TestMuxServerSchemasMatch` still passes with `MINIO_ENDPOINT` set and unset. `Default` is not part of the advertised protocol schema, and the description changes are mirrored in `minio/framework_provider.go`, which the mux requires to match.

Full unit suite, `go vet ./...` and `gofmt` pass.

### Docs

`templates/index.md.tmpl` and `docs/index.md` are updated for all three attributes and stay in sync.

### Related Issues

- Closes #1149
- Unblocks #1152