### PR TITLE
fix: pull the MinIO test images from quay.io

### DIFF
--- a/.github/workflows/test-latest-minio.yml
+++ b/.github/workflows/test-latest-minio.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Override MinIO image in docker-compose.yml
         run: |
           TAG="${{ steps.minio.outputs.tag }}"
-          sed -i "s|minio/minio:RELEASE\.[^\"']*|minio/minio:${TAG}|" docker-compose.yml
+          sed -i "s|minio/minio:RELEASE\.[^}\"']*|minio/minio:${TAG}|" docker-compose.yml
           echo "Updated MinIO image to minio/minio:${TAG}"
           grep "minio/minio:" docker-compose.yml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,12 +170,16 @@ TEST_PATTERN=TestAccMinioIAMUser docker compose run --rm test
 TF_ACC=1 go test -v ./minio -run TestAccMinioS3Bucket_basic
 
 # Take the MinIO images from another registry, for every MinIO service at once
-MINIO_IMAGE=mirror.example.com/minio/minio:RELEASE.2025-09-07T16-13-09Z docker compose run --rm test
+MINIO_IMAGE=minio/minio:RELEASE.2025-09-07T16-13-09Z docker compose run --rm test
 ```
 
-`MINIO_IMAGE` exists because Docker Hub refuses anonymous pulls of
-`minio/minio` from many networks. Without it, the only way past a blocked pull
-was to edit `docker-compose.yml` and remember not to commit the edit.
+The default is `quay.io/minio/minio`. On 2026-09-11 Docker Hub stopped serving
+`minio/minio` to anonymous clients and every CI run went red at the pull step,
+with `pull access denied for minio/minio`, before a single test ran. A probe
+from a runner found the pinned tag and `latest` on `quay.io` and on no other
+public registry: `ghcr.io/minio/minio` and `public.ecr.aws/minio/minio` do not
+carry it. `MINIO_IMAGE` overrides the image for all six MinIO services, so a
+future move needs one variable rather than an edit to `docker-compose.yml`.
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,14 @@ TEST_PATTERN=TestAccMinioIAMUser docker compose run --rm test
 
 # Run with verbose output
 TF_ACC=1 go test -v ./minio -run TestAccMinioS3Bucket_basic
+
+# Take the MinIO images from another registry, for every MinIO service at once
+MINIO_IMAGE=mirror.example.com/minio/minio:RELEASE.2025-09-07T16-13-09Z docker compose run --rm test
 ```
+
+`MINIO_IMAGE` exists because Docker Hub refuses anonymous pulls of
+`minio/minio` from many networks. Without it, the only way past a blocked pull
+was to edit `docker-compose.yml` and remember not to commit the edit.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,15 @@ docker compose run --rm test
 
 # Run a subset by name:
 TEST_PATTERN=TestAccMinioS3Bucket_basic docker compose run --rm test
+
+# Pull the MinIO images from somewhere else, for a mirror or another release.
+# This replaces the image for every MinIO service at once:
+MINIO_IMAGE=mirror.example.com/minio/minio:RELEASE.2025-09-07T16-13-09Z task test
 ```
+
+`docker compose run` needs to pull `minio/minio` from Docker Hub, which
+refuses anonymous pulls from many networks. Run `docker login` first, or point
+`MINIO_IMAGE` at a registry you can reach.
 
 Full setup, project layout, and the MinIO consoles used during testing are covered in [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ TEST_PATTERN=TestAccMinioS3Bucket_basic docker compose run --rm test
 
 # Pull the MinIO images from somewhere else, for a mirror or another release.
 # This replaces the image for every MinIO service at once:
-MINIO_IMAGE=mirror.example.com/minio/minio:RELEASE.2025-09-07T16-13-09Z task test
+MINIO_IMAGE=minio/minio:RELEASE.2025-09-07T16-13-09Z task test
 ```
 
-`docker compose run` needs to pull `minio/minio` from Docker Hub, which
-refuses anonymous pulls from many networks. Run `docker login` first, or point
-`MINIO_IMAGE` at a registry you can reach.
+The images come from `quay.io/minio/minio`. Docker Hub stopped serving
+`minio/minio` to anonymous clients, including GitHub Actions runners, so
+`MINIO_IMAGE` is there to point the suite at any registry you can reach.
 
 Full setup, project layout, and the MinIO consoles used during testing are covered in [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Define MinIO image version to use across all services
 # Using version that supports adding object lock after bucket creation
-x-minio-image: &minio_image minio/minio:RELEASE.2025-09-07T16-13-09Z
+x-minio-image: &minio_image ${MINIO_IMAGE:-minio/minio:RELEASE.2025-09-07T16-13-09Z}
 
 services:
   openldap:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Define MinIO image version to use across all services
 # Using version that supports adding object lock after bucket creation
-x-minio-image: &minio_image ${MINIO_IMAGE:-minio/minio:RELEASE.2025-09-07T16-13-09Z}
+x-minio-image: &minio_image ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}
 
 services:
   openldap:


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

No provider code changes. This unblocks CI.

### What does this PR do?

**`main` is red and nothing in this repository caused it.** Docker Hub stopped serving `minio/minio` to anonymous clients today, GitHub Actions runners included. Every run since 19:36 UTC dies at the pull step, before a single test executes:

```
ldapminio Error pull access denied for minio/minio, repository does not exist
or may require 'docker login'
```

| Run | Branch | Result |
| --- | --- | --- |
| 19:21 UTC | main | success |
| 19:25 UTC | feat/1150-mux-acceptance-test | success |
| **19:36 UTC** | **main** | **failure** |
| 19:40 UTC | test/1152-framework-coverage | failure |
| 19:53 UTC | this branch | failure |

The 19:36 run is on `main` with no new commit. The pinned image has not changed since 8 September.

### Which registry still serves it

A throwaway workflow on a runner checked the pinned tag and `latest` against four registries:

```
minio/minio:RELEASE.2025-09-07T16-13-09Z                 FAILED
quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z         OK
ghcr.io/minio/minio:RELEASE.2025-09-07T16-13-09Z         FAILED
public.ecr.aws/minio/minio:RELEASE.2025-09-07T16-13-09Z  FAILED

minio/minio:latest                                       FAILED
quay.io/minio/minio:latest                               OK
ghcr.io/minio/minio:latest                               FAILED
```

Docker Hub fails on `latest` as well, so this is the repository being closed off rather than one tag being pulled. `quay.io` is the only public registry that still carries the image.

### The change

```yaml
x-minio-image: &minio_image ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z}
```

The anchor already covered all six MinIO services, so this is one line. The variable is new: it overrides the image without editing a tracked file, so anyone with a Docker Hub login can keep using the old image, and the next move takes one variable instead of an edit nobody must commit by accident.

```sh
MINIO_IMAGE=minio/minio:RELEASE.2025-09-07T16-13-09Z task test
```

### A bug this uncovered in test-latest-minio.yml

That workflow rewrites the pinned tag with sed:

```sh
sed -i "s|minio/minio:RELEASE\.[^\"']*|minio/minio:${TAG}|" docker-compose.yml
```

`[^\"']*` matches everything up to a quote, so with a `${...}` around the image it swallowed the closing brace and left a file that no longer parses:

```yaml
x-minio-image: &minio_image ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-01-01T00-00-00Z
```

The character class now excludes `}`. The expression starts matching at `minio/minio:`, so the `quay.io/` prefix survives and only the tag is replaced. Verified both ways.

### How was this change tested?

`docker compose config` needs no daemon, so this is reproducible anywhere:

```
$ docker compose config --images | sort -u
dexidp/dex:v2.45.1
osixia/openldap:1.5.0
quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
redis:8-alpine

$ MINIO_IMAGE=minio/minio:RELEASE.2025-09-07T16-13-09Z docker compose config --images | sort -u
dexidp/dex:v2.45.1
minio/minio:RELEASE.2025-09-07T16-13-09Z
osixia/openldap:1.5.0
redis:8-alpine
```

All six MinIO services follow the variable and the other three images are untouched. `docker compose config -q` passes. The `Test` job on this PR is the real check: it either pulls from quay.io and runs the suite, or it does not.

### Left to clean up

The probe branch `probe/registry-check` is still on the remote. My push to delete it was refused with a 403, so it needs deleting by hand. It holds one throwaway workflow that only runs on that branch name.

### No CHANGELOG entry

Nothing a user of the provider can observe changes.
