### PR TITLE
test: cover the framework half of the provider

### DIFF
--- a/minio/ephemeral_sts_credentials_test.go
+++ b/minio/ephemeral_sts_credentials_test.go
@@ -429,3 +429,143 @@ func TestRequestSTSCredentialsReportsAnUnusableTransport(t *testing.T) {
 		t.Errorf("error = %q, want it to say the transport could not be built", err)
 	}
 }
+
+func TestSTSCredentialsConfigureIgnoresAbsentProviderData(t *testing.T) {
+	res := NewSTSCredentialsEphemeralResource().(*stsCredentialsEphemeralResource)
+
+	var resp ephemeral.ConfigureResponse
+	res.Configure(context.Background(), ephemeral.ConfigureRequest{ProviderData: nil}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Terraform calls Configure with no provider data before the provider is configured, which must not be an error: %v", resp.Diagnostics)
+	}
+	if res.config != nil {
+		t.Error("the resource invented a configuration out of nothing")
+	}
+}
+
+func TestSTSCredentialsOpenWithoutConfigureReportsTheProviderBug(t *testing.T) {
+	res := NewSTSCredentialsEphemeralResource().(*stsCredentialsEphemeralResource)
+
+	var schemaResp ephemeral.SchemaResponse
+	res.Schema(context.Background(), ephemeral.SchemaRequest{}, &schemaResp)
+	raw := mustObjectValue(t, schemaResp.Schema, nullSTSModel())
+
+	openResp := ephemeral.OpenResponse{
+		Result: tfsdk.EphemeralResultData{Schema: schemaResp.Schema, Raw: raw},
+	}
+	res.Open(context.Background(), ephemeral.OpenRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: raw},
+	}, &openResp)
+
+	if !openResp.Diagnostics.HasError() {
+		t.Fatal("opening before Configure must be reported, not silently return empty credentials")
+	}
+	if summary := openResp.Diagnostics.Errors()[0].Summary(); summary != "Provider not configured" {
+		t.Errorf("summary = %q, want %q", summary, "Provider not configured")
+	}
+}
+
+func TestSTSCredentialsOpenSendsTheConfiguredSessionAndDuration(t *testing.T) {
+	var sent url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		sent = r.PostForm
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprintf(w, stsResponseTemplate, "A", "B", "C", time.Now().Add(2*time.Hour).UTC().Format(time.RFC3339))
+	}))
+	defer srv.Close()
+
+	model := nullSTSModel()
+	model.SessionName = types.StringValue("pipeline")
+	model.DurationSeconds = types.Int64Value(7200)
+
+	resp := openSTSEphemeral(t, &S3MinioConfig{
+		S3HostPort:   strings.TrimPrefix(srv.URL, "http://"),
+		S3UserAccess: "accesskey",
+		S3UserSecret: "secretkey",
+		S3Region:     "us-east-1",
+	}, model)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("opening the ephemeral resource: %v", resp.Diagnostics)
+	}
+	if got := sent.Get("RoleSessionName"); got != "pipeline" {
+		t.Errorf("RoleSessionName = %q, want the configured session name", got)
+	}
+	if got := sent.Get("DurationSeconds"); got != "7200" {
+		t.Errorf("DurationSeconds = %q, want the configured duration", got)
+	}
+}
+
+func TestSTSCredentialsOpenLeavesExpirationNullWhenTheServerOmitsIt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>NOEXPIRY</AccessKeyId>
+      <SecretAccessKey>SECRET</SecretAccessKey>
+      <SessionToken>TOKEN</SessionToken>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`)
+	}))
+	defer srv.Close()
+
+	resp := openSTSEphemeral(t, &S3MinioConfig{
+		S3HostPort:   strings.TrimPrefix(srv.URL, "http://"),
+		S3UserAccess: "accesskey",
+		S3UserSecret: "secretkey",
+		S3Region:     "us-east-1",
+	}, nullSTSModel())
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("opening the ephemeral resource: %v", resp.Diagnostics)
+	}
+
+	var result stsCredentialsModel
+	if diags := resp.Result.Get(context.Background(), &result); diags.HasError() {
+		t.Fatalf("reading the result: %v", diags)
+	}
+	if !result.Expiration.IsNull() {
+		t.Errorf("expiration = %q, want null when the server reports no expiry", result.Expiration.ValueString())
+	}
+}
+
+func TestSTSCredentialsOpenReportsAServerRejection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `<ErrorResponse><Error><Code>AccessDenied</Code><Message>not allowed</Message></Error></ErrorResponse>`)
+	}))
+	defer srv.Close()
+
+	resp := openSTSEphemeral(t, &S3MinioConfig{
+		S3HostPort:   strings.TrimPrefix(srv.URL, "http://"),
+		S3UserAccess: "accesskey",
+		S3UserSecret: "secretkey",
+		S3Region:     "us-east-1",
+	}, nullSTSModel())
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("a rejected AssumeRole must be reported")
+	}
+	if summary := resp.Diagnostics.Errors()[0].Summary(); summary != "Failed to request STS credentials" {
+		t.Errorf("summary = %q, want %q", summary, "Failed to request STS credentials")
+	}
+}
+
+func TestRequestSTSCredentialsRefusesAProviderWithoutCredentials(t *testing.T) {
+	_, err := requestSTSCredentials(context.Background(), &S3MinioConfig{
+		S3HostPort: "localhost:9000",
+		S3Region:   "us-east-1",
+	}, stsRequest{SessionName: "tfacc", DurationSeconds: 3600})
+
+	if err == nil {
+		t.Fatal("expected an error when the provider has no static credentials to sign with")
+	}
+	if !strings.Contains(err.Error(), "access/secretkey") {
+		t.Errorf("error = %q, want it to name the missing credentials", err)
+	}
+}

--- a/minio/framework_config_test.go
+++ b/minio/framework_config_test.go
@@ -386,3 +386,158 @@ func webIdentityObjectType() types.ObjectType {
 		"duration_seconds":        types.Int64Type,
 	}}
 }
+
+func TestFrameworkConfigReadsTheWebIdentityBlock(t *testing.T) {
+	ctx := context.Background()
+
+	objectType := webIdentityObjectType()
+
+	block, diags := types.ObjectValue(objectType.AttrTypes, map[string]attr.Value{
+		"web_identity_token":      types.StringValue("a.jwt.token"),
+		"web_identity_token_file": types.StringValue("/run/secrets/token"),
+		"duration_seconds":        types.Int64Value(5400),
+	})
+	if diags.HasError() {
+		t.Fatalf("building the assume_role_with_web_identity object: %v", diags)
+	}
+
+	list, diags := types.ListValue(objectType, []attr.Value{block})
+	if diags.HasError() {
+		t.Fatalf("building the assume_role_with_web_identity list: %v", diags)
+	}
+
+	model := nullFrameworkModel()
+	model.AssumeRoleWebIdentity = list
+
+	var configDiags diag.Diagnostics
+	config := frameworkConfig(ctx, model, &configDiags)
+	if configDiags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", configDiags)
+	}
+
+	if config.WebIdentityToken != "a.jwt.token" {
+		t.Errorf("WebIdentityToken = %q", config.WebIdentityToken)
+	}
+	if config.WebIdentityTokenFile != "/run/secrets/token" {
+		t.Errorf("WebIdentityTokenFile = %q", config.WebIdentityTokenFile)
+	}
+	if config.WebIdentityDuration != 5400 {
+		t.Errorf("WebIdentityDuration = %d, want 5400", config.WebIdentityDuration)
+	}
+}
+
+func TestFrameworkConfigWebIdentityDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	t.Setenv("MINIO_WEB_IDENTITY_TOKEN", "")
+	t.Setenv("MINIO_WEB_IDENTITY_TOKEN_FILE", "")
+
+	objectType := webIdentityObjectType()
+
+	block, diags := types.ObjectValue(objectType.AttrTypes, map[string]attr.Value{
+		"web_identity_token":      types.StringNull(),
+		"web_identity_token_file": types.StringNull(),
+		"duration_seconds":        types.Int64Null(),
+	})
+	if diags.HasError() {
+		t.Fatalf("building the assume_role_with_web_identity object: %v", diags)
+	}
+
+	list, diags := types.ListValue(objectType, []attr.Value{block})
+	if diags.HasError() {
+		t.Fatalf("building the assume_role_with_web_identity list: %v", diags)
+	}
+
+	model := nullFrameworkModel()
+	model.AssumeRoleWebIdentity = list
+
+	var configDiags diag.Diagnostics
+	config := frameworkConfig(ctx, model, &configDiags)
+	if configDiags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", configDiags)
+	}
+
+	if config.WebIdentityDuration != 3600 {
+		t.Errorf("WebIdentityDuration = %d, want the default 3600", config.WebIdentityDuration)
+	}
+}
+
+func TestFrameworkConfigPrefersTheConfiguredBooleanOverTheEnvironment(t *testing.T) {
+	t.Setenv("MINIO_ENABLE_HTTPS", "true")
+	t.Setenv("MINIO_INSECURE", "true")
+
+	model := nullFrameworkModel()
+	model.MinioSSL = types.BoolValue(false)
+	model.MinioInsecure = types.BoolValue(false)
+
+	var diags diag.Diagnostics
+	config := frameworkConfig(context.Background(), model, &diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if config.S3SSL {
+		t.Error("S3SSL = true, want the configured false to win over MINIO_ENABLE_HTTPS")
+	}
+	if config.S3SSLSkipVerify {
+		t.Error("S3SSLSkipVerify = true, want the configured false to win over MINIO_INSECURE")
+	}
+}
+
+func TestFrameworkConfigSaysWhenARetryValueIsOutOfRange(t *testing.T) {
+	clearRetryTuningEnvironment(t)
+	t.Setenv("MINIO_RETRY_DELAY_MS", "99999999999999999999")
+
+	var diags diag.Diagnostics
+	frameworkConfig(context.Background(), nullFrameworkModel(), &diags)
+
+	if !diags.HasError() {
+		t.Fatal("a value beyond the integer range must be reported")
+	}
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Detail(), "out of range") {
+			return
+		}
+	}
+	t.Errorf("no diagnostic says the value is out of range: %v", diags)
+}
+
+func TestFrameworkProviderConfigureStopsOnAnInvalidEnvironment(t *testing.T) {
+	t.Setenv("MINIO_ENDPOINT", "")
+	clearRetryTuningEnvironment(t)
+	t.Setenv("MINIO_MAX_RETRIES", "abc")
+
+	p := NewFrameworkProvider()
+
+	var schemaResp provider.SchemaResponse
+	p.Schema(context.Background(), provider.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building the provider schema: %v", schemaResp.Diagnostics)
+	}
+
+	model := nullFrameworkModel()
+	model.MinioServer = types.StringValue("localhost:9000")
+	model.AssumeRole = types.ListNull(assumeRoleObjectType())
+	model.AssumeRoleWebIdentity = types.ListNull(webIdentityObjectType())
+
+	object, diags := types.ObjectValueFrom(context.Background(), schemaResp.Schema.Type().(types.ObjectType).AttrTypes, model)
+	if diags.HasError() {
+		t.Fatalf("converting the model: %v", diags)
+	}
+	raw, err := object.ToTerraformValue(context.Background())
+	if err != nil {
+		t.Fatalf("converting the model to a Terraform value: %s", err)
+	}
+
+	var resp provider.ConfigureResponse
+	p.Configure(context.Background(), provider.ConfigureRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: raw},
+	}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("an unusable environment variable must stop the provider from configuring")
+	}
+	if resp.EphemeralResourceData != nil || resp.ResourceData != nil || resp.DataSourceData != nil {
+		t.Error("the provider handed out a configuration it could not build correctly")
+	}
+}


### PR DESCRIPTION
## Description

### Type of Change
- [x] Refactoring (no functional changes, code improvement)

No provider code changes. Test only.

### What does this PR do?

Fixes #1152.

| File | Before | After |
| --- | --- | --- |
| `minio/ephemeral_sts_credentials.go` | 80.4% | **98.0%** |
| `minio/framework_config.go` | 78.0% | **96.6%** |
| `minio/framework_provider.go` | 88.2% | **94.1%** |
| `minio/mux.go` | 80.0% | 80.0% |

Measured with `go test ./minio/ -coverprofile`, counting statements per file.

### What the new tests assert

**`ephemeral_sts_credentials.go`**

- `Configure` with no provider data is not an error. Terraform calls it that way before the provider is configured, so treating it as a failure would break a normal sequence.
- `Open` before `Configure` reports `Provider not configured` instead of returning empty credentials.
- A configured `session_name` and `duration_seconds` reach the AssumeRole request, checked against the form the stub server receives.
- `expiration` is null when the server returns no expiry, rather than a zero timestamp.
- A rejected AssumeRole surfaces as `Failed to request STS credentials`.
- A provider with no static credentials fails with an error naming them, instead of sending an unsigned request.

**`framework_config.go`**

- The `assume_role_with_web_identity` block is read, and its `duration_seconds` defaults to 3600. Nothing exercised that block before, so the framework half could have stopped reading web identity configuration and every test would still have passed.
- A configured boolean wins over the environment, which no test covered for `frameworkBool`.
- A retry value beyond the integer range produces a diagnostic that says so.

**`framework_provider.go`**

- `Configure` stops on an environment it cannot read, and hands out no configuration to resources, data sources or ephemeral resources. A half-built configuration reaching consumers would be worse than the error.

### Why mux.go stays at 80%

Its two uncovered branches are the error checks after `tf5to6server.UpgradeServer` and `tf6muxserver.NewMuxServer`. In `terraform-plugin-mux` v0.23.1 both functions end with `return ..., nil` and have no failure path at all, so the branches cannot be taken whatever the input.

The issue said to remove a genuinely unreachable branch rather than test it. That does not apply here: both functions return an error in their signature, a later version may start using it, and dropping the check would mean discarding a returned error. So they stay, and `mux.go` stays at 80% rather than reaching 90% through a fake library or a test that asserts nothing.

The remaining uncovered statements in the other three files are the same shape: `req.Config.Get` and `ElementsAs` decode failures, which the framework only produces when a configuration does not match a schema the provider itself declared.

### How was this change tested?

Full unit suite, `go vet ./...` and `gofmt -s` pass. The coverage numbers above come from the same run.

### No CHANGELOG entry

Nothing a user can observe changes.

### Related Issues

- Closes #1152