### PR TITLE
fix: drop ClientAuth from client TLS CA setup

### DIFF
--- a/minio/new_client.go
+++ b/minio/new_client.go
@@ -263,7 +263,6 @@ func (config *S3MinioConfig) configureCACert(tlsConfig *tls.Config) error {
 		return fmt.Errorf("failed to append CA certificate to cert pool")
 	}
 
-	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	tlsConfig.RootCAs = rootCAs
 	return nil
 }


### PR DESCRIPTION
configureCACert was setting `tls.Config.ClientAuth`, which only matters for TLS servers. This provider is the client, so the line did nothing. RootCAs stays.

Fixes #1155