### PR TITLE
ci: promote the Unreleased changelog section when tagging a release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -314,9 +314,11 @@ dependency bumps with no behavior change, test-only changes, refactors, and
 documentation fixes. When in doubt, add the entry — a reviewer can always drop
 it.
 
-The release workflow refuses to tag a version that has no matching
-`## [x.y.z]` section in `CHANGELOG.md`, so entries must be moved from
-`[Unreleased]` into a dated section as part of preparing a release.
+The release workflow moves `[Unreleased]` into a dated `## [x.y.z]` section
+itself, updates the link references and commits that before it tags, so
+preparing a release takes no changelog edit. It stops when `[Unreleased]` is
+empty, because a release with no notes is almost always a mistake. A section
+written by hand ahead of time is left alone.
 
 ### Commit Message Format
 

--- a/.github/scripts/promote_changelog.py
+++ b/.github/scripts/promote_changelog.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Promote the Unreleased section of CHANGELOG.md to a dated release section."""
+
+import datetime
+import os
+import pathlib
+import re
+import sys
+
+CHANGELOG = pathlib.Path("CHANGELOG.md")
+
+
+def emit(name, value):
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def fail(message):
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main(version):
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        fail(f"version must be X.Y.Z, got {version!r}")
+
+    text = CHANGELOG.read_text(encoding="utf-8")
+
+    if re.search(rf"^## \[{re.escape(version)}\]", text, re.MULTILINE):
+        print(f"CHANGELOG.md already has a section for {version}. Nothing to promote.")
+        emit("changed", "false")
+        return
+
+    unreleased = re.search(r"^## \[Unreleased\]\n(.*?)(?=^## \[|\Z)", text, re.MULTILINE | re.DOTALL)
+    if not unreleased:
+        fail("CHANGELOG.md has no '## [Unreleased]' section to promote.")
+    if not unreleased.group(1).strip():
+        fail(
+            "The '## [Unreleased]' section is empty. Write what changed before "
+            "releasing, or this release would ship with no notes."
+        )
+
+    link = re.search(r"^\[Unreleased\]: (\S+/compare)/(\S+)\.\.\.HEAD$", text, re.MULTILINE)
+    if not link:
+        fail("CHANGELOG.md has no '[Unreleased]: .../compare/<tag>...HEAD' link reference.")
+    compare, previous = link.group(1), link.group(2)
+
+    date = datetime.date.today().isoformat()
+    text = text.replace(
+        "## [Unreleased]\n",
+        f"## [Unreleased]\n\n## [{version}] - {date}\n",
+        1,
+    )
+    text = text.replace(
+        link.group(0),
+        f"[Unreleased]: {compare}/v{version}...HEAD\n[{version}]: {compare}/{previous}...v{version}",
+        1,
+    )
+
+    CHANGELOG.write_text(text, encoding="utf-8")
+    print(f"Promoted the Unreleased section to {version} ({date}), previous tag {previous}.")
+    emit("changed", "true")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        fail("usage: promote_changelog.py X.Y.Z")
+    main(sys.argv[1])

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -87,17 +87,18 @@ jobs:
             exit 1
           fi
 
-      - name: Check CHANGELOG has a section for this version
+      - name: Promote the Unreleased CHANGELOG section
+        id: changelog
+        run: python3 .github/scripts/promote_changelog.py "${VERSION#v}"
+
+      - name: Commit the CHANGELOG
+        if: steps.changelog.outputs.changed == 'true'
         run: |
-          PLAIN_VERSION="${VERSION#v}"
-          if ! grep -q "^## \[${PLAIN_VERSION}\]" CHANGELOG.md; then
-            echo "Error: CHANGELOG.md has no '## [${PLAIN_VERSION}]' section."
-            echo "Move the relevant entries from '## [Unreleased]' into a dated"
-            echo "'## [${PLAIN_VERSION}] - $(date +%Y-%m-%d)' section (and update the"
-            echo "link references at the bottom), then re-run this workflow."
-            exit 1
-          fi
-          echo "CHANGELOG.md contains a section for ${PLAIN_VERSION}."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: release ${{ env.VERSION }}"
+          git push origin "HEAD:${{ github.ref_name }}"
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

No provider code changes. Release tooling.

### What does this PR do?

Every run of **Create Release Tag** fails the same way:

```
Error: CHANGELOG.md has no '## [3.42.0]' section.
Move the relevant entries from '## [Unreleased]' into a dated
'## [3.42.0] - 2026-09-11' section (and update the
link references at the bottom), then re-run this workflow.
```

The workflow asks for an edit it could make itself. Worse, it asks after calculating the version, so you only learn which version to write about by reading the failure.

The three-part edit is mechanical:

1. rename `## [Unreleased]` to `## [3.42.0] - 2026-09-11` and open a fresh empty `## [Unreleased]` above it,
2. point `[Unreleased]: .../compare/<prev>...HEAD` at the new tag,
3. add `[3.42.0]: .../compare/<prev>...v3.42.0`.

`.github/scripts/promote_changelog.py` now does it, the workflow commits the result to the branch it was dispatched from, and then tags that commit. The tag carries the changelog that describes it, rather than the changelog that preceded it.

The previous tag comes from the existing `[Unreleased]` link reference rather than from a separate input, so there is nothing to keep in sync.

### Two cases that keep it honest

**A section written by hand is left alone.** The script exits without changing anything and the commit step is skipped, so preparing a release ahead of time still works and re-running the workflow is safe.

**An empty `[Unreleased]` stops the run:**

```
Error: The '## [Unreleased]' section is empty. Write what changed before
releasing, or this release would ship with no notes.
```

A release with nothing to say is almost always a mistake, so this one stays a failure. It is the only thing the workflow still refuses.

### How was this change tested?

Ran the script against the real `CHANGELOG.md` at `3.42.0`:

```
Promoted the Unreleased section to 3.42.0 (2026-09-11), previous tag v3.41.1.

## [Unreleased]

## [3.42.0] - 2026-09-11

### Added
...

[Unreleased]: https://github.com/aminueza/terraform-provider-minio/compare/v3.42.0...HEAD
[3.42.0]: https://github.com/aminueza/terraform-provider-minio/compare/v3.41.1...v3.42.0
[3.41.1]: https://github.com/aminueza/terraform-provider-minio/compare/v3.41.0...v3.41.1
```

Then re-ran it on the promoted file, which reported `already has a section for 3.42.0` and set `changed=false`, and ran it against a copy whose `[Unreleased]` was emptied, which failed with the message above. The working tree was restored afterwards, so this PR does not carry a pre-promoted changelog.

### One thing to check before merging

The commit step pushes to the branch the workflow runs on. If `main` is protected against direct pushes, that push is refused and the workflow fails there instead of at the old check. The job already declares `contents: write`; whether a protection rule allows it is a repository setting I cannot see. If it is blocked, the alternative is to tag from a release branch or to open a pull request instead of pushing.

### No CHANGELOG entry

Nothing a user of the provider can observe changes.