### PR TITLE
fix: send STS credential requests through the provider transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ History older than 3.39.0 lives in the
 
 ### Fixed
 
+- `minio_sts_credentials` now uses the provider TLS settings. The request went
+  out on the default HTTP client, so `minio_insecure`, `minio_cacert_file`,
+  `minio_cert_file`, `minio_key_file` and `request_timeout_seconds` were all
+  ignored. Against a server with a private certificate authority the resource
+  failed with `x509: certificate signed by unknown authority` while every other
+  resource worked. The request now also stops when Terraform is interrupted
+  ([#1151](https://github.com/aminueza/terraform-provider-minio/issues/1151)).
 - `MINIO_REQUEST_TIMEOUT_SECONDS`, `MINIO_MAX_RETRIES` and `MINIO_RETRY_DELAY_MS`
   now set `request_timeout_seconds`, `max_retries` and `retry_delay_ms`. The
   three attributes declared a static default beside the environment lookup, and

--- a/minio/ephemeral_sts_credentials.go
+++ b/minio/ephemeral_sts_credentials.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -133,7 +134,7 @@ func (r *stsCredentialsEphemeralResource) Open(ctx context.Context, req ephemera
 		"duration": duration,
 	})
 
-	value, err := requestSTSCredentials(r.config, stsRequest{
+	value, err := requestSTSCredentials(ctx, r.config, stsRequest{
 		RoleARN:         model.RoleARN.ValueString(),
 		SessionName:     sessionName,
 		DurationSeconds: duration,
@@ -158,10 +159,15 @@ func (r *stsCredentialsEphemeralResource) Open(ctx context.Context, req ephemera
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &model)...)
 }
 
-func requestSTSCredentials(config *S3MinioConfig, req stsRequest) (credentials.Value, error) {
+func requestSTSCredentials(ctx context.Context, config *S3MinioConfig, req stsRequest) (credentials.Value, error) {
 	scheme := "http"
 	if config.S3SSL {
 		scheme = "https"
+	}
+
+	transport, err := config.customTransport(ctx)
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("failed to configure transport: %w", err)
 	}
 
 	stsCreds, err := credentials.NewSTSAssumeRole(fmt.Sprintf("%s://%s", scheme, config.S3HostPort), credentials.STSAssumeRoleOptions{
@@ -178,5 +184,8 @@ func requestSTSCredentials(config *S3MinioConfig, req stsRequest) (credentials.V
 		return credentials.Value{}, err
 	}
 
-	return stsCreds.GetWithContext(&credentials.CredContext{})
+	return stsCreds.GetWithContext(&credentials.CredContext{
+		Client:  &http.Client{Transport: transport},
+		Context: ctx,
+	})
 }

--- a/minio/ephemeral_sts_credentials_test.go
+++ b/minio/ephemeral_sts_credentials_test.go
@@ -2,10 +2,13 @@ package minio
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +53,7 @@ func TestRequestSTSCredentialsReturnsServerValues(t *testing.T) {
 		S3Region:     "us-east-1",
 	}
 
-	value, err := requestSTSCredentials(config, stsRequest{
+	value, err := requestSTSCredentials(context.Background(), config, stsRequest{
 		RoleARN:         "arn:aws:iam:::role/reader",
 		SessionName:     "tfacc",
 		DurationSeconds: 7200,
@@ -102,7 +105,7 @@ func TestRequestSTSCredentialsPropagatesServerError(t *testing.T) {
 		S3Region:     "us-east-1",
 	}
 
-	if _, err := requestSTSCredentials(config, stsRequest{SessionName: "tfacc", DurationSeconds: 3600}); err == nil {
+	if _, err := requestSTSCredentials(context.Background(), config, stsRequest{SessionName: "tfacc", DurationSeconds: 3600}); err == nil {
 		t.Fatal("expected an error when the server rejects the request")
 	}
 }
@@ -186,7 +189,7 @@ func TestRequestSTSCredentialsCannotShortenBelowOneHour(t *testing.T) {
 		S3Region:     "us-east-1",
 	}
 
-	if _, err := requestSTSCredentials(config, stsRequest{SessionName: "tfacc", DurationSeconds: 900}); err != nil {
+	if _, err := requestSTSCredentials(context.Background(), config, stsRequest{SessionName: "tfacc", DurationSeconds: 900}); err != nil {
 		t.Fatalf("requesting STS credentials: %s", err)
 	}
 
@@ -308,5 +311,102 @@ func TestSTSCredentialsOpenRefusesAssumedProviderCredentials(t *testing.T) {
 				t.Fatal("expected the ephemeral resource to refuse a provider that does not use static credentials")
 			}
 		})
+	}
+}
+
+func newSTSTLSServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprintf(w, stsResponseTemplate, "TEMPACCESS", "TEMPSECRET", "TEMPTOKEN", time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+	}))
+	t.Cleanup(srv.Close)
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("writing the CA certificate: %s", err)
+	}
+
+	return srv, path
+}
+
+func TestRequestSTSCredentialsUsesTheProviderTLSSettings(t *testing.T) {
+	srv, caFile := newSTSTLSServer(t)
+	host := strings.TrimPrefix(srv.URL, "https://")
+
+	for _, tc := range []struct {
+		name    string
+		config  *S3MinioConfig
+		wantErr string
+	}{
+		{
+			name:   "minio_insecure skips verification",
+			config: &S3MinioConfig{S3SSL: true, S3SSLSkipVerify: true},
+		},
+		{
+			name:   "minio_cacert_file trusts the private authority",
+			config: &S3MinioConfig{S3SSL: true, S3SSLCACertFile: caFile},
+		},
+		{
+			name:    "neither option leaves the certificate untrusted",
+			config:  &S3MinioConfig{S3SSL: true},
+			wantErr: "certificate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.config.S3HostPort = host
+			tc.config.S3UserAccess = "accesskey"
+			tc.config.S3UserSecret = "secretkey"
+			tc.config.S3Region = "us-east-1"
+
+			value, err := requestSTSCredentials(context.Background(), tc.config, stsRequest{SessionName: "tfacc", DurationSeconds: 3600})
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("the request succeeded against an untrusted certificate, so the TLS settings are not reaching the STS call")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %q, want it to mention %q", err, tc.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("requesting STS credentials: %s", err)
+			}
+			if value.AccessKeyID != "TEMPACCESS" {
+				t.Errorf("AccessKeyID = %q, want %q", value.AccessKeyID, "TEMPACCESS")
+			}
+		})
+	}
+}
+
+func TestRequestSTSCredentialsHonoursContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(time.Second)
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprintf(w, stsResponseTemplate, "A", "B", "C", time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+	}))
+	defer srv.Close()
+
+	config := &S3MinioConfig{
+		S3HostPort:   strings.TrimPrefix(srv.URL, "http://"),
+		S3UserAccess: "accesskey",
+		S3UserSecret: "secretkey",
+		S3Region:     "us-east-1",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	if _, err := requestSTSCredentials(ctx, config, stsRequest{SessionName: "tfacc", DurationSeconds: 3600}); err == nil {
+		t.Fatal("expected the expired context to stop the STS request")
+	}
+
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Errorf("the request took %s: the caller context must reach the STS call, not only the transport timeout", elapsed)
 	}
 }

--- a/minio/ephemeral_sts_credentials_test.go
+++ b/minio/ephemeral_sts_credentials_test.go
@@ -410,3 +410,22 @@ func TestRequestSTSCredentialsHonoursContextCancellation(t *testing.T) {
 		t.Errorf("the request took %s: the caller context must reach the STS call, not only the transport timeout", elapsed)
 	}
 }
+
+func TestRequestSTSCredentialsReportsAnUnusableTransport(t *testing.T) {
+	config := &S3MinioConfig{
+		S3HostPort:      "localhost:9000",
+		S3UserAccess:    "accesskey",
+		S3UserSecret:    "secretkey",
+		S3Region:        "us-east-1",
+		S3SSL:           true,
+		S3SSLCACertFile: filepath.Join(t.TempDir(), "missing.pem"),
+	}
+
+	_, err := requestSTSCredentials(context.Background(), config, stsRequest{SessionName: "tfacc", DurationSeconds: 3600})
+	if err == nil {
+		t.Fatal("expected an error when the TLS settings cannot be turned into a transport")
+	}
+	if !strings.Contains(err.Error(), "failed to configure transport") {
+		t.Errorf("error = %q, want it to say the transport could not be built", err)
+	}
+}


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

### What does this PR do?

Fixes #1151.

`requestSTSCredentials` ended with an empty credential context:

```go
return stsCreds.GetWithContext(&credentials.CredContext{})
```

`minio-go` picks the HTTP client in this order: the one set on the credential provider, then the one on the `CredContext`, then `http.DefaultClient`. The context was empty, so every request `minio_sts_credentials` made went out on the default client. `minio_insecure`, `minio_cacert_file`, `minio_cert_file`, `minio_key_file` and `request_timeout_seconds` were all ignored.

The effect on a server with a private certificate authority: every resource and data source works, and the ephemeral resource alone fails with `x509: certificate signed by unknown authority`. `minio_insecure = true` does not help. A server that requires mTLS rejects the request, because the client certificate is never presented.

The fix builds the transport with `customTransport`, as `NewClient` does, and passes it in the credential context:

```go
return stsCreds.GetWithContext(&credentials.CredContext{
    Client:  &http.Client{Transport: transport},
    Context: ctx,
})
```

`Context` is set as well, so an interrupted Terraform run stops the STS request instead of waiting out the transport timeout. `requestSTSCredentials` takes a `context.Context` for this; `Open` already had one.

### What this PR does not change, and why

#1151 first claimed that `assume_role` and `assume_role_with_web_identity` in `minio/new_client.go` had the same defect. Reading `minio-go` and `madmin-go` shows they do not.

`STSAssumeRoleOptions` has no client field; `Client` belongs to the `STSAssumeRole` provider struct that `NewSTSAssumeRole` builds internally. And those two paths do not need one: they hand the credentials object to `minio.New` and `madmin.NewWithOptions`, both configured with the provider transport, and both build a `CredContext` from their own HTTP client when credentials are retrieved (`Client.CredContext` in minio-go, `AdminClient.CredContext` in madmin-go). Setting a client on the provider there would override that per-client choice for no gain.

I wrote the first version of the change that way and reverted it. The issue is corrected to match.

So the defect is only in the ephemeral resource, and only since #1147, because it is the one place that calls `GetWithContext` directly instead of through a client.

### How was this change tested?

`TestRequestSTSCredentialsUsesTheProviderTLSSettings` runs against an `httptest.NewTLSServer` whose certificate is written to a temporary file, in three cases:

| Configuration | Expected |
| --- | --- |
| `minio_insecure = true` | credentials returned |
| `minio_cacert_file` pointing at the server certificate | credentials returned |
| neither | fails with a certificate error |

The third case is what stops the first two from passing for the wrong reason.

`TestRequestSTSCredentialsHonoursContextCancellation` points the resource at a handler that sleeps for a second and gives it a context that expires after 100 ms, then asserts the call returns before the handler finishes.

Verified against the pre-fix code: with the empty `CredContext` restored, both TLS cases fail with `tls: failed to verify certificate: x509: certificate signed by unknown authority`, and the cancellation test fails as well.

Full unit suite, `go vet ./...` and `gofmt` pass.

### Related Issues

- Closes #1151