### PR TITLE
ci: open a pull request for the release changelog instead of pushing to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -314,11 +314,16 @@ dependency bumps with no behavior change, test-only changes, refactors, and
 documentation fixes. When in doubt, add the entry — a reviewer can always drop
 it.
 
-The release workflow moves `[Unreleased]` into a dated `## [x.y.z]` section
-itself, updates the link references and commits that before it tags, so
-preparing a release takes no changelog edit. It stops when `[Unreleased]` is
-empty, because a release with no notes is almost always a mistake. A section
-written by hand ahead of time is left alone.
+Preparing a release takes no changelog edit. Running **Create Release Tag**
+moves `[Unreleased]` into a dated `## [x.y.z]` section, updates the link
+references and opens a pull request with that change. `main` is protected, so
+the workflow cannot commit there directly; merging the pull request creates the
+tag and starts the release on its own.
+
+Two cases behave differently on purpose. When the section is already there,
+written by hand or by an earlier release, the workflow tags straight away and
+opens nothing. When `[Unreleased]` is empty it stops, because a release with no
+notes is almost always a mistake.
 
 ### Commit Message Format
 

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -17,18 +17,25 @@ on:
           - minor
           - major
         default: "patch"
+  push:
+    branches:
+      - main
+    paths:
+      - CHANGELOG.md
 
 permissions:
   contents: read
 
 jobs:
-  create-tag:
+  prepare:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # required to create and push git tags
+      contents: write  # required to push the release branch and the tag
+      pull-requests: write  # required to open the release pull request
     timeout-minutes: 5
     outputs:
-      tag: ${{ steps.version.outputs.new }}
+      tag: ${{ steps.tag.outputs.created }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
@@ -38,21 +45,15 @@ jobs:
       - name: Get latest version and calculate next
         id: version
         run: |
-          # Get latest tag
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Latest tag: $LATEST_TAG"
 
-          # Remove 'v' prefix for calculation
           LATEST_VERSION=${LATEST_TAG#v}
-
-          # Split into major.minor.patch
           IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
 
-          # Use manual version if provided, otherwise calculate
           MANUAL_VERSION="${{ github.event.inputs.version }}"
 
           if [[ -n "$MANUAL_VERSION" ]]; then
-            # Validate manual version format
             if [[ ! "$MANUAL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Error: Version must be in format X.Y.Z (e.g., 3.15.0)"
               exit 1
@@ -60,7 +61,6 @@ jobs:
             NEW_VERSION="$MANUAL_VERSION"
             echo "Using manual version: $NEW_VERSION"
           else
-            # Calculate based on release type
             RELEASE_TYPE="${{ github.event.inputs.release_type }}"
             case "$RELEASE_TYPE" in
               major)
@@ -91,40 +91,92 @@ jobs:
         id: changelog
         run: python3 .github/scripts/promote_changelog.py "${VERSION#v}"
 
-      - name: Commit the CHANGELOG
+      - name: Open the release pull request
         if: steps.changelog.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="release/${{ env.VERSION }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add CHANGELOG.md
           git commit -m "chore: release ${{ env.VERSION }}"
-          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base "${{ github.ref_name }}" \
+            --head "$BRANCH" \
+            --title "chore: release ${{ env.VERSION }}" \
+            --body "Moves the \`[Unreleased]\` entries into \`${VERSION#v}\` and updates the link references. Merging this tags ${{ env.VERSION }} and starts the release."
+          {
+            echo "## Release pull request opened"
+            echo ""
+            echo "\`${{ env.VERSION }}\` is not tagged yet. Merge the pull request above and the tag is created automatically."
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Create and push tag
+        id: tag
+        if: steps.changelog.outputs.changed == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ env.VERSION }}" -m "Release ${{ env.VERSION }}"
           git push origin "${{ env.VERSION }}"
+          echo "created=${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          {
+            echo "## Release Tag Created"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Previous** | \`${{ steps.version.outputs.latest }}\` |"
+            echo "| **New Tag** | \`${{ steps.version.outputs.new }}\` |"
+            echo "| **Commit** | \`${{ github.sha }}\` |"
+          } >> $GITHUB_STEP_SUMMARY
 
-      - name: Summary
+  tag-merged-release:
+    if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create and push git tags
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.tag.outputs.created }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Create and push tag
+        id: tag
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          echo "## Release Tag Created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| | |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| **Previous** | \`${{ steps.version.outputs.latest }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **New Tag** | \`${{ steps.version.outputs.new }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Commit** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Release Type** | \`${{ github.event.inputs.release_type }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The [Release workflow](../actions/workflows/release.yml) has been triggered and will build and publish the provider with auto-generated release notes." >> $GITHUB_STEP_SUMMARY
+          VERSION=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -n 1 | sed -n 's|^chore: release \(v[0-9]\+\.[0-9]\+\.[0-9]\+\).*|\1|p')
+          if [[ -z "$VERSION" ]]; then
+            echo "The head commit subject does not name a version. Nothing to tag."
+            exit 0
+          fi
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists. Nothing to do."
+            exit 0
+          fi
+          if ! grep -q "^## \[${VERSION#v}\]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md has no section for ${VERSION#v}, so this is not a release commit."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "created=$VERSION" >> $GITHUB_OUTPUT
 
   release:
-    needs: create-tag
+    needs: [prepare, tag-merged-release]
+    if: ${{ always() && (needs.prepare.outputs.tag != '' || needs.tag-merged-release.outputs.tag != '') }}
     permissions:
       contents: write  # required by the release workflow to create GitHub releases and upload assets
     uses: ./.github/workflows/release.yml
     with:
-      tag: ${{ needs.create-tag.outputs.tag }}
+      tag: ${{ needs.prepare.outputs.tag || needs.tag-merged-release.outputs.tag }}
     secrets: inherit


### PR DESCRIPTION
## Description

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

No provider code changes. Release tooling. Follow-up to #1159.

### What does this PR do?

#1159 made the release workflow promote the `[Unreleased]` section itself and commit it. The commit is fine; the push is not:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

I flagged this as unverified when opening #1159, because the branch protection rules are a repository setting I cannot read. They are on, so the workflow now fails one step later than before.

### The change

The promotion goes to a `release/vX.Y.Z` branch and the workflow opens a pull request for it. Merging that pull request lands the changelog on `main` through the protected path, and a `push` trigger on `main` then creates the tag and starts the release.

So a release is: run **Create Release Tag**, merge the pull request it opens. No changelog edit, no second dispatch.

```
workflow_dispatch ──▶ promote ──▶ release/v3.42.0 ──▶ pull request
                                                           │
                                                        (merge)
                                                           ▼
                            push to main ──▶ tag v3.42.0 ──▶ release.yml
```

### Guards on the push trigger

A workflow that tags on a push to `main` has to be hard to fire by accident, so the job runs only when all three hold:

- the head commit subject starts with `chore: release v`,
- the version parsed from it has no tag yet,
- `CHANGELOG.md` really carries a `## [x.y.z]` section for that version, otherwise the job fails rather than tagging.

The subject reaches the shell through an environment variable rather than an expression inside `run`, and the extraction drops everything after the version number, so a crafted commit subject cannot reach the tag command:

```
chore: release v3.42.0             -> v3.42.0
chore: release v3.42.0 (#1160)     -> v3.42.0      (squash merge keeps the number)
chore: release v3.42.0$(whoami)    -> v3.42.0
fix: something else                -> (nothing, job exits without tagging)
```

### Unchanged behaviour

When the version's section already exists, written by hand or by an earlier release, the workflow tags straight away and opens no pull request. An empty `[Unreleased]` still stops the run.

### How was this change tested?

The workflow file parses as YAML and the three jobs resolve as intended. The version extraction was run against the four subjects in the table above. The promotion script itself is unchanged from #1159, where it was exercised against the real `CHANGELOG.md`.

The rest can only be proven by running it: whether `gh pr create` succeeds depends on **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**, which is another setting I cannot read. If it is off, the workflow fails at that step with a permissions error and the switch needs turning on. It is a narrower permission than letting Actions bypass branch protection, which is the alternative.

### No CHANGELOG entry

Nothing a user of the provider can observe changes.

### Left to clean up

`ci/1159-promote-changelog-on-release` is on the remote again. Pushing this follow-up recreated it, because GitHub had deleted it when #1159 merged and my push predated the fetch. It carries nothing that is not in this pull request. Deleting branches from here is refused with a 403, so it needs deleting by hand, along with `probe/registry-check` from #1158.