### PR TITLE
test: run Terraform against the muxed provider server

### DIFF
--- a/minio/mux_acc_test.go
+++ b/minio/mux_acc_test.go
@@ -1,0 +1,153 @@
+package minio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccMuxProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"minio": func() (tfprotov6.ProviderServer, error) {
+			return MuxProviderServer(context.Background())
+		},
+	}
+}
+
+func testAccRequireTerraform(t *testing.T, minMajor, minMinor int) {
+	t.Helper()
+
+	binary := os.Getenv("TF_ACC_TERRAFORM_PATH")
+	if binary == "" {
+		found, err := exec.LookPath("terraform")
+		if err != nil {
+			t.Skipf("terraform is not on PATH, so the required version cannot be checked: %s", err)
+		}
+		binary = found
+	}
+
+	out, err := exec.Command(binary, "version", "-json").Output()
+	if err != nil {
+		t.Skipf("reading the version of %s: %s", binary, err)
+	}
+
+	var parsed struct {
+		Version string `json:"terraform_version"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Skipf("parsing the version reported by %s: %s", binary, err)
+	}
+
+	parts := strings.SplitN(parsed.Version, ".", 3)
+	if len(parts) < 2 {
+		t.Skipf("%s reports an unreadable version %q", binary, parsed.Version)
+	}
+	major, majorErr := strconv.Atoi(parts[0])
+	minor, minorErr := strconv.Atoi(parts[1])
+	if majorErr != nil || minorErr != nil {
+		t.Skipf("%s reports an unreadable version %q", binary, parsed.Version)
+	}
+
+	if major < minMajor || (major == minMajor && minor < minMinor) {
+		t.Skipf("Terraform %s is below %d.%d, which ephemeral resources need", parsed.Version, minMajor, minMinor)
+	}
+}
+
+func TestAccMuxServesTheSDKHalfOverProtocolSix(t *testing.T) {
+	bucketName := "tfacc-mux-sdk-" + acctest.RandString(8)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxProviderFactories(),
+		CheckDestroy:             testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "minio_s3_bucket" "sdk" {
+  bucket = "` + bucketName + `"
+}
+
+data "minio_s3_bucket" "sdk" {
+  bucket = minio_s3_bucket.sdk.bucket
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("minio_s3_bucket.sdk", "bucket", bucketName),
+					resource.TestCheckResourceAttr("data.minio_s3_bucket.sdk", "bucket", bucketName),
+					resource.TestCheckResourceAttrSet("data.minio_s3_bucket.sdk", "region"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMuxServesEphemeralCredentialsToAnotherProvider(t *testing.T) {
+	bucketName := "tfacc-mux-ephemeral-" + acctest.RandString(8)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccRequireTerraform(t, 1, 10)
+		},
+		ProtoV6ProviderFactories: testAccMuxProviderFactories(),
+		CheckDestroy:             testAccCheckMinioS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+ephemeral "minio_sts_credentials" "scoped" {
+  session_name     = "tfacc-mux"
+  duration_seconds = 3600
+}
+
+provider "minio" {
+  alias               = "scoped"
+  minio_server        = %q
+  minio_ssl           = %s
+  minio_user          = ephemeral.minio_sts_credentials.scoped.access_key
+  minio_password      = ephemeral.minio_sts_credentials.scoped.secret_key
+  minio_session_token = ephemeral.minio_sts_credentials.scoped.session_token
+}
+
+resource "minio_s3_bucket" "scoped" {
+  provider = minio.scoped
+  bucket   = %q
+}`, testAccEndpoint(""), testAccEnableHTTPS(""), bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("minio_s3_bucket.scoped", "bucket", bucketName),
+					testAccCheckStateHoldsNoEphemeralCredentials,
+				),
+			},
+		},
+	})
+}
+
+func testAccEnableHTTPS(prefix string) string {
+	enabled, _ := strconv.ParseBool(os.Getenv(prefix + "MINIO_ENABLE_HTTPS"))
+	return strconv.FormatBool(enabled)
+}
+
+func testAccCheckStateHoldsNoEphemeralCredentials(s *terraform.State) error {
+	for name, rs := range s.RootModule().Resources {
+		if rs.Type == "minio_sts_credentials" {
+			return fmt.Errorf("%s is in the state: an ephemeral resource must not be persisted", name)
+		}
+		for attribute, value := range rs.Primary.Attributes {
+			if value == "" {
+				continue
+			}
+			if strings.Contains(attribute, "session_token") || strings.Contains(attribute, "secret_key") {
+				return fmt.Errorf("%s holds a credential in %s", name, attribute)
+			}
+		}
+	}
+	return nil
+}

--- a/minio/mux_acc_test.go
+++ b/minio/mux_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -36,7 +37,10 @@ func testAccRequireTerraform(t *testing.T, minMajor, minMinor int) {
 		binary = found
 	}
 
-	out, err := exec.Command(binary, "version", "-json").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, binary, "version", "-json").Output()
 	if err != nil {
 		t.Skipf("reading the version of %s: %s", binary, err)
 	}


### PR DESCRIPTION
## Description

### Type of Change
- [x] Refactoring (no functional changes, code improvement)

No provider code changes. Test only.

### What does this PR do?

Fixes #1150.

Every acceptance test builds the SDKv2 provider directly through `ProviderFactories`, so nothing ran Terraform against the server a user actually gets. `minio/mux_test.go` compares the two provider schemas and lists what each half serves, but it never starts Terraform, so a broken protocol upgrade or a misrouted request would reach a release.

This adds `minio/mux_acc_test.go` with two tests, both through `ProtoV6ProviderFactories` with `MuxProviderServer`:

**`TestAccMuxServesTheSDKHalfOverProtocolSix`** creates a `minio_s3_bucket` and reads it back through the `minio_s3_bucket` data source. It covers the SDKv2 half after `tf5to6server.UpgradeServer`, which no test reached before.

**`TestAccMuxServesEphemeralCredentialsToAnotherProvider`** is the whole feature in one plan:

```hcl
ephemeral "minio_sts_credentials" "scoped" {
  session_name     = "tfacc-mux"
  duration_seconds = 3600
}

provider "minio" {
  alias               = "scoped"
  minio_server        = "<test endpoint>"
  minio_user          = ephemeral.minio_sts_credentials.scoped.access_key
  minio_password      = ephemeral.minio_sts_credentials.scoped.secret_key
  minio_session_token = ephemeral.minio_sts_credentials.scoped.session_token
}

resource "minio_s3_bucket" "scoped" {
  provider = minio.scoped
  bucket   = "<generated>"
}
```

One plan routes the ephemeral resource to the framework half and the bucket to the SDKv2 half, and the bucket only gets created if the temporary credentials work. `testAccCheckStateHoldsNoEphemeralCredentials` then walks the state and fails if a `minio_sts_credentials` resource was persisted, or if any attribute named for a session token or secret key carries a value.

### Version guard

`helper/resource.TestCase` has no `TerraformVersionChecks`, and `terraform-plugin-testing` is not a dependency of this repository. Rather than pull in a second test harness for one check, `testAccRequireTerraform` reads `terraform version -json` from `TF_ACC_TERRAFORM_PATH` or from `PATH` and skips below 1.10, where ephemeral resources start. It skips rather than fails on anything it cannot determine, so it never turns a missing binary into a red suite.

The compose suite pins Terraform 1.11.4, so both tests run in CI.

### Results

Both tests ran and passed in the `Test` job against the compose MinIO instance:

```
--- PASS: TestAccMuxServesEphemeralCredentialsToAnotherProvider (1.64s)
--- PASS: TestAccMuxServesTheSDKHalfOverProtocolSix (1.73s)
```

That settles a question I could not answer while writing them, since this environment has no Docker daemon and no Terraform binary: the test instance authenticates as the MinIO **root** user, and `minio_sts_credentials` signs its AssumeRole request with the provider credentials. MinIO rejects AssumeRole from temporary credentials and from service accounts, which the resource already refuses up front, but whether it accepts a request signed by root was untested anywhere in this repository. It does.

That mattered, because the fallback would have been a dedicated IAM user, and one cannot be created in the same configuration: Terraform requires provider configuration to be known at plan time, and a new user's secret is not.

### No CHANGELOG entry

Nothing a user can observe changes.

### Related Issues

- Closes #1150
- Unblocks #1152